### PR TITLE
ci: align install path with release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-
-      - name: Install pnpm
-        run: npm install -g pnpm
+          node-version: 24
+          cache: npm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci --legacy-peer-deps
 
       - name: Lint the code
-        run: pnpm lint
+        run: npm run lint
 
       # - name: Analyze unused files and dependencies
       #   run: pnpm knip
 
       - name: Run Prettier check
-        run: pnpm format:check
+        run: npm run format:check
 
       - name: Build the project
-        run: pnpm build
+        run: npm run build
 
       - name: Run service template checks
         shell: bash


### PR DESCRIPTION
## Summary
- switch CI from pnpm frozen-lockfile install to the same npm install path used by release
- update CI to Node 24 with npm cache
- keep the service-template checks in CI after build

## Why
After merging the template-contract work, CI was still failing on pnpm lockfile/install drift even though the release workflow path was already working.
