### PR TITLE
ci: fix release workflow install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- fix the release workflow dependency install step
- use the same compatibility flag needed by this repo's dependency graph so the pipeline can complete

## Why
The first release workflow run failed at npm ci with peer-resolution errors, so no artifact was produced.
