### PR TITLE
fix: unblock logs build and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/src/features/logs/provider.runtime.test.ts
+++ b/src/features/logs/provider.runtime.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const service = {
+  id: 'service-admin',
+  metadata: {
+    logPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
+  },
+} as const
+
+describe('logs provider configured api mode', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('requests log info and chunk reads from the configured api base url', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: 'http://api.test',
+    }))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            serviceId: 'service-admin',
+            type: 'default',
+            path: 'C:\\runtime\\service-admin.log',
+            availableTypes: ['default'],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            serviceId: 'service-admin',
+            type: 'default',
+            path: 'C:\\runtime\\service-admin.log',
+            totalLines: 140,
+            start: 40,
+            end: 140,
+            hasMore: true,
+            nextBefore: 40,
+            limit: 100,
+            lines: Array.from({ length: 100 }, (_, index) => `line ${index + 41}`),
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchServiceLogChunk, fetchServiceLogInfo } = await import('./provider')
+
+    const info = await fetchServiceLogInfo(service as never, 'default')
+    const chunk = await fetchServiceLogChunk(service as never, 'default')
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://api.test/api/services/log-info?service=service-admin&type=default'
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://api.test/api/logs/read?service=service-admin&type=default&limit=100'
+    )
+
+    expect(info.path).toBe('C:\\runtime\\service-admin.log')
+    expect(chunk.lines).toHaveLength(100)
+    expect(chunk.nextBefore).toBe(40)
+  })
+
+  it('fails cleanly when the runtime api returns non-json content', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: 'http://api.test',
+    }))
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response('<!doctype html><html><body>wrong</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        })
+      )
+    )
+
+    const { fetchServiceLogChunk } = await import('./provider')
+
+    await expect(fetchServiceLogChunk(service as never, 'default')).rejects.toThrow(
+      'Live logs are unavailable right now.'
+    )
+  })
+})

--- a/src/features/logs/provider.stub.test.ts
+++ b/src/features/logs/provider.stub.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const service = {
+  id: 'service-admin',
+  metadata: {
+    logPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
+  },
+} as const
+
+describe('logs provider relative api mode', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('requests log info and log chunks through relative api routes when no api base is configured', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: null,
+    }))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            serviceId: 'service-admin',
+            type: 'default',
+            path: 'C:\\runtime\\service-admin.log',
+            availableTypes: ['default'],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            serviceId: 'service-admin',
+            type: 'default',
+            path: 'C:\\runtime\\service-admin.log',
+            totalLines: 122,
+            start: 22,
+            end: 122,
+            hasMore: true,
+            nextBefore: 22,
+            limit: 100,
+            lines: Array.from({ length: 100 }, (_, index) => `line ${index + 23}`),
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchServiceLogChunk, fetchServiceLogInfo } = await import('./provider')
+
+    const info = await fetchServiceLogInfo(service as never, 'default')
+    const chunk = await fetchServiceLogChunk(service as never, 'default')
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/services/log-info?service=service-admin&type=default'
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/logs/read?service=service-admin&type=default&limit=100'
+    )
+
+    expect(info.path).toBe('C:\\runtime\\service-admin.log')
+    expect(chunk.limit).toBe(100)
+    expect(chunk.lines).toHaveLength(100)
+    expect(chunk.hasMore).toBe(true)
+  })
+})

--- a/src/features/logs/provider.ts
+++ b/src/features/logs/provider.ts
@@ -1,0 +1,128 @@
+import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+
+const logsDebugEnabled =
+  import.meta.env.DEV || import.meta.env.VITE_SERVICE_LASSO_LOGS_DEBUG === 'true'
+const relativeLogsApiBaseUrl = ''
+
+export type ServiceLogInfo = {
+  serviceId: string
+  type: 'default' | 'access' | 'error'
+  path: string
+  availableTypes: string[]
+}
+
+export type ServiceLogChunk = {
+  serviceId: string
+  type: 'default' | 'access' | 'error'
+  path: string
+  totalLines: number
+  start: number
+  end: number
+  hasMore: boolean
+  nextBefore: number
+  limit: number
+  lines: string[]
+}
+
+export function debugLogs(message: string, details?: Record<string, unknown>) {
+  if (!logsDebugEnabled) return
+  console.log('[logs-debug]', message, details ?? {})
+}
+
+async function parseJsonResponse<T>(response: Response) {
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (!response.ok) {
+    throw new Error('Live logs are unavailable right now.')
+  }
+
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error('Live logs are unavailable right now.')
+  }
+
+  return (await response.json()) as T
+}
+
+function resolveLogsApiBaseUrl() {
+  return serviceLassoApiBaseUrl ?? relativeLogsApiBaseUrl
+}
+
+function buildLogsApiUrl(
+  pathname: '/api/services/log-info' | '/api/logs/read',
+  params: URLSearchParams
+) {
+  return `${resolveLogsApiBaseUrl()}${pathname}?${params.toString()}`
+}
+
+export async function fetchServiceLogInfo(
+  service: DashboardService,
+  type: 'default' | 'access' | 'error'
+) {
+  const params = new URLSearchParams({
+    service: service.id,
+    type,
+  })
+  const infoUrl = buildLogsApiUrl('/api/services/log-info', params)
+
+  debugLogs('requesting log info', {
+    serviceId: service.id,
+    type,
+    infoUrl,
+  })
+
+  const response = await fetch(infoUrl)
+  const info = await parseJsonResponse<ServiceLogInfo>(response)
+
+  debugLogs('log info loaded', {
+    serviceId: info.serviceId,
+    type: info.type,
+    path: info.path,
+    availableTypes: info.availableTypes,
+  })
+
+  return info
+}
+
+export async function fetchServiceLogChunk(
+  service: DashboardService,
+  type: 'default' | 'access' | 'error',
+  before?: number,
+  limit = 100
+) {
+  const params = new URLSearchParams({
+    service: service.id,
+    type,
+    limit: String(limit),
+  })
+
+  if (typeof before === 'number') {
+    params.set('before', String(before))
+  }
+
+  const chunkUrl = buildLogsApiUrl('/api/logs/read', params)
+
+  debugLogs('requesting log chunk', {
+    serviceId: service.id,
+    type,
+    before: before ?? null,
+    limit,
+    chunkUrl,
+  })
+
+  const response = await fetch(chunkUrl)
+  const chunk = await parseJsonResponse<ServiceLogChunk>(response)
+
+  debugLogs('log chunk loaded', {
+    serviceId: chunk.serviceId,
+    type: chunk.type,
+    before: before ?? null,
+    lineCount: chunk.lines.length,
+    totalLines: chunk.totalLines,
+    hasMore: chunk.hasMore,
+    nextBefore: chunk.nextBefore,
+    firstLinePreview: chunk.lines[0]?.slice(0, 120) ?? null,
+  })
+
+  return chunk
+}


### PR DESCRIPTION
## Summary
- stop .gitignore from swallowing src/features/logs sources
- add the missing logs provider module and its focused tests
- keep the release workflow install compatibility fix

## Why
The release pipeline was still failing because GitHub could not see src/features/logs/provider.ts even though it existed locally.
