### PR TITLE
fix: import remaining service template contract

### DIFF
--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -1,0 +1,109 @@
+name: validate-template
+
+# Service Admin uses the service-template contract as its base and then layers app code on top.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+
+env:
+  SERVICE_LASSO_HARNESS_REPO: service-lasso/service-lasso-harness
+  SERVICE_LASSO_HARNESS_VERSION: v0.1.1
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win32
+            archive_name: service-lasso-harness-windows-amd64.zip
+            extracted_dir: service-lasso-harness-windows-amd64
+          - os: ubuntu-latest
+            platform: linux
+            archive_name: service-lasso-harness-linux-amd64.tar.gz
+            extracted_dir: service-lasso-harness-linux-amd64
+          - os: macos-14
+            platform: darwin
+            archive_name: service-lasso-harness-darwin-arm64.tar.gz
+            extracted_dir: service-lasso-harness-darwin-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build app
+        run: npm run build
+
+      - name: Download released service-lasso-harness binary
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .harness/download .harness/bin
+          gh release download "$SERVICE_LASSO_HARNESS_VERSION" \
+            --repo "$SERVICE_LASSO_HARNESS_REPO" \
+            --pattern "${{ matrix.archive_name }}" \
+            --dir .harness/download
+
+      - name: Extract released harness binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Expand-Archive -Path ".harness/download/${{ matrix.archive_name }}" -DestinationPath ".harness/bin" -Force
+          Add-Content -Path $env:GITHUB_PATH -Value (Resolve-Path ".harness/bin")
+
+      - name: Extract released harness binary (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf ".harness/download/${{ matrix.archive_name }}" -C .harness/bin
+          echo "$PWD/.harness/bin" >> "$GITHUB_PATH"
+
+      - name: Package service artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .\scripts\package.ps1
+
+      - name: Package service artifact (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash ./scripts/package.sh
+
+      - name: Run service tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .\scripts\test.ps1
+
+      - name: Run service tests (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash ./scripts/test.sh
+
+      - name: Verify via released harness (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .\scripts\verify.ps1
+
+      - name: Verify via released harness (POSIX)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash ./scripts/verify.sh

--- a/docs/openspec-drafts/OPENSPEC-TRACKER.md
+++ b/docs/openspec-drafts/OPENSPEC-TRACKER.md
@@ -1,0 +1,44 @@
+# Service Template - OpenSpec Tracker
+
+_Status: working tracker_
+
+## Current repo target
+- `service-template`
+
+## Draft Spec Register
+
+| Draft Spec | Area | Status | Main Source Docs | Intended Repo Target | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `SPEC-SERVICE-TEMPLATE-REPO.md` | Template | `draft` | `docs/reference/SERVICE-TEMPLATE-REPO.md`, `docs/reference/SERVICE-STRUCTURE-REVIEW.md`, `docs/reference/PROPOSED-CODEBASE-STRUCTURE.md` | `service-template` | Canonical template/service-author contract draft. |
+
+## Current focus
+1. lock the canonical template repo contract
+2. define the minimum sample service + packaging/release path
+3. define the first harness-facing validation example shape
+4. only then broaden into more detailed template variants if still needed
+
+## Current local source set
+- `README.md`
+- `docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md`
+- `docs/reference/SERVICE-TEMPLATE-REPO.md`
+- `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
+- `docs/reference/PROPOSED-CODEBASE-STRUCTURE.md`
+- `docs/reference/DECISION-CONTEXT.md`
+- `docs/reference/EXAMPLE-REPO-TREE.md`
+- `docs/reference/EXAMPLE-service.json`
+- `docs/reference/EXAMPLE-service-harness.json`
+- `docs/reference/EXAMPLE-verify.ps1`
+- `docs/reference/EXAMPLE-verify.sh`
+
+## Shared/adjacent context now copied locally
+These are now available inside this folder for standalone review:
+- `docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md`
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+- `docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md`
+
+## Current gaps
+Still needs explicit implementation-ready work for:
+- deciding which starter-file fields are canonical first-pass contract versus illustrative placeholders
+- normalizing the exact health schema around `process` default plus explicit `http|tcp|file|variable` overrides
+- replacing the starter CI package/test flow with a real released-harness invocation once `service-lasso-harness` exists as a binary

--- a/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
+++ b/docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md
@@ -1,0 +1,278 @@
+# Spec Draft - Service Template Repo
+
+_Status: draft_
+
+## Intent
+Define the canonical `service-template` repo as the standard starting point for future Service Lasso service repos. This matters because service authors should have one authoritative source for repo shape, manifest expectations, packaging/release behavior, validation-harness integration, and service-author documentation instead of reconstructing the contract from scattered donor-analysis notes.
+
+## Scope
+Included in this spec:
+- the role of `service-template` as the canonical base repo for future services
+- one-service-per-repo discipline and its relationship to app bundling/distribution
+- minimum repo layout/documentation expectations for service authors
+- minimum sample service direction
+- reference release/packaging expectations
+- validation-harness integration expectations
+- naming direction and practical bootstrap/repo-creation guidance
+- the requirement that the template repo explain the service contract directly and comprehensively
+
+Explicitly out of scope for this spec:
+- the full Service Lasso core runtime spec
+- the full harness implementation spec beyond the template integration expectations
+- UI/admin behavior
+- the final detailed implementation of every future service role/type
+- every possible future template variant beyond the first canonical template
+
+## Acceptance Criteria
+- `AC-1`: The spec states that each Service Lasso service should live in its own repo.
+- `AC-2`: The spec states that `service-template` is the canonical base repo for future service repos.
+- `AC-3`: The spec defines the minimum repo/layout/documentation expectations that the template must provide to service authors.
+- `AC-4`: The spec states what the template docs must explain directly about `service.json`, defaults vs overrides, `actions`, install/config/start semantics, uninstall vs reset, and managed `.state/` usage.
+- `AC-5`: The spec defines the minimum canonical folder/layout direction for the first real `service-template` repo.
+- `AC-6`: The spec defines the standard validation-harness direction and records that services should be able to prove they work under real Service Lasso semantics locally and in CI.
+- `AC-7`: The spec defines expectations for a minimal sample service plus a reference packaging/release pipeline.
+- `AC-8`: The spec records the practical GitHub repo/template creation flow for `service-template`.
+- `AC-9`: The spec makes the current canonical repo name explicit as `service-template`.
+- `AC-10`: Open questions are recorded explicitly instead of being left implicit in planning notes.
+
+## Tests and Evidence
+Planning/reference evidence currently available:
+- `docs/reference/SERVICE-TEMPLATE-REPO.md`
+- `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
+- `docs/reference/PROPOSED-CODEBASE-STRUCTURE.md`
+- `docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md`
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+- `docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md`
+- representative donor service manifests and READMEs under the donor `services/` tree
+
+Implementation evidence required later:
+- a real `service-template` repo structure matching the documented contract
+- a minimal sample service proving the template lifecycle
+- reference packaging/release scripts and output artifacts
+- a harness-facing validation example that the shared harness can execute
+
+Current first-pass starter evidence now present locally:
+- `service.json`
+- `verify/service-harness.json`
+- `scripts/verify.ps1`
+- `scripts/verify.sh`
+- `scripts/package.ps1`
+- `scripts/package.sh`
+- `runtime/win32/echo-service.ps1`
+- `runtime/linux/echo-service.sh`
+- `runtime/darwin/echo-service.sh`
+- `.github/workflows/validate-template.yml`
+- packaged sample artifact `dist/echo-service-win32.zip`
+
+## Documentation Impact
+This spec is expected to govern or inform:
+- `README.md`
+- future service-author onboarding docs in this repo
+- future sample-service docs and packaging scripts
+- future validation-contract example files (`scripts/verify.*`, `verify/service-harness.json`)
+- future release/CI guidance for service repos derived from this template
+
+## Verification
+Verify this spec by checking that the template repo docs and future implementation consistently enforce the same model:
+- one service per repo remains explicit
+- `service-template` is clearly the canonical starting point
+- the template layout is concrete enough to start from without donor archaeology
+- service-author documentation requirements are explicit enough to avoid reconstructing the contract from scratchpads
+- sample service, packaging, and harness integration expectations are clear enough to drive a real first implementation slice
+
+## Change Notes
+- Initial template spec draft was created from donor-analysis/template planning work.
+- This revision rewrites the template spec into the project’s actual standard/governance shape instead of leaving it as a ref-style planning note.
+- Current canonical repo name recorded explicitly here: `service-template`.
+
+## Current Contract Direction
+
+### Canonical repo name
+Current canonical repo name:
+- `service-template`
+
+This is the intended first public template repo for the Service Lasso ecosystem.
+
+### Template repo role
+`service-template` should be the canonical base repo for future Service Lasso service repos.
+
+Its job is to:
+- establish the service-repo contract in one place
+- provide a standard repo/layout/doc shape
+- provide a minimal sample service
+- provide reference packaging/release behavior
+- provide the first harness-facing validation example
+
+### One service per repo
+Each service should live in its own repo.
+
+This remains true even when:
+- some services are bundled into app packages at package time
+- some services are preinstalled in a base distribution
+- some services are downloaded dynamically later
+
+Bundling is a distribution choice, not a repo-ownership model change.
+
+### Naming direction
+Current naming direction for service repos:
+- use `lasso-` as the shared repo prefix
+- after removing `lasso-`, the remainder maps to the local service folder name
+
+Examples:
+- `lasso-@archive`
+- `lasso-@node`
+- `lasso-fastapi`
+
+### What the template must standardize
+The template must standardize at least:
+- canonical `service.json` usage and shape guidance
+- defaults vs overrides guidance
+- how `actions` works in practice
+- install/config/start expectations at the service-author level
+- uninstall vs reset expectations
+- managed `.state/` direction for mutable operational state
+- runtime/config/content folder conventions
+- per-OS folders where relevant (`win32/`, `linux/`, `darwin/`)
+- release artifact shape
+- build/package/verify script expectations
+- documentation structure
+- versioning/release conventions
+
+### Minimum canonical repo structure
+The first real `service-template` repo should make the minimum expected structure explicit.
+
+Current minimum direction:
+- `service.json`
+- `README.md`
+- `CHANGELOG.md`
+- `LICENSE`
+- `config/`
+- `scripts/`
+- `runtime/` or another clear payload/runtime folder
+- per-OS folders where the service actually needs OS-specific payloads
+- release/packaging config sufficient to produce installable artifacts
+
+The repo should be small enough to stay understandable, but concrete enough that a new service can be created from it without donor archaeology.
+
+### What the template docs must explain directly
+The template docs should explain directly, in one place:
+- what `service.json` is for
+- what each top-level section means
+- how defaults work vs overrides
+- what `actions` means in practice
+- how install works conceptually
+- how config differs from install and when it reruns
+- how uninstall differs from reset
+- how managed `.state/` usage works at the service-author level
+- that `.state/` is the preferred mutable operational state area and legacy standalone `service.pid` should not be treated as mandatory unless a concrete need survives review
+- how release artifacts, packaging, and per-OS folders fit together
+- how a service creator should think about service-specific command mappings versus Lasso defaults
+
+### Sample service direction
+The template should include a deliberately minimal sample service.
+
+Current preferred direction:
+- use a simple echo service
+- avoid real application complexity
+- include explicit per-OS folders as needed
+- make the service easy to understand and easy to package
+
+The sample should prove:
+- manifest shape
+- install flow
+- action/default behavior
+- state/log behavior
+- release artifact flow
+
+Current example artifacts have now been added under `docs/reference/`:
+- `EXAMPLE-REPO-TREE.md`
+- `EXAMPLE-service.json`
+- `EXAMPLE-service-harness.json`
+- `EXAMPLE-verify.ps1`
+- `EXAMPLE-verify.sh`
+
+### Health model direction
+Current health-model direction:
+- default health model is **process**
+- other health models are allowed when explicitly declared by the service config
+
+Ref/code-backed donor healthcheck types observed:
+- `http`
+- `tcp`
+- `file`
+- `variable`
+
+Relevant donor/runtime evidence:
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+- `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
+- donor runtime implementation in `runtime/Service.ts` (copied evidence path remains in donor-ref source)
+
+For `service-template`, the first sample should stay aligned with this rule:
+- use `process` as the default/simple case
+- only use another health model when the service contract needs it and declares it explicitly
+
+### Validation-harness integration direction
+Each service should be able to prove that it works inside Service Lasso, not only as a standalone app/script.
+
+Current preferred direction:
+- use one shared Lasso validation harness model across service repos
+- let each service repo provide a small service-specific validation contract rather than bespoke orchestration logic
+- make the same validation flow runnable both locally and in CI
+
+The template should provide a standard example shape, likely including:
+- `scripts/verify.ps1`
+- `scripts/verify.sh`
+- an example machine-readable validation contract/manifest
+- example CI wiring that runs the same harness contract in pipeline
+
+A first concrete example contract and thin verify wrappers now exist under `docs/reference/` for review:
+- `EXAMPLE-service-harness.json`
+- `EXAMPLE-verify.ps1`
+- `EXAMPLE-verify.sh`
+
+The `service-template` repo should include a golden harness example that proves:
+- the sample service artifact can be packaged
+- the sample service can be installed into an isolated harness root
+- the sample service can be started via Service Lasso semantics
+- expected health/log/state outputs appear
+- cleanup/stop behavior works cleanly
+
+### Reference release pipeline direction
+The template should include a simple reference release pipeline.
+
+Current preferred direction:
+- include simple `*.ps1` and `*.sh` scripts
+- use per-OS subfolders as packaging inputs
+- create compressed release artifacts
+- use 7zip-based packaging configuration where needed
+- make the resulting artifacts usable for end-to-end install/release testing
+- make the resulting artifacts usable by the shared harness in CI
+
+### Practical bootstrap guidance
+Useful GitHub CLI direction for the canonical template repo:
+
+```bash
+gh repo create service-lasso/service-template --public --clone
+gh repo edit service-lasso/service-template --template
+```
+
+Important clarification:
+- create it as a normal repo first
+- then mark it as a GitHub template repo
+
+### Recommended first value
+The first real `service-template` repo should be valuable immediately as both:
+- a service repo starting point
+- a release/pipeline test fixture
+- a harness example proving what “works in Lasso” means in practice
+
+## Open Questions
+- What exact folder layout should become canonical beyond the current minimum direction?
+- What exact sample service should ship first beyond the current echo-service direction?
+- What exact release artifact structure and packaging scripts should be mandatory versus optional?
+- How much generated/example `.state/` material should be included versus merely documented?
+- Which parts of the service-author contract should live directly in the template repo versus separate central docs copied or linked into it?
+- Which fields in the first example `service.json` and `service-harness.json` should be treated as canonical first-pass fields versus illustrative placeholders?
+- Do we want to explicitly normalize the health field names/shapes now around `process` default plus `http|tcp|file|variable` overrides, or leave exact schema locking to the next contract pass?
+- Should there be one single base template only at first, or a later layered template strategy for runtime-provider / infrastructure / app-service variants after the canonical first template is proven?

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,10 @@
+# Packaging
+
+Reference packaging scripts:
+- `scripts/package.ps1`
+- `scripts/package.sh`
+
+Current first-pass direction:
+- package the minimal sample service into a release artifact under `dist/`
+- include `service.json`, runtime payload, and config
+- use the produced artifact as the thing later consumed by the shared harness

--- a/docs/reference/DECISION-CONTEXT.md
+++ b/docs/reference/DECISION-CONTEXT.md
@@ -1,0 +1,49 @@
+# Service Template - Decision Context
+
+_Status: local context note_
+
+This file exists so `service-template` can stand on its own without pretending that every relevant decision lives only inside this folder.
+
+## Why this file exists
+
+The template work depends on some shared Service Lasso reconciliation/decision docs that still live under the donor-reference area.
+
+That shared context should not be duplicated casually, but it should be easy to find.
+
+## Shared context to consult
+
+### Local copies of the shared reconciliation docs
+- `shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `shared-runtime/ARCHITECTURE-DECISIONS.md`
+- `shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+
+### Why they matter to `service-template`
+They contain the current settled direction for things like:
+- `install` vs `config`
+- `actions` semantics
+- utility/runtime-provider/service boundaries
+- port negotiation expectations
+- `globalenv` direction
+- `.state` direction
+- uninstall vs reset semantics
+- runtime/service lifecycle expectations that template examples should not contradict
+
+## Local docs in this folder
+Within `service-template`, start with:
+1. `docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md`
+2. `docs/reference/SERVICE-TEMPLATE-REPO.md`
+3. `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
+4. `docs/reference/PROPOSED-CODEBASE-STRUCTURE.md`
+
+## Related adjacent repo
+The shared validation runner still lives separately as a project in:
+- `C:\projects\service-lasso\service-lasso-harness`
+
+For standalone review convenience, the most relevant adjacent harness spec is also copied locally here:
+- `adjacent/SPEC-SERVICE-LASSO-HARNESS.md`
+
+## Working rule
+
+Use this folder as the main working area for template-specific work.
+
+Default to the local copies in this folder first. If those copies drift later, reconcile against their source repos deliberately rather than guessing.

--- a/docs/reference/EXAMPLE-REPO-TREE.md
+++ b/docs/reference/EXAMPLE-REPO-TREE.md
@@ -1,0 +1,60 @@
+# Service Template - Example Repo Tree
+
+_Status: draft example_
+
+This is the first concrete example repo tree for the future `service-template` repo.
+
+It is intentionally small.
+
+```text
+service-template/
+  README.md
+  CHANGELOG.md
+  LICENSE
+  service.json
+  verify/
+    service-harness.json
+  scripts/
+    verify.ps1
+    verify.sh
+    package.ps1
+    package.sh
+  runtime/
+    win32/
+      echo-service.ps1
+    linux/
+      echo-service.sh
+    darwin/
+      echo-service.sh
+  config/
+    example.env
+  docs/
+    service-contract.md
+    packaging.md
+    validation.md
+```
+
+## Notes
+
+- `service.json`
+  - canonical service manifest for the sample service
+- `verify/service-harness.json`
+  - machine-readable validation contract for the shared harness
+- `scripts/verify.*`
+  - thin wrappers that call the shared harness binary
+- `scripts/package.*`
+  - reference packaging entrypoints
+- `runtime/`
+  - minimal payload/runtime files for the sample service
+- `config/`
+  - example config inputs if needed
+- `docs/`
+  - service-author-facing explanation in the real template repo
+
+## Why this shape
+
+This tree is meant to be:
+- small enough to understand quickly
+- concrete enough to be copied by service authors
+- compatible with the harness-first validation direction
+- compatible with per-OS payload expectations where needed

--- a/docs/reference/EXAMPLE-service-harness.json
+++ b/docs/reference/EXAMPLE-service-harness.json
@@ -1,0 +1,28 @@
+{
+  "serviceId": "echo-service",
+  "artifact": {
+    "path": "dist/echo-service-win32.zip",
+    "kind": "archive"
+  },
+  "dependencies": [],
+  "lifecycle": {
+    "install": true,
+    "config": true,
+    "start": true,
+    "stop": true
+  },
+  "health": {
+    "type": "process",
+    "timeoutSeconds": 30
+  },
+  "expect": {
+    "logs": true,
+    "state": true,
+    "exitClean": true
+  },
+  "artifacts": {
+    "captureLogs": true,
+    "captureState": true,
+    "captureSummary": true
+  }
+}

--- a/docs/reference/EXAMPLE-service.json
+++ b/docs/reference/EXAMPLE-service.json
@@ -1,0 +1,38 @@
+{
+  "id": "echo-service",
+  "name": "Echo Service",
+  "description": "Minimal sample service used to prove the service-template contract.",
+  "enabled": true,
+  "version": "0.1.0",
+  "logoutput": true,
+  "icon": "terminal",
+  "servicetype": 50,
+  "servicelocation": 10,
+  "actions": {
+    "install": {
+      "description": "Prepare the sample runtime payload if needed."
+    },
+    "config": {
+      "description": "Materialize effective runtime config for the sample service."
+    },
+    "start": {
+      "description": "Start the sample echo service."
+    },
+    "stop": {
+      "description": "Stop the sample echo service gracefully."
+    }
+  },
+  "execconfig": {
+    "serviceorder": 100,
+    "serviceport": 0,
+    "execcwd": "runtime",
+    "executable": "echo-service",
+    "env": {
+      "ECHO_MESSAGE": "hello from service-template"
+    },
+    "depend_on": [],
+    "healthcheck": {
+      "type": "process"
+    }
+  }
+}

--- a/docs/reference/EXAMPLE-verify.ps1
+++ b/docs/reference/EXAMPLE-verify.ps1
@@ -1,0 +1,13 @@
+param(
+  [string]$Contract = ".\verify\service-harness.json"
+)
+
+$Harness = "service-lasso-harness.exe"
+
+if (-not (Get-Command $Harness -ErrorAction SilentlyContinue)) {
+  Write-Error "service-lasso-harness.exe not found in PATH"
+  exit 1
+}
+
+& $Harness run --contract $Contract
+exit $LASTEXITCODE

--- a/docs/reference/EXAMPLE-verify.sh
+++ b/docs/reference/EXAMPLE-verify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTRACT="${1:-./verify/service-harness.json}"
+
+if ! command -v service-lasso-harness >/dev/null 2>&1; then
+  echo "service-lasso-harness not found in PATH" >&2
+  exit 1
+fi
+
+service-lasso-harness run --contract "$CONTRACT"

--- a/docs/reference/PROPOSED-CODEBASE-STRUCTURE.md
+++ b/docs/reference/PROPOSED-CODEBASE-STRUCTURE.md
@@ -1,0 +1,429 @@
+# Service Lasso - Proposed Codebase Structure
+
+_Status: working draft_
+
+Important reconciliation note:
+- this file is a structural sketch, not a canonical decision log
+- use `QUESTION-LIST-AND-CODE-VALIDATION.md` and `ARCHITECTURE-DECISIONS.md` to decide what is actually settled before treating any proposed layer/folder split here as fixed
+
+Purpose:
+
+- document the proposed target codebase structure for `service-lasso`
+- separate donor file boundaries from the future architectural layers
+- provide a concrete structure to refine while design decisions continue
+
+Related docs:
+
+- `ARCHITECTURE.md`
+- `ARCHITECTURE-DECISIONS.md`
+- `SERVICE-STRUCTURE-REVIEW.md`
+- `SERVICE-MANAGER-BEHAVIOR.md`
+- `RUNTIME-API-INDEX.md`
+- `SERVICE-TEMPLATE-REPO.md`
+
+---
+
+## 1. Main Goal
+
+The donor runtime should be restructured into clear layers for:
+
+- runtime/orchestration
+- services/instances
+- install/update/bootstrap
+- env/ports/health/routing
+- API
+- UI
+- CLI
+- shared contracts/types
+
+The future structure should follow conceptual ownership, not donor file history.
+
+---
+
+## 2. Proposed Main Repo Structure
+
+```text
+service-lasso/
+  src/
+    core/
+      runtime/
+      services/
+      instances/
+      install/
+      env/
+      ports/
+      health/
+      routing/
+    api/
+      server/
+      routes/
+      schemas/
+    ui/
+      app/
+      assets/
+    cli/
+    shared/
+      contracts/
+      utils/
+      system/
+    paths/
+  templates/
+    service-repo/
+    app-node/
+  examples/
+  docs/
+  package.json
+  tsconfig.json
+```
+
+---
+
+## 3. Core Layer Breakdown
+
+### `src/core/runtime/`
+Responsibilities:
+- top-level runtime startup/shutdown
+- runtime lifecycle
+- runtime events/state
+- wiring managers together
+
+Candidate files:
+- `Runtime.ts`
+- `RuntimeConfig.ts`
+- `RuntimeLifecycle.ts`
+- `RuntimeEvents.ts`
+
+### `src/core/services/`
+Responsibilities:
+- service definitions
+- service discovery/registry
+- service manager logic
+- service dependency graph
+- service state model
+
+Candidate files:
+- `Service.ts`
+- `ServiceManager.ts`
+- `ServiceRegistry.ts`
+- `ServiceDefinition.ts`
+- `ServiceState.ts`
+- `ServiceDependencyGraph.ts`
+
+### `src/core/instances/`
+Responsibilities:
+- app/instance manifests
+- instance lifecycle
+- grouping services into a named instance
+
+Candidate files:
+- `Instance.ts`
+- `InstanceManager.ts`
+- `InstanceManifest.ts`
+- `InstanceState.ts`
+
+### `src/core/install/`
+Responsibilities:
+- install/update/bootstrap flows
+- archive extraction
+- service source resolution
+- installed service tracking
+- bundled vs lightweight bootstrap behavior
+
+Candidate files:
+- `InstallManager.ts`
+- `Installer.ts`
+- `ArchiveProvider.ts`
+- `BootstrapInstaller.ts`
+- `ServiceSource.ts`
+- `GitHubReleaseSource.ts`
+- `InstalledServiceStore.ts`
+
+### `src/core/env/`
+Responsibilities:
+- service env generation
+- global env propagation or equivalent replacement model
+- template substitution
+- runtime provider env helpers
+
+Candidate files:
+- `EnvBuilder.ts`
+- `GlobalEnvRegistry.ts`
+- `TemplateVars.ts`
+- `RuntimeProviderEnv.ts`
+
+### `src/core/ports/`
+Responsibilities:
+- port reservation/allocation
+- port inspection/tracking
+- future port-block support
+
+Candidate files:
+- `PortRegistry.ts`
+- `PortAllocator.ts`
+- `PortReservation.ts`
+- `PortInspector.ts`
+
+### `src/core/health/`
+Responsibilities:
+- health check definitions
+- health check runners
+- readiness/liveness aggregation
+
+Candidate files:
+- `HealthCheck.ts`
+- `HealthCheckRunner.ts`
+- `HealthStatus.ts`
+
+### `src/core/routing/`
+Responsibilities:
+- local routed hostnames
+- service host registration
+- reverse-proxy/routing integration
+
+Candidate files:
+- `RoutingManager.ts`
+- `RouteDefinition.ts`
+- `ServiceHostname.ts`
+
+---
+
+## 4. API Layer
+
+### `src/api/`
+This becomes the primary control plane.
+
+Candidate structure:
+
+```text
+src/api/
+  server/
+    createServer.ts
+    RuntimeServer.ts
+  routes/
+    runtime.ts
+    services.ts
+    instances.ts
+    installs.ts
+    logs.ts
+    health.ts
+  schemas/
+    runtime.ts
+    services.ts
+    instances.ts
+```
+
+The API should replace host-specific IPC as the default core control surface.
+
+---
+
+## 5. UI Layer
+
+### `src/ui/`
+The UI should be separable from the core runtime bootstrap.
+
+Candidate structure:
+
+```text
+src/ui/
+  app/
+    pages/
+    components/
+    hooks/
+    client/
+  assets/
+```
+
+The UI should support two modes:
+- embedded UI served directly by the runtime
+- separate managed UI service registered into the routing layer
+
+---
+
+## 6. CLI Layer
+
+### `src/cli/`
+The CLI should expose runtime/service/install/instance operations.
+
+Candidate structure:
+
+```text
+src/cli/
+  index.ts
+  commands/
+    runtime.ts
+    service.ts
+    instance.ts
+    install.ts
+```
+
+---
+
+## 7. Shared Contracts / Utilities
+
+### `src/shared/contracts/`
+This should hold the canonical contract types that later ports must mirror.
+
+Candidate files:
+- `service-manifest.ts`
+- `instance-manifest.ts`
+- `install-manifest.ts`
+- `base-service-types.ts`
+
+### `src/shared/utils/`
+Cross-cutting helper functions.
+
+### `src/shared/system/`
+Platform/process/system abstractions.
+
+---
+
+## 8. Path Layer
+
+### `src/paths/`
+Replace donor `Resources.ts` with explicit runtime path modules.
+
+Candidate files:
+- `RuntimePaths.ts`
+- `DataPaths.ts`
+- `ServicePaths.ts`
+
+---
+
+## 9. Templates and Examples
+
+### `templates/service-repo/`
+Canonical template for one-service-per-repo service packages.
+
+### `templates/app-node/`
+Reference Node host/app template.
+
+### `examples/`
+Examples of:
+- basic instances
+- multi-service instances
+- maybe packaged/bundled vs lightweight setups later
+
+---
+
+## 10. Local Installed Service Layout (Outside `src/`)
+
+The installed `services/` directory should be treated as a local dynamic inventory.
+
+Example direction:
+
+```text
+services/
+  @archive/
+  @localcert/
+  @node/
+  @python/
+  @java/
+  @traefik/
+  fastapi/
+  mongo/
+  postgredb/
+```
+
+Potential per-service layout:
+
+```text
+services/
+  <service-name>/
+    service.json
+    service.state
+    service.pid
+    config/
+    installed/
+```
+
+Current direction:
+- `service.json` is the canonical manifest/contract
+- `service.state` stores mutable local install/resolution/state information
+- `service.pid` stores the current running pid/process state
+- `config/` comes from the repo/package
+- `installed/` is created by the install process
+
+---
+
+## 11. Mapping From Donor Files
+
+### Donor `Service.ts`
+Likely split across:
+- `src/core/services/Service.ts`
+- `src/core/install/Installer.ts`
+- `src/core/health/HealthCheckRunner.ts`
+- `src/core/env/EnvBuilder.ts`
+- `src/core/ports/PortReservation.ts`
+
+### Donor `ServiceManager.ts`
+Likely split across:
+- `src/core/services/ServiceManager.ts`
+- `src/core/services/ServiceRegistry.ts`
+- `src/core/runtime/Runtime.ts`
+- `src/core/ports/PortRegistry.ts`
+
+### Donor `Services.ts`
+Likely split across:
+- `src/api/server/createServer.ts`
+- `src/ui/...`
+- `src/cli/...`
+- maybe `src/core/runtime/bootstrap.ts`
+
+### Donor `Utils.ts`
+Likely split across:
+- `src/shared/utils/`
+- `src/shared/system/`
+- `src/core/ports/`
+- `src/core/env/`
+
+### Donor `Resources.ts`
+Likely replaced by:
+- `src/paths/RuntimePaths.ts`
+
+---
+
+## 12. Reference Hosts / Separate Repos
+
+Outside the core repo, reference hosts remain separate:
+
+- `service-lasso-app-node`
+- `service-lasso-app-electron`
+- `service-lasso-app-tauri`
+- `service-lasso-app-docker`
+- `service-lasso-app-pkg`
+- `service-lasso-app-nexe`
+
+The core repo should not absorb their host-specific concerns.
+
+---
+
+## 13. Service Repos / Separate Repos
+
+All services should live in their own repos.
+
+Naming rule currently documented elsewhere:
+- repo prefix `lasso-`
+- remove `lasso-`
+- remainder is exact local service folder name
+
+Examples:
+- `lasso-@archive`
+- `lasso-@node`
+- `lasso-fastapi`
+- `lasso-mongo`
+
+---
+
+## 14. Working Summary
+
+The proposed future structure separates the current donor runtime into:
+- core runtime/orchestration
+- install/update/bootstrap
+- services/instances
+- ports/env/health/routing
+- API
+- UI
+- CLI
+- shared contracts
+
+This should make the final Service Lasso codebase much easier to reason about and much closer to the architecture we are actually designing.

--- a/docs/reference/SERVICE-STRUCTURE-REVIEW.md
+++ b/docs/reference/SERVICE-STRUCTURE-REVIEW.md
@@ -1,0 +1,667 @@
+# Service Lasso - Donor Service Structure Review
+
+_Status: working draft / template-design input_
+
+Important reconciliation note:
+- this file reviews donor service structure and extracts patterns
+- use `QUESTION-LIST-AND-CODE-VALIDATION.md` and `ARCHITECTURE-DECISIONS.md` first when deciding what is settled versus what is only a proposed migration/template direction
+
+Purpose:
+
+- review the current donor `services/` folder structure
+- identify the main service shapes/patterns
+- extract what should become the basis for a **template service repo**
+- clarify what is donor baggage vs what is a reusable contract
+
+---
+
+## 1. Key Design Intent
+
+The `services/` folder should remain **dynamic**, not fixed.
+
+Target behavior:
+
+- Service Lasso can discover installed services under `services/`
+- services can be added from external sources (for example GitHub releases)
+- the runtime can download/install a release package into `services/`
+- the service manager can then load and run the installed service
+- every service should live in its own repo, even when some services are bundled into an app package at package time
+
+So the donor `services/` folder is best interpreted as:
+
+- a **local installed service inventory**
+- not a permanently source-controlled monolith
+
+That means this review is about defining the **service package/install contract**.
+
+---
+
+## 2. Donor Service Inventory
+
+Current donor service directories reviewed:
+
+### Runtime / utility services
+- `_archive`
+- `_java`
+- `_keycloak`
+- `_localcert`
+- `_node`
+- `_python`
+- `_traefik`
+
+### Application / data / platform services
+- `bpmn-server`
+- `cms`
+- `fastapi`
+- `filebeat`
+- `files`
+- `jupyterlab`
+- `messageservice-client`
+- `mongo`
+- `nginx`
+- `openobserve`
+- `postgredb`
+- `postgredb-admin`
+- `totaljs-flow`
+- `totaljs-messageservice`
+- `typedb`
+- `typedb-init`
+- `typedb-sample`
+- `wsecho`
+
+### Non-service app/example folder observed
+- `bpmn-client`
+
+Important note:
+- `bpmn-client` does **not** contain `service.json`, so it is not currently in the same runtime-managed contract as the actual services.
+
+---
+
+## 3. What Almost Every Managed Service Has
+
+The donor contract strongly centers on a per-service folder containing:
+
+- `service.json`
+- optional README / notes
+- optional payload archives or platform binaries
+- optional config/data/templates/scripts
+- optional app source/runtime files
+
+The single biggest contract artifact is:
+
+- `services/<service-id>/service.json`
+
+This is the thing the runtime discovers and interprets.
+
+---
+
+## 4. Common Top-Level Service Folder Shapes
+
+Across the donor services, the main recurring folder shapes are:
+
+### A. Utility runtime provider services
+Examples:
+- `_node`
+- `_python`
+- `_java`
+- `_archive`
+
+Typical contents:
+- `service.json`
+- platform folders like `win32/`, `darwin/`, `linux/`
+- setup archive(s) or runtime payloads
+- README / notes
+
+Purpose:
+- provide a runtime binary/toolchain used by other services
+- often referenced via `execservice`
+
+### B. Archive-installed infrastructure services
+Examples:
+- `mongo`
+- `postgredb`
+- `_traefik`
+- `openobserve`
+- `typedb`
+- `_keycloak`
+
+Typical contents:
+- `service.json`
+- payload archives or split archive parts
+- platform-specific runtime folders
+- config/data directories
+- README / notes
+
+Purpose:
+- unpack and run a packaged infrastructure dependency
+
+### C. Source/application services run via a utility runtime
+Examples:
+- `fastapi`
+- `messageservice-client`
+- `postgredb-admin`
+- `wsecho`
+- `typedb-sample`
+- `typedb-init`
+- `bpmn-server`
+- `files`
+- `totaljs-flow`
+- `totaljs-messageservice`
+
+Typical contents:
+- `service.json`
+- app source/runtime files
+- language-specific dependency manifests
+  - `package.json`
+  - `requirements.txt`
+- config/data/templates/scripts
+
+Purpose:
+- run app code using another service/runtime provider such as `node` or `python`
+
+### D. Config-heavy proxy/cert/bootstrap services
+Examples:
+- `nginx`
+- `_localcert`
+- `_traefik`
+
+Typical contents:
+- `service.json`
+- config folders
+- command templates / command config
+- generated cert/data folders
+
+Purpose:
+- support the wider service graph rather than act as end-user apps
+
+---
+
+## 5. `service.json` Contract - Main Observed Structure
+
+Most services follow this high-level shape:
+
+```json
+{
+  "id": "...",
+  "name": "...",
+  "description": "...",
+  "enabled": true,
+  "status": "...",
+  "icon": "...",
+  "servicetype": 50,
+  "servicelocation": 10,
+  "execconfig": {
+    "...": "..."
+  }
+}
+```
+
+### Common top-level fields observed
+- `id`
+- `name`
+- `description`
+- `enabled`
+- `status`
+- `logoutput`
+- `icon`
+- `servicetype`
+- `servicelocation`
+- `version` (some services)
+- `actions` (some services)
+- `execconfig`
+
+### Common `execconfig` fields observed
+- `serviceorder`
+- `serviceport`
+- `serviceportsecondary`
+- `serviceportconsole`
+- `serviceportdebug`
+- `portmapping`
+- `executable`
+- `executablecli`
+- `execservice`
+- `execshell`
+- `execcwd`
+- `commandline`
+- `commandlinecli`
+- `commandconfig`
+- `setup`
+- `setuparchive`
+- `datapath`
+- `env`
+- `globalenv`
+- `depend_on`
+- `healthcheck`
+- `authentication`
+- `outputvarregex`
+- `urls`
+- `ignoreexiterror`
+- `debuglog`
+
+---
+
+## 6. Main Runtime Patterns In The Donor Contract
+
+### Pattern 1 - `execservice`
+A service can depend on another service to provide the executable/runtime.
+
+Examples in spirit:
+- app service runs via `node`
+- app service runs via `python`
+- dependent tool uses `java`
+
+This is useful and should survive.
+
+### Pattern 2 - `setuparchive`
+A service can install/unpack a payload archive before runtime.
+
+This also maps well to the future GitHub-release install model.
+
+### Pattern 3 - `depend_on`
+Services explicitly declare dependency order.
+
+This is core and should survive.
+
+### Pattern 4 - `healthcheck`
+Services declare their runtime health expectations.
+
+This is core and should survive, but may need normalization.
+
+### Pattern 5 - environment templating
+Services rely heavily on `env` and `globalenv` generation.
+
+This is useful, but the exact donor shape is likely too app-specific and should be cleaned.
+
+---
+
+## 7. Donor Issues / Weaknesses Observed
+
+These are important because the template repo should avoid them.
+
+### A. Mixed concerns in a single folder
+Many donor service folders mix:
+- install payloads
+- app source
+- generated data
+- runtime state
+- config
+- docs
+
+This makes services less portable and harder to reason about.
+
+### B. Bundled payload assumptions
+Some donor services assume archives/binaries are already present locally.
+
+For Service Lasso, these should be installable dynamically from a release source, not assumed to already exist.
+
+### C. Runtime state mixed with package content
+Some folders contain data/runtime/generated state next to source/config.
+
+The cleaner model is:
+- service package content
+- separate installed/runtime data/state locations
+
+### D. Service contract is powerful but under-normalized
+`service.json` currently mixes several concerns:
+- metadata
+- install instructions
+- runtime instructions
+- env generation
+- health
+- dependency graph
+- auth/config hints
+
+This should probably be split conceptually, even if a single file remains possible for compatibility.
+
+---
+
+## 8. Recommended Conceptual Split For A Service Package
+
+For Service Lasso, each service should conceptually have three layers:
+
+### 1. Source definition
+Where does the service come from?
+
+Examples:
+- GitHub release
+- local path
+- bundled core service
+
+### 2. Installed artifact
+What is installed locally right now?
+
+Examples:
+- installed version
+- install path
+- checksum
+- installed timestamp
+
+### 3. Runtime definition
+How is it executed and supervised?
+
+Examples:
+- executable or execservice
+- ports
+- env
+- dependencies
+- health checks
+
+The donor `service.json` currently tends to compress all of this into one place.
+
+---
+
+## 9. Proposed Template Service Repo Goal
+
+A template service repo should make it easy to publish a service that Service Lasso can install and run.
+
+That template should be designed so a service can be:
+
+- built/published independently
+- packaged for release
+- downloaded/installed into `services/`
+- discovered by the runtime
+- started with predictable setup/runtime behavior
+
+---
+
+## 10. Proposed Template Service Repo Structure
+
+Suggested baseline template:
+
+```text
+service-template/
+  service.json
+  README.md
+  CHANGELOG.md
+  LICENSE
+  release/
+    manifest.json
+  config/
+  scripts/
+  assets/
+  runtime/
+  package/
+```
+
+If the service is source-based, maybe:
+
+```text
+service-template/
+  service.json
+  README.md
+  src/
+  config/
+  scripts/
+  package.json | requirements.txt | etc
+```
+
+But for release/installability, I think the final packaged artifact should always converge on a predictable installed shape.
+
+---
+
+## 11. Proposed Installed Service Folder Shape
+
+Suggested installed layout under local `services/`:
+
+```text
+services/
+  <service-id>/
+    service.json
+    service.state
+    service.pid
+    config/
+    installed/
+```
+
+Possible meanings:
+
+- `service.json`
+  - canonical service manifest / contract
+- `service.state`
+  - mutable local install/resolution/state information
+  - for example resolved version, installed version, install timestamps, selected mode, checksum, setup/install flags
+- `service.pid`
+  - current running pid / process state file
+- `config/`
+  - config content coming from repo/package
+- `installed/`
+  - extracted/installed service payload
+
+This keeps the local `services/` directory dynamic and installable while clearly separating immutable contract from mutable runtime/install state.
+
+---
+
+## 12. Proposed Template `service.json` Sections
+
+For the future template, I would normalize the contract into clearer sections.
+
+Example direction:
+
+```json
+{
+  "id": "example-service",
+  "name": "Example Service",
+  "version": "1.0.0",
+  "kind": "application",
+  "source": {
+    "type": "github-release"
+  },
+  "install": {
+    "strategy": "archive",
+    "entry": "runtime/"
+  },
+  "runtime": {
+    "execservice": "node",
+    "command": "main.js",
+    "cwd": "runtime",
+    "ports": {
+      "service": 8000
+    },
+    "env": {},
+    "dependsOn": []
+  },
+  "health": {
+    "type": "http",
+    "url": "http://localhost:${SERVICE_PORT}/health"
+  }
+}
+```
+
+This is conceptually cleaner than the current flat donor `execconfig` shape.
+
+---
+
+## 13. Recommended Template Repo Files
+
+The template repo should likely include:
+
+### Required
+- `service.json`
+- `README.md`
+- release packaging config
+- runtime entrypoint or executable target
+
+### Strongly recommended
+- `CHANGELOG.md`
+- `LICENSE`
+- `scripts/build.*`
+- `scripts/package.*`
+- `scripts/verify.*`
+- release manifest/checksum file
+
+### Optional
+- sample config
+- healthcheck probe script
+- migration/setup scripts
+- platform-specific packaging helpers
+
+---
+
+## 14. Suggested Service Categories For Template Thinking
+
+It may help to define template variants:
+
+### Template A - Runtime provider service
+Examples:
+- node
+- python
+- java
+
+### Template B - Archive-installed infrastructure service
+Examples:
+- mongo
+- postgres
+- traefik
+- openobserve
+
+### Template C - Source/app service using a runtime provider
+Examples:
+- fastapi app
+- node app
+- python worker
+
+### Template D - Setup/bootstrap job service
+Examples:
+- typedb-init
+- data/bootstrap/seed services
+
+These likely want slightly different template defaults, even if they share a common contract.
+
+---
+
+## 15. Best Current Extraction For The Template Repo Contract
+
+If we strip the donor clutter away, the main reusable contract appears to be:
+
+A service package should provide:
+
+1. **identity**
+   - id, name, version, description
+2. **runtime requirements**
+   - executable or runtime provider
+3. **install strategy**
+   - archive/setup/source layout
+4. **dependency graph**
+   - what must exist/run first
+5. **ports**
+   - declared or mapped ports
+6. **env/config**
+   - service env and generated globals
+7. **health**
+   - how the manager knows it is alive/ready
+8. **operator metadata**
+   - icon, actions, docs links if desired
+
+---
+
+## 16. Packaging / Installation Modes
+
+Current direction from Max:
+
+All Service Lasso app/reference hosts should support two service-distribution modes:
+
+### A. Bundled / base-services mode
+The app package includes a base set of services pre-packaged with the app.
+
+Use cases:
+- smoother offline or low-friction startup
+- known-good default runtime set
+- reference/demo distributions
+
+Implications:
+- app packages need a manifest of included base services
+- installed-service registration must recognize pre-bundled services
+- updates must distinguish bundled version vs locally updated version
+
+### B. Lightweight / bootstrap-download mode
+The app package ships light and downloads required/base services on first start.
+
+Use cases:
+- smaller installer/package size
+- faster app release cycles
+- dynamic service acquisition from GitHub releases or other sources
+
+Implications:
+- runtime needs bootstrap install flow
+- source/install metadata must be first-class
+- first-run UX must clearly show install/download progress and failures
+
+This reinforces that the `services/` directory is a dynamic installed inventory, not a fixed static source tree.
+
+## 17. Immediate Recommendation
+
+Use the donor service review to define:
+
+- a **normalized service package contract**
+- a **template service repo structure**
+- a **local installed service layout** under `services/`
+
+Do **not** copy the donor service folders 1:1 as the final model.
+
+The donor set is valuable as a reference corpus, but the final template/service packaging model should be cleaner, more installable, and explicitly designed for dynamic GitHub-release-based installation.
+
+---
+
+## 18. Base Service Classification Notes
+
+Current direction from discussion:
+
+### Base utility/provider capabilities
+- `_archive`
+  - donor config confirms this is effectively a packaged archive tool provider (7zip / 7zz)
+  - exports global env like `ARCHIVE` and `ARCHIVE_HOME`
+  - likely to evolve toward an internal provider/tool abstraction rather than a normal service
+- `_localcert`
+  - donor config confirms this is a local cert/bootstrap provider
+  - generates local cert material and exports values like `CERT_FILE`, `CERT_KEY`, `CERT_PFX`, `CAROOT_CERT`
+  - used to support local HTTPS hosting flows for the routing layer
+
+### Base runtime providers
+- `_node`
+  - donor config confirms this is a packaged Node runtime provider with install archive + exported globals `NODE`, `NODE_HOME`, `NPM`
+- `_python`
+  - donor config confirms this is a packaged Python runtime provider with setup/bootstrap logic and exported globals `PYTHON`, `PYTHON_HOME`
+- `_java`
+  - donor config confirms this is a packaged Java runtime provider with exported globals `JAVA`, `JAVA_HOME`
+
+These are strong donor concepts worth preserving, but they should become explicit runtime-provider roles rather than relying on underscore-prefixed naming.
+
+### Base infrastructure
+- `_traefik`
+  - donor config confirms this is more than a simple proxy convenience
+  - acts as the routing/ingress/service-host layer
+  - owns stable local URLs and hostnames
+  - supports service-to-service communication via local routed hostnames
+  - depends on `localcert` and `nginx` in the donor setup
+
+### Removed from base classification
+- `_keycloak`
+  - should not remain a base service
+  - better treated as optional infrastructure/auth service
+
+## 19. Open Questions For Next Iteration
+
+- should `service.json` stay single-file or split into `source/install/runtime` files?
+- should installed versions be symlinked or copied into `current/`?
+- should a service package contain runtime state/data at all, or must that always live elsewhere?
+- how should checksums/signatures be represented?
+- how should secrets/config references be expressed?
+- should actions/admin UI metadata live in the service contract or in a separate UI descriptor?
+- what should the exact release artifact contract look like for GitHub-installed services?
+
+---
+
+## 20. Working Summary
+
+The donor services folder demonstrates a useful runtime contract centered on `service.json`, dependencies, setup archives, runtime providers, and health checks.
+
+For Service Lasso, this should evolve into a cleaner dynamic service package/install model where:
+
+- services are installable from release sources
+- local `services/` is an installed inventory
+- each service has a clearer split between source, install, and runtime concerns
+- a template service repo can be published independently and then installed by the manager
+
+---
+
+_Add per-service notes and refinements as we continue reviewing._

--- a/docs/reference/SERVICE-TEMPLATE-REPO.md
+++ b/docs/reference/SERVICE-TEMPLATE-REPO.md
@@ -1,0 +1,250 @@
+# Service Lasso - Service Template Repo
+
+_Status: working draft_
+
+Important reconciliation note:
+- this file is a migration/template planning doc
+- use `QUESTION-LIST-AND-CODE-VALIDATION.md` and `ARCHITECTURE-DECISIONS.md` first when deciding what is already settled versus what remains template-design work
+
+Purpose:
+
+- define the role of the canonical Service Lasso service template repo
+- clarify how individual services should be migrated out into their own repos
+- document the rule that packaging some services with an app does not change service ownership
+- serve as the place that must eventually explain the full service contract comprehensively, not just by shorthand references to other scratchpad docs
+
+Related docs:
+
+- `ARCHITECTURE.md`
+- `ARCHITECTURE-DECISIONS.md`
+- `SERVICE-STRUCTURE-REVIEW.md`
+
+---
+
+## 1. Core Rule
+
+All services must live in their **own repos**.
+
+Important current decisions:
+- the service template repo should be **public**
+- all Service Lasso ecosystem repos should be public
+- it should be the **first repo created** in the new Service Lasso ecosystem because it unlocks migration/creation of all later service repos
+
+This remains true even when:
+
+- some services are bundled into app packages at package time
+- some services are preinstalled in bundled/base distributions
+- some services are downloaded dynamically on first start
+
+Bundling does **not** change ownership.
+
+---
+
+## 2. Template Repo Role
+
+There should be a canonical **service template repo** that defines the standard shape for a Service Lasso service repo.
+
+Every migrated service repo should use that template as its starting point.
+
+Current direction:
+- we only need **one** service template repo first
+- we do not need multiple template repos before migration starts
+- this template should be the canonical base for all later service repos
+
+This ensures consistent:
+
+- repo layout
+- service contract structure
+- release packaging
+- metadata conventions
+- install/update behavior
+- CI/release expectations
+
+---
+
+## 3. Migration Rule
+
+For each donor-era service that survives into the new platform model:
+
+1. create its own repo
+2. initialize it from the canonical service template repo
+3. migrate its service-specific code/config/assets into that repo
+4. make it publishable/releasable independently
+5. have Service Lasso install it from its released artifacts
+
+---
+
+## 4. Naming Convention
+
+Service repos should use one shared prefix:
+
+- `lasso-`
+
+Rule:
+- remove `lasso-` from the repo name
+- the remainder is the exact local service folder name
+
+Examples:
+- `lasso-@archive` -> `@archive`
+- `lasso-@node` -> `@node`
+- `lasso-fastapi` -> `fastapi`
+
+This convention should be part of the template/migration standard.
+
+## 5. What The Template Must Standardize
+
+The template repo should standardize at least:
+
+- canonical `service.json` manifest shape
+- expected local `service.state` usage
+- expected local `service.pid` usage
+- release artifact shape
+- runtime/config layout
+- explicit per-OS subfolders (for example `win32/`, `linux/`, `darwin/`)
+- scripts for build/package/verify
+- documentation structure
+- versioning/release conventions
+- a minimal sample service implementation that proves the lifecycle
+- a simple reference release pipeline for producing compressed test artifacts
+- packaging configuration for building release archives with 7zip
+
+## 6. Template Sample Service
+
+The template repo should include a deliberately minimal sample service.
+
+Current direction:
+- use a simple **echo service** as the sample
+- it should not do any real application work
+- it should exist only to prove the template/service lifecycle contract
+- the template should include explicit OS subfolders such as `win32/`, `linux/`, and `darwin/`
+
+Recommended sample behavior:
+- install/setup runs cleanly
+- during install/setup it writes a simple echo message into the log
+- the sample script itself should just echo sample text
+- it proves service registration, install flow, state handling, and log output without adding heavy runtime complexity
+
+Why this is good:
+- easiest possible template to understand
+- proves the manifest/release/install flow
+- avoids dragging real app/runtime complexity into the template repo
+
+### Reference pipeline requirement
+The template repo should also include a simple reference release pipeline.
+
+Current direction:
+- include a simple `*.ps1` script and `*.sh` script in the template repo
+- the sample script behavior should just echo sample text
+- these should use the per-OS subfolders as packaging inputs
+- these should be used to create compressed release artifacts
+- archiving/package creation should be done using 7zip
+- the pipeline/template should include the necessary packaging config for 7zip-based release creation
+- the resulting release artifacts should be usable for testing the Service Lasso install/release flow end-to-end
+
+This gives the template immediate value as both:
+- a service repo starting point
+- a release/pipeline test fixture
+
+## 7. Packaging Rule
+
+---
+
+## 7. Packaging Rule
+
+Some apps/reference hosts may package a selected set of services at package time.
+
+That is allowed.
+
+But those packaged services must still:
+
+- originate from their own independent service repos
+- follow the service template repo contract
+- remain independently releasable/versioned
+
+So app packaging is a **distribution choice**, not a repo-ownership model.
+
+---
+
+## 8. Why This Matters
+
+Without a template repo and one-service-per-repo discipline, the platform drifts back toward a giant mixed donor tree.
+
+The template repo keeps migration clean and makes the service ecosystem scalable.
+
+---
+
+## 9. Documentation Expectation
+
+The canonical service template repo doc will need a **comprehensive explanation of the full service contract**.
+
+That explanation should eventually cover, in one place:
+
+- what `service.json` is for
+- what each top-level section means
+- how defaults work versus overrides
+- what `actions` means in practice
+- how install/config/start relate
+- what `service.state` and `service.pid` are for
+- how releases, packaging, and per-OS folders fit together
+- how a service creator should reason about defaults versus service-specific command mappings
+
+Important rule:
+- this should be explained directly and comprehensively in the template repo docs
+- future service authors should not need to reconstruct the contract by piecing together scattered scratchpad notes
+
+---
+
+## 10. GitHub CLI Repo/Template Creation Commands
+
+Useful `gh` CLI commands to remember when creating the Service Lasso ecosystem repos:
+
+### Create a normal public repo
+```bash
+gh repo create service-lasso/<repo-name> --public
+```
+
+### Create and clone a normal public repo
+```bash
+gh repo create service-lasso/<repo-name> --public --clone
+```
+
+### Create a public repo from the current folder and push it
+```bash
+gh repo create service-lasso/<repo-name> --public --source . --push
+```
+
+### Add a description at creation time
+```bash
+gh repo create service-lasso/<repo-name> --public --description "<description>"
+```
+
+### Mark an existing repo as a template repo
+```bash
+gh repo edit service-lasso/<repo-name> --template
+```
+
+### Recommended flow for the canonical service template repo
+```bash
+gh repo create service-lasso/service-template --public --clone
+gh repo edit service-lasso/service-template --template
+```
+
+### Verify the repo afterwards
+```bash
+gh repo view service-lasso/<repo-name>
+```
+
+Important clarification:
+- GitHub template repos are created by first creating a normal repo, then marking it with `gh repo edit ... --template`
+- use `--source . --push` when the local folder already exists and should become the remote repo immediately
+
+---
+
+## 11. Working Summary
+
+Service Lasso should have:
+
+- one canonical service template repo
+- one service per repo
+- optional app/package-time bundling of selected service releases
+- dynamic install/update flows that still treat each service as independently owned and released

--- a/docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md
+++ b/docs/reference/adjacent/SPEC-SERVICE-LASSO-HARNESS.md
@@ -1,0 +1,229 @@
+# Spec Draft - Service Lasso Harness
+
+_Status: draft_
+
+## Intent
+Define the dedicated `service-lasso-harness` contract as the shared validation runner for Service Lasso service repos. This matters because service authors need one standard way to prove that a service artifact works under real Service Lasso semantics — install, config, start, health, stop, and evidence capture — rather than relying on ad hoc repo-local smoke scripts that drift from each other.
+
+## Scope
+Included in this spec:
+- the role and boundary of `service-lasso-harness` as a standalone shared validation utility
+- the split between service-repo-owned validation contracts and harness-owned execution behavior
+- preferred v1 implementation language and distribution model
+- the minimum v1 validation flow the harness must perform
+- minimum result/evidence outputs from a harness run
+- how consumer service repos and CI are expected to invoke the harness
+- the relationship between `service-template` and the harness as the first golden example
+- current role-based validation direction for runtime-provider, infrastructure, app, and utility/bootstrap services
+
+Explicitly out of scope for this spec:
+- the full Service Lasso core runtime spec
+- the full `service-template` spec beyond what the harness needs to consume
+- the final canonical `service.json` structure for all services
+- UI/admin behavior or route design
+- implementation details for every future validation role/profile beyond the minimum first-pass direction
+
+## Acceptance Criteria
+- `AC-1`: The spec states that `service-lasso-harness` exists to validate service artifacts under real Service Lasso semantics, not only by direct standalone execution.
+- `AC-2`: The spec states that consumer service repos own a small validation contract and thin verify entrypoints, while the harness owns the shared execution engine.
+- `AC-3`: The preferred v1 implementation language is explicitly defined as **Go**.
+- `AC-4`: The preferred distribution model is explicitly defined as downloadable **GitHub release binaries**.
+- `AC-5`: The spec states that service repos and CI should consume released harness binaries rather than depending on a local Node toolchain for harness execution.
+- `AC-6`: The spec defines the minimum v1 validation flow: isolated root creation, artifact install, dependency bootstrapping where required, `install`/`config`/`start`/health/`stop` execution, and evidence capture.
+- `AC-7`: The spec defines the minimum required outputs from a harness run, including machine-readable result status plus enough evidence to debug failures.
+- `AC-8`: The spec defines the current role-based validation direction for runtime-provider, infrastructure, app, and utility/bootstrap services.
+- `AC-9`: The spec defines `service-template` as the first intended golden-example consumer of the harness contract.
+- `AC-10`: Open questions are recorded explicitly instead of being left implicit in surrounding planning text.
+
+## Tests and Evidence
+Planning evidence currently available:
+- `README.md`
+- `docs/usage-flow.md`
+- `docs/openspec-drafts/OPENSPEC-TRACKER.md`
+- `C:\projects\service-lasso\service-template\docs\openspec-drafts\SPEC-SERVICE-TEMPLATE-REPO.md`
+- `C:\projects\service-lasso\service-template\docs\reference\SERVICE-TEMPLATE-REPO.md`
+- `C:\projects\service-lasso\service-template\docs\reference\SERVICE-STRUCTURE-REVIEW.md`
+- `C:\projects\service-lasso\service-lasso\ref\typerefinery-service-manager-donor\QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `C:\projects\service-lasso\service-lasso\ref\typerefinery-service-manager-donor\ARCHITECTURE-DECISIONS.md`
+
+Implementation evidence required later:
+- a Go runner binary that can execute the first stable `run` flow against a service contract
+- a machine-readable contract/schema for `verify/service-harness.json`
+- at least one end-to-end validation proof against the `service-template` sample service
+- CI proof that the released harness binary can be acquired and executed by a consumer service repo
+
+## Documentation Impact
+This spec is expected to govern or inform:
+- `README.md`
+- `docs/usage-flow.md`
+- future `docs/validation-contract.md`
+- future `schemas/service-harness.schema.json`
+- future CLI/runner docs for the released binary
+- future `service-template` example verify-contract docs and sample usage
+
+## Verification
+Verify this spec by checking that the harness docs and future implementation consistently enforce the same model:
+- service repos declare a small validation contract instead of embedding a bespoke validation engine
+- the harness is clearly treated as the shared executor
+- Go is the explicit v1 implementation choice
+- GitHub release binaries are the explicit distribution mechanism
+- consumer repos and CI are expected to invoke the released harness binary
+- the minimum run flow covers isolated setup, artifact/dependency preparation, lifecycle execution, health/readiness checks, and evidence capture
+- run outputs are explicit enough that a future implementation can prove pass/fail and support debugging
+
+## Change Notes
+- Initial dedicated harness spec draft was created after the harness work was split into its own standalone local folder.
+- This revision rewrites the harness spec into the project’s actual standard spec/governance structure instead of a freeform planning note.
+- Current preferred direction recorded here: implement v1 in Go, distribute via GitHub release binaries, and have service repos consume the released harness binary.
+
+## Current Contract Direction
+
+### Harness role
+`service-lasso-harness` is the shared validation runner for Service Lasso service repos.
+
+Its purpose is to answer:
+
+> does this service artifact actually work inside Service Lasso?
+
+It should not be treated as a replacement for unit tests, a UI test framework, a service template repo, or a general workflow engine.
+
+### Service repo interaction model
+A consumer service repo is expected to provide a small contract surface such as:
+- `scripts/verify.ps1`
+- `scripts/verify.sh`
+- `verify/service-harness.json`
+
+Those files should be thin wrappers/contracts rather than full validation engines.
+
+Conceptual direction for invocation:
+
+```powershell
+service-lasso-harness.exe run --contract .\verify\service-harness.json
+```
+
+Equivalent non-Windows shell invocation should follow the same contract model.
+
+### Harness-owned execution behavior
+The harness should own the shared validation engine behavior:
+- isolated Lasso root creation
+- artifact installation
+- dependency bootstrapping where required for validation
+- lifecycle execution (`install`, `config`, `start`, health/readiness, `stop`)
+- logs/state/result artifact capture
+- machine-readable pass/fail output
+
+### Preferred v1 implementation language
+Preferred v1 implementation language:
+- **Go**
+
+Reasoning:
+- single-binary distribution is cleaner for a shared cross-repo utility
+- easier version pinning for service repos and CI
+- easier GitHub-release consumption model
+- avoids requiring a local Node toolchain solely to execute the harness runner
+
+### Preferred distribution model
+Preferred distribution model:
+- **GitHub release binaries**
+
+Current intended direction:
+- publish platform-specific binaries per release
+- let consumer repos and CI download/use a pinned harness release asset
+- treat released binaries as the default execution path for service verification
+
+### Minimum v1 run flow
+The minimum meaningful v1 harness flow should be:
+1. create an isolated temporary Lasso validation root
+2. materialize test config if required
+3. install the target service artifact
+4. install declared validation dependencies where required
+5. run `install`
+6. run `config` if required
+7. run `start`
+8. wait for readiness / health
+9. validate expected outputs
+10. run `stop`
+11. capture and emit result artifacts
+
+`uninstall` / `reset` checks may begin as narrower or later slices if needed, but the overall direction should remain explicit.
+
+### Minimum run outputs
+Each harness run should produce enough evidence to trust passes and debug failures.
+
+Minimum direction:
+- machine-readable pass/fail result
+- failing stage / failure reason when not successful
+- logs
+- relevant runtime/state outputs
+- timing information
+- artifact summary and/or artifact paths
+
+### Role-based validation direction
+Current role-based validation direction:
+
+#### Runtime-provider services
+Examples:
+- `@node`
+- `@python`
+- `@java`
+
+Expected direction:
+- runtime installs successfully
+- binary is callable
+- expected env is exported
+- a dependent sample service can execute through it
+
+#### Infrastructure services
+Examples:
+- postgres
+- traefik
+- mongo
+
+Expected direction:
+- payload/archive install works
+- config materializes correctly
+- service port opens
+- health succeeds
+- stop behavior works correctly
+
+#### App services
+Examples:
+- node app
+- python app
+- API service
+
+Expected direction:
+- runtime dependency resolves
+- app starts correctly
+- health/readiness succeeds
+- expected logs/state are written
+
+#### Utility/bootstrap services
+Examples:
+- `@archive`
+- `@localcert`
+
+Expected direction:
+- expected action completes
+- expected artifacts are produced
+- exported values are usable by dependent services
+
+### Relationship to `service-template`
+`service-template` is the first intended golden-example consumer of the harness contract.
+
+The harness + template relationship should prove:
+- how a service declares the validation contract
+- how a local verify script calls the harness
+- how CI uses the same path
+- what a successful evidence bundle looks like
+
+The harness should not overrun the template contract, but it still needs its own standalone spec because it is a separate shared utility with its own release/distribution responsibilities.
+
+## Open Questions
+- What exact schema should be locked first for `verify/service-harness.json`?
+- How much dependency bootstrapping should the harness own versus the service contract declare?
+- Which uninstall/reset checks belong in v1 versus later slices?
+- What exact CLI surface should be stabilized first (`run`, `validate-contract`, `version`, etc.)?
+- Which output artifacts should be mandatory for every run?
+- How much platform-specific logic should live in the Go binary versus service-owned wrappers/config?
+- Should there be an optional helper installer/bootstrap path for acquiring the binary, or should pinned direct release-asset download remain the only supported path?

--- a/docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md
+++ b/docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md
@@ -1,0 +1,639 @@
+# Service Lasso - Architecture Decisions
+
+_Status: working draft / decision log_
+
+Important reconciliation note:
+- this file is a decision log, but `QUESTION-LIST-AND-CODE-VALIDATION.md` is the canonical transcript+code reconciliation source for the main donor/runtime-boundary questions
+- if an older decision section here drifts away from that reconciled source, the reconciled question doc should win unless the discussion is explicitly reopened
+
+Purpose:
+
+- capture the important architectural decisions discussed so far
+- keep critical decisions out of chat-only memory
+- provide a concise companion to the larger architecture notes
+
+Related docs:
+
+- `ARCHITECTURE.md`
+- `SERVICE-STRUCTURE-REVIEW.md`
+- `QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `REFERENCE-APP-NODE.md`
+- `REFERENCE-APP-ELECTRON.md`
+- `REFERENCE-APP-TAURI.md`
+- `REFERENCE-APP-DOCKER.md`
+- `REFERENCE-APP-PKG.md`
+- `REFERENCE-APP-NEXE.md`
+
+---
+
+## 1. Core Product Boundary
+
+### Decision
+The core product is `service-lasso`.
+
+### Meaning
+It should be:
+- Node-first
+- npm-publishable
+- buildable to plain JS
+- executable with `node`
+- the canonical first implementation of the architecture
+
+### Not part of the core boundary
+- Electron shell concerns
+- Tauri shell concerns
+- Docker packaging concerns
+- `pkg` / `nexe` packaging concerns
+
+These belong in separate reference apps/packages.
+
+---
+
+## 2. Runtime Shape
+
+### Decision
+Service Lasso should be a Node-first local service orchestration runtime.
+
+### Meaning
+The core should provide:
+- runtime engine
+- service/instance orchestration
+- local control API
+- CLI/runtime entrypoints
+- shared contracts used by optional UI/reference hosts
+
+Important clarification:
+- the admin/operator UI is **not** privileged core
+- it should be an optional separate service/reference consumer of the API
+- the core owns orchestration + API + CLI + contracts, not a mandatory built-in UI shell
+
+---
+
+## 3. Implementation Hierarchy
+
+### Decision
+Node/JS is the canonical first implementation.
+
+### Meaning
+The first full working implementation lives in `service-lasso`.
+
+Future native ports should be:
+- `service-lasso-go`
+- `service-lasso-rust`
+
+These must be **true ports**, not divergent rewrites.
+
+## 4. App / Instance Model
+
+### Decision
+An app start creates an app instance at runtime.
+
+### Meaning
+- when one app starts, it negotiates ports and loads all required services
+- when another app starts, it does the same again on a different set of ports
+- each app startup is therefore an instance in practice
+- services come from shared service repos/packages, but app runs create separate instance-level runtime state and negotiated ports
+- if a service needs its own internal sub-instance/forking behavior, that can be handled within that service itself
+
+---
+
+## 5. Repo Visibility Rule
+
+### Decision
+All Service Lasso ecosystem repos should be public.
+
+### Meaning
+- core repo
+- service repos
+- reference app repos
+- template repos
+
+Current rationale:
+- public visibility keeps the pipeline/release flow working as intended
+
+## 6. Reference App Set
+
+### Decision
+Reference apps/packages are separate from the core.
+
+### Current set
+#### Host/environment references
+- `service-lasso-app-node`
+- `service-lasso-app-electron`
+- `service-lasso-app-tauri`
+- `service-lasso-app-docker`
+
+#### Packaging references
+- `service-lasso-app-pkg`
+- `service-lasso-app-nexe`
+
+### Rule
+Reference apps/packages must consume the core package and must not contain hidden orchestration logic absent from core.
+
+---
+
+## 7. Electron Position
+
+### Decision
+Electron is excluded from the core architecture and belongs only in a reference app.
+
+### Meaning
+Electron may be used to:
+- host the UI
+- wrap/package the runtime
+- provide desktop shell behavior
+
+But it must not define the core runtime architecture.
+
+---
+
+## 8. IPC vs API
+
+### Decision
+Electron-style renderer IPC should not define the core control plane.
+
+### Meaning
+The core should expose a local API/control plane.
+
+Reference hosts like Electron/Tauri may adapt to that API, but the core should not depend on host-specific IPC semantics.
+
+---
+
+## 9. Service Folder Model
+
+### Decision
+The `services/` folder should remain dynamic, not fixed.
+
+### Meaning
+Service Lasso should support:
+- discovering installed services under `services/`
+- downloading/installing services from release sources
+- updating/removing services
+- treating `services/` as an installed local inventory
+
+It should not depend on a permanently source-controlled monolithic service tree.
+
+Current clarified local service layout direction:
+- each service has its own folder under `services/`
+- each service keeps one canonical metadata file (`service.json`)
+- each service has a mutable local state file (`service.state`) for install/resolution/state info
+- each service has a pid file (`service.pid`) for current running process state
+- each service has config folders coming from the repo/package
+- each service has an `installed/` folder created by the install process
+- install commonly means extracting the service archive (for example zip / 7zip, possibly chunked for large payloads)
+
+---
+
+## 10. Service Template Priority
+
+### Decision
+The first template repo to create should be the public service template repo.
+
+### Meaning
+- it should be created before the wider service repo migration begins
+- it should be the canonical base for all later service repos
+- it should include a minimal echo-style sample service proving the lifecycle/install/log contract
+- the sample script behavior should just echo sample text
+- it should include explicit OS subfolders such as `win32/`, `linux/`, and `darwin/`
+- the pipeline should use those OS subfolders as packaging inputs
+- it should include a simple reference release pipeline (for example `*.ps1` and `*.sh`) that produces compressed release artifacts for end-to-end testing
+- archive/package creation in that pipeline should be done using 7zip-based packaging config
+
+## 11. Service Source / Install Model
+
+### Decision
+All services must live in their own repos.
+
+### Meaning
+- one service = one repo
+- service repos are independently versioned and released
+- Service Lasso installs services from those external repos/releases
+- the core repo should not become a permanent monorepo of service implementations
+- services support explicit versions and should resolve to exact release versions when selected
+
+Service Lasso should support a flow like:
+- resolve service source
+- choose exact release/version (for example `@node:1.18.0`)
+- download release package
+- install/unpack into local `services/`
+- run setup/install exec commands if defined
+- register and run the service
+
+Important clarification:
+- install is not just archive extraction
+- install may include both archive extraction and command-based setup steps
+
+The service CLI/app flow should support service acquisition modes such as:
+- `embed` -> download/install now
+- `package` -> defer inclusion to package/build time
+- `runtime` -> resolve/download/install when the app/runtime starts
+
+---
+
+## 12. Action Model
+
+### Decision
+Services should use one finite built-in action vocabulary.
+
+### Current action set
+- `install`
+- `uninstall`
+- `update`
+- `start`
+- `stop`
+- `restart`
+- `config`
+
+### Meaning of `config`
+`config` is a real operational action.
+
+It should allow services to:
+- generate templated config
+- merge service-provided config with app-space overrides
+- inject runtime-resolved values (ports, URLs, cert paths, env-derived values)
+- write/update effective config into the runtime/installed area
+
+Important example:
+- for `@traefik`, `config` can regenerate routing config when services are added/changed
+
+### Model rule
+All services share:
+- one registry
+- one broad banded state machine
+- one finite action vocabulary
+
+Services differ by:
+- which actions they support
+- which states are meaningful for them in practice
+- their role/category metadata
+
+Important clarification:
+- diagnostics and status inspection should primarily be exposed through UI/API/state, not separate built-in actions like `validate` / `inspect`
+- actions should stay operational and finite
+
+---
+
+## 13. Packaging Modes
+
+### Decision
+App/reference hosts should support multiple service-acquisition modes.
+
+### Modes
+#### `embed`
+- download/install the selected service now
+
+#### `package`
+- defer the selected service to package/build time inclusion
+
+#### `runtime`
+- resolve/download/install the selected service when the app/runtime starts
+
+### Meaning
+This rule should apply consistently across:
+- node
+- electron
+- tauri
+- docker
+- pkg
+- nexe
+- later go/rust ports
+
+Important rule:
+- packaging some services with an app at package time does **not** change the ownership model
+- those services still belong in their own repos and are only bundled as selected release artifacts
+- by default services may track latest, unless an app/service selection pins an exact version
+
+---
+
+## 13. UI Hosting Model
+
+### Decision
+The UI should be treated as a separate optional service.
+
+### Meaning
+- apps typically roll their own UI
+- Service Lasso should provide its own UI as an optional service used in reference apps
+- the UI can register into the routing layer like other services
+
+### Example
+- `admin.servicelasso.localhost`
+
+---
+
+## 14. Naming Convention
+
+### Decision
+Service repos should use one simple shared repo prefix:
+
+- `lasso-`
+
+After removing that prefix, the remainder should be the exact local service folder name.
+
+### Examples
+- `lasso-@archive` -> local folder `@archive`
+- `lasso-@localcert` -> local folder `@localcert`
+- `lasso-@node` -> local folder `@node`
+- `lasso-fastapi` -> local folder `fastapi`
+- `lasso-mongo` -> local folder `mongo`
+
+### Meaning
+This provides:
+- simple repo-to-folder mapping
+- clear visual grouping in GitHub/org listings
+- easy automation
+- consistent naming across all service repos
+
+### Base/system services
+Future base/system services should likely use `@` naming rather than `_` naming.
+
+Example direction:
+- `@archive`
+- `@localcert`
+- `@node`
+- `@python`
+- `@java`
+- `@traefik`
+
+### Important rule
+Naming is a grouping/ordering signal.
+Actual semantics must still be defined in metadata.
+
+---
+
+## 15. Base Service Classification
+
+### Decision
+Not all donor underscore services remain equal in the future model, and none of them are mandatory by default.
+
+### Utility/provider capabilities
+- `archive`
+- `localcert`
+
+### Runtime providers
+- `node`
+- `python`
+- `java`
+
+### Infrastructure
+- `traefik`
+
+### Not base by default
+- `keycloak`
+
+Important clarification:
+- base/system services remain optional
+- reference apps may include a selected default set
+- some users may only want a subset (for example only `@archive`, or no utility services at all if their service does not require them)
+
+---
+
+## 16. `archive` Interpretation
+
+### Decision
+`archive` remains a service-registry-visible utility service.
+
+### Meaning
+It provides:
+- archive extraction capability
+- install/unpack support for service packages
+- executable path/global env bindings
+- independently updateable archive binaries
+
+Important clarification:
+- it is still treated as a service in the registry
+- it is not expected to behave like a normal long-running app service
+
+---
+
+## 17. `localcert` Interpretation
+
+### Decision
+`localcert` remains a service-registry-visible utility/bootstrap service.
+
+### Meaning
+It exists to:
+- generate local cert material
+- support local HTTPS flows
+- provide cert/root-CA paths to the routing layer and other services
+
+Important clarification:
+- it runs first-time/setup behavior
+- it is considered a utility service
+- it is not expected to be a normal startable long-running service
+- it still appears in the service registry like `archive`
+
+---
+
+## 18. Runtime Provider Interpretation
+
+### Decision
+`node`, `python`, and `java` are base runtime providers.
+
+### Meaning
+Other services may declare that they require one of these runtimes.
+
+These providers should remain explicit first-class concepts in the architecture.
+
+---
+
+## 19. Routing Layer Interpretation
+
+### Decision
+`traefik` should remain part of the platform foundation, but as just another service.
+
+### Meaning
+It is more than a convenience proxy. It acts as:
+- routing layer
+- ingress/service-host layer
+- stable local URL provider
+
+This supports URLs like:
+- `admin.servicelasso.localhost`
+
+Important clarification:
+- browser/frontend interaction typically uses routed URLs
+- service-to-service communication is typically done directly to ports, not routed hostnames
+
+---
+
+## 20. Keycloak Classification
+
+### Decision
+`keycloak` should be removed from base services.
+
+### Meaning
+It is better treated as optional infrastructure/auth service, not universal baseline capability.
+
+---
+
+## 21. Environment Isolation Model
+
+### Decision
+All services are sandboxed from OS-level environment variables.
+
+### Meaning
+- services should not implicitly inherit the host OS environment
+- a service creator must explicitly specify what the service needs
+- services are spawned only with what is available through the Service Lasso-controlled environment model
+- shared service-visible environment should come from `globalenv` (and explicit service env derived from it)
+
+### Why
+This keeps service execution:
+- more reproducible
+- more portable
+- less dependent on hidden machine state
+- easier to reason about across Node/Go/Rust implementations
+
+## 22. Debug Mode Goal
+
+### Decision
+Debug mode should keep the runtime and UI useful even if services are not fully started.
+
+### Meaning
+Debug mode should allow:
+- runtime up
+- UI up
+- services stopped or partially unavailable
+- visibility into blocked/missing service payloads
+
+The UI should not become useless simply because full readiness has not been reached.
+
+---
+
+## 23. Donor Snapshot Status
+
+### Decision
+The donor code in `ref/typerefinery-service-manager-donor/` is reference material only.
+
+### Meaning
+It has been cleaned into a standalone node-only runtime shape for analysis, but it is not the final tracked Service Lasso runtime.
+
+The real product should be built intentionally from the target architecture, not by preserving donor structure unchanged.
+
+---
+
+## 24. Manifest Structure Direction
+
+### Decision
+The donor-style giant `execconfig` block should be cleaned up into clearer named sections.
+
+### Meaning
+Service Lasso should not preserve one large catch-all `execconfig` shape forever.
+
+Current direction is to split manifest concerns into clearer structured sections such as:
+- runtime
+- install
+- network
+- env
+- health
+- dependencies
+
+Important clarification:
+- this is a schema cleanup/normalization direction
+- exact final section names and boundaries can still be refined
+- the key decision is to move away from one overloaded donor catch-all block toward cleaner structured manifest sections
+
+---
+
+## 25. Actions Semantics
+
+### Decision
+`actions` should be treated as **service-specific custom commands that override Service Lasso default behavior for a named service action**.
+
+### Meaning
+`actions` is not:
+- an arbitrary free-form custom action registry
+- generic metadata
+- a separate capability system unrelated to service behavior
+
+Instead, `actions` exists so the service creator can explicitly map their service-specific command when that service needs to override what Service Lasso would normally do by default for a named action.
+
+Examples of what this means:
+- a service may define `stop` to run a graceful shutdown command instead of default process termination
+- if no action override is defined, Service Lasso should use its default behavior for that action
+- action expansion should be evidence-driven rather than speculative; do not widen the overrideable action list until a concrete service shows a real need
+
+Important clarification:
+- action names are still owned by Service Lasso, not invented ad hoc per service
+- `actions` supplies per-service override command mappings for those named actions
+- this keeps the action surface finite while still allowing service-specific behavior
+
+---
+
+## 26. Install Semantics Clarification
+
+### Decision
+`install` should converge a service into its current expected installed/configured state.
+
+### Meaning
+Install may include:
+- acquiring/downloading payloads
+- extracting/unpacking artifacts
+- running setup/preparation commands
+- rewriting Lasso-managed effective config/output
+
+Important clarification:
+- install should not be treated as a destructive full revert of all content back to pristine defaults
+- install is closer to reconcile/materialize desired installed state than to wipe-and-reset behavior
+- if install already rewrites managed config during normal convergence, a separate first-class `config` action should only be kept when a concrete lighter-weight regeneration/update scenario requires it
+
+---
+
+## 27. `service.state` Structure Direction
+
+### Decision
+Managed service state should move toward a `.state/` folder, with structured JSON state rather than a single overloaded flat blob.
+
+### Meaning
+Current preferred areas are:
+- service reference info
+- install
+- content
+- config
+- runtime
+
+Important clarification:
+- backups should live under `.state/backups/` and be tracked as a list/history rather than a single backup field
+- logs should remain logs by default; they do not need to become state snapshots unless a concrete need appears
+- avoid a separate pointer/current file unless a concrete need appears
+- avoid a separate legacy `service.pid` file unless a concrete need appears; PID/runtime info can live in the structured state JSON itself
+
+Current lifecycle-write rule:
+- when a service starts, its state JSON is created
+- when the service stops, that same state JSON is updated with the last action/result
+- other lifecycle events should generally write logs for now rather than creating additional timestamped state files by default
+
+This keeps managed operational state simpler while preserving a clear last-known service record.
+
+---
+
+## 28. Canonical Reconciliation Source
+
+### Decision
+`QUESTION-LIST-AND-CODE-VALIDATION.md` is the canonical reconciliation doc for the main donor/runtime-boundary questions.
+
+### Meaning
+If later planning text drifts away from:
+- the settled transcript answers
+- the donor code evidence
+- the reconciled four-question boundary set
+
+then the reconciled question doc should be treated as more authoritative than older speculative planning sections unless the discussion is explicitly reopened.
+
+---
+
+## 29. Working Summary
+
+Service Lasso is currently intended to become:
+
+- a canonical Node-first orchestration runtime
+- a publishable npm module
+- a buildable plain-JS runtime executable with Node
+- a dynamic installed-service platform
+- a system with explicit utility services, runtime providers, and routing infrastructure
+- a product with separate reference hosts/packages and later true Go/Rust ports
+- a platform where services are independently versioned repos resolved to exact releases when chosen, but may default to latest unless pinned
+
+---
+
+_Add new decisions here as they become stable._

--- a/docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md
+++ b/docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md
@@ -1,0 +1,304 @@
+# Service Lasso - Canonical Question List and Code Validation
+
+_Status: reconciled from chat transcript + donor code review_
+
+Purpose:
+
+- keep one canonical list of the important donor/runtime-boundary questions discussed in chat
+- record the answers that were actually settled in transcript
+- show what the donor code validates, what it only partially supports, and what remains implementation/spec work
+- stop later speculative question batches from drifting away from the grounded discussion
+
+Primary sources:
+
+- Telegram chat export reviewed from `C:\Users\maxbarrass\Downloads\Telegram Desktop\ChatExport_2026-04-06\messages.html`
+- donor runtime code under `runtime/Service.ts`, `runtime/ServiceManager.ts`, and `runtime/Services.ts`
+- donor service manifests under `services/*/service.json`
+
+Related docs:
+
+- `ARCHITECTURE-DECISIONS.md`
+- `SERVICE-MANAGER-BEHAVIOR.md`
+- `QUESTIONABLE-CURRENT-RUNTIME-AREAS.md`
+- `SERVICE-STRUCTURE-REVIEW.md`
+
+---
+
+## 1. Canonical question list recovered from transcript
+
+These were the important runtime-boundary questions that anchored the discussion:
+
+1. Should `@archive` and `@localcert` use the same lifecycle APIs as normal services, or should they have clearer utility/setup semantics?
+2. Do you want `globalenv` to remain merged/ambient within the Service Lasso sandbox, or should it become more explicitly bound per service?
+3. Should port negotiation be fully owned by Service Lasso core, with services only declaring needs?
+4. How much of setup/install should stay inside service lifecycle vs be owned by a dedicated install manager?
+
+These four should be treated as the canonical donor/runtime-boundary question set for this discussion.
+
+---
+
+## 2. Reconciled answers
+
+### Question 1
+**Should `@archive` and `@localcert` use the same lifecycle APIs as normal services, or should they have clearer utility/setup semantics?**
+
+### Settled answer from transcript
+Use:
+
+- one registry
+- one broad banded state machine
+- one finite built-in action vocabulary
+
+But utility services still have **clearer utility/setup semantics** than normal long-running services.
+
+Meaning:
+
+- `@archive` remains a registry-visible service because its binaries/versioning/update path matter independently
+- `@localcert` remains a registry-visible utility/bootstrap service
+- neither should be treated as a normal daemon-like service in the UI/API
+- services differ by supported actions and meaningful states, not by requiring separate service engines
+
+### What donor code validates
+The donor code validates this direction strongly:
+
+- `Service.ts` already distinguishes utility services with `servicetype === UTILITY`
+- utility services end in `COMPLETED` / `COMPLETEDERROR` rather than daemon-style runtime states
+- `Services.ts` and the existing state machine already assume one registry / one service system
+- donor manifests for `_archive` and `_localcert` show they are capability/bootstrap providers, not normal user-facing app daemons
+
+### Validation result
+**Validated by transcript and broadly supported by code.**
+
+The remaining work is implementation polish:
+
+- define which built-in actions each service role supports
+- make UI/API show only meaningful actions
+- make service metadata classify role/category explicitly
+
+---
+
+### Question 2
+**Do you want `globalenv` to remain merged/ambient within the Service Lasso sandbox, or should it become more explicitly bound per service?**
+
+### Settled answer from transcript
+Keep `globalenv` as the **shared Service Lasso-controlled runtime environment**.
+
+Important rule settled in chat:
+
+- services are sandboxed from OS environment variables
+- service creators must explicitly specify what they need
+- services are spawned only with what is available through Service Lasso-controlled env rules
+
+Meaning:
+
+- `globalenv` remains real and important
+- it is not a fallback to host-machine env leakage
+- explicit service env is still valuable, but it is derived from the controlled Service Lasso model, not ambient OS state
+
+### What donor code validates
+The donor code validates the mechanism directly:
+
+- each service may emit `execconfig.globalenv`
+- `Service.globalEnvironmentVariables` resolves and emits those values
+- `ServiceManager.getGlobalEnv()` merges emitted values from all services
+- the merged env is pushed back into services
+- donor manifests for `archive`, `localcert`, `node`, `python`, `java`, and `traefik` all use exported globals as part of the service graph
+
+### Validation result
+**Strongly validated by transcript and code.**
+
+Remaining implementation/spec work:
+
+- define precedence rules when multiple services export the same key
+- define export/import visibility rules clearly in schema docs
+- distinguish shared/exported env from private service-only env sections more cleanly
+
+These are implementation/specification details, not open product-direction questions.
+
+---
+
+### Question 3
+**Should port negotiation be fully owned by Service Lasso core, with services only declaring needs?**
+
+### Settled answer from transcript
+Yes.
+
+The intended model is:
+
+- services declare port needs / port roles
+- Service Lasso core resolves, reserves, negotiates, and publishes final ports
+
+### What donor code validates
+The donor code validates this very strongly:
+
+- `ServiceManager.ts` owns port reservation bookkeeping
+- services declare ports and mappings through manifest fields like:
+  - `serviceport`
+  - `serviceportsecondary`
+  - `serviceportconsole`
+  - `serviceportdebug`
+  - `portmapping`
+- service startup depends on the manager’s resolved/reserved port model
+
+### Validation result
+**Strongly validated by transcript and code.**
+
+Remaining implementation/spec work:
+
+- define exact stability guarantees across reload/install/update
+- define exact collision policy and fallback behavior
+- define how port blocks are expressed for app-level runtime footprints
+
+Again, these are implementation-contract details, not unresolved product questions.
+
+---
+
+### Question 4
+**How much of setup/install should stay inside service lifecycle vs be owned by a dedicated install manager?**
+
+### Settled answer from transcript
+The reconciled model is:
+
+- service manifests declare install/setup/config-relevant behavior
+- Service Lasso core orchestrates install/config work
+- `install` is the main built-in action that converges a service into its expected installed state
+- install may include archive extraction, setup commands, and rewriting Lasso-managed effective config/output
+- install should not be read as a destructive revert of all content back to pristine defaults
+
+Meaning:
+
+- install is not just unzip/download
+- install may include archive extraction and platform-specific setup commands
+- install may also rewrite managed effective config/output as part of converging the service into the expected installed/configured state
+- this is closer to reconcile/materialize desired state than to hard reset everything
+- a separate first-class `config` action may still exist later for lighter-weight regeneration/update scenarios, but should not be assumed unless a concrete use case requires it
+- the donor-style service contract remains important, but orchestration should be cleaner than the donor’s current entangled implementation
+
+### What donor code validates
+The donor code validates the mechanics but also shows the current entanglement:
+
+- `Service.install()` delegates to setup flow in `Service.ts`
+- `setuparchive` supports archive extraction
+- `setup` supports platform-specific exec commands
+- `commandconfig` supports config file materialization behavior
+- the donor current code mixes install/setup/config/runtime concerns more than the future model should
+
+### Validation result
+**Validated directionally by transcript and partially validated by donor mechanics.**
+
+The donor code proves that:
+
+- install includes archive extraction
+- install includes setup exec commands
+- config materialization exists as a real runtime need
+- the current donor `setup` flow is doing more than a narrow installer; it already performs behavior that is partly installation/bootstrap and partly configuration/preparation
+
+Important interpretation:
+
+- donor `setup` should not be read as evidence that `setup` is the correct future first-class action name
+- instead, it is evidence that the donor currently entangles install-like and config-like work inside one setup flow
+- this strengthens the decision to separate future `install` and `config` as distinct built-in actions
+
+But the donor code does **not** yet provide the clean boundary we want.
+
+Remaining implementation/spec work:
+
+- separate install orchestration from runtime execution more cleanly
+- define exactly where generated effective config is written
+- define install/config state recording in `service.state`
+- decide whether separate first-class `config` remains necessary, or whether install fully owns normal config materialization with only lighter-weight regeneration scenarios separated later
+
+These are design-implementation tasks, not open direction questions.
+
+---
+
+## 3. Additional decisions validated from transcript + code
+
+The transcript settled several related points that should be treated as current truth.
+
+### Service contract / repo shape
+- one `service.json` should remain the canonical manifest file
+- one service = one repo
+- services support explicit versions and exact release selection
+- `services/` is a dynamic installed inventory, not a fixed source-controlled monolith
+
+### Environment / execution
+- services are sandboxed from OS env
+- `globalenv` is the shared controlled runtime environment
+- service-to-service communication is typically direct to ports
+- routed URLs are mainly for browser/frontend/operator interaction
+
+### UI / control plane
+- core should own orchestration + API + CLI + contracts
+- admin UI should be an optional separate service, not privileged core
+- per-service UI remains valuable, but as API-driven admin UI rather than inline bootstrap HTML
+
+### Finite action model
+Current settled built-in action set:
+
+- `install`
+- `uninstall`
+- `update`
+- `start`
+- `stop`
+- `restart`
+- `config`
+
+Current clarified interpretation of `actions`:
+
+- `actions` is for **service-specific custom commands that override Service Lasso default behavior for a named service action**
+- the service creator explicitly maps their service-specific command when the default is not right for that service
+- if no override is present, Service Lasso falls back to its default behavior for that action
+- it is not an arbitrary free-form custom action registry
+- action names are still owned by Service Lasso
+- do not expand the overrideable action list spec pre-emptively; only extend it when a concrete service demonstrates a real need
+
+And explicitly **not** in the current core action set:
+
+- `reinstall`
+- `regenconfig`
+- `validate`
+- `inspect`
+- arbitrary custom action names
+
+Diagnostic/status views should instead come from:
+
+- UI/API service detail
+- `service.json`
+- `service.state`
+- `service.pid`
+- logs
+- status/health fields
+
+---
+
+## 4. What is still a real gap after reconciliation
+
+After transcript + code reconciliation, the main remaining gaps are **not** the original four product-boundary questions.
+
+Those four are effectively answered.
+
+The remaining gaps are implementation/specification work such as:
+
+1. define the exact cleaned section names/boundaries for the normalized `service.json` shape now that the direction away from one giant donor-style `execconfig` block is settled
+2. define precise `service.state` content and lifecycle transitions inside the newer `.state/`-folder model, including what is written on start/stop versus what remains log-only
+3. define exact install-state / config-state recording rules
+4. define exact generated-config output paths and precedence rules
+5. define exact port-allocation guarantees and persistence behavior
+6. define exact supported-action declaration shape in manifest/schema
+7. define UI/API payloads that reflect supported actions, role/category, and current state cleanly
+
+These should be treated as specification and implementation tasks, not as unresolved top-level direction questions.
+
+---
+
+## 5. Working summary
+
+The important outcome of this reconciliation is:
+
+- the four runtime-boundary questions are now consolidated in one place
+- transcript answers take precedence over later speculative drift
+- donor code is used to validate mechanism and identify where the donor implementation is still too entangled
+- what remains is mostly schema/runtime/API specification work, not fresh architecture ideation
+
+If later docs conflict with this file, this file should win unless the discussion is explicitly reopened.

--- a/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
+++ b/docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md
@@ -1,0 +1,355 @@
+# Service Lasso - Current Service Manager Behavior Review
+
+_Status: working draft / donor behavior analysis_
+
+Important reconciliation note:
+- this is a donor behavior/evidence doc
+- use `QUESTION-LIST-AND-CODE-VALIDATION.md` for the reconciled transcript+code answers to the main runtime-boundary questions
+- this file should explain what the donor currently does, not override settled product-direction answers from transcript
+
+Purpose:
+
+- document how the current donor-derived service manager actually behaves
+- record how `service.json` is used by the runtime
+- create a place to keep picking apart the current manager behavior as part of the refactor/design process
+
+Related docs:
+
+- `ARCHITECTURE.md`
+- `ARCHITECTURE-DECISIONS.md`
+- `SERVICE-STRUCTURE-REVIEW.md`
+- `SERVICE-TEMPLATE-REPO.md`
+
+---
+
+## 1. Primary Contract File
+
+The current service manager treats:
+
+- `service.json`
+
+as the canonical per-service manifest/runtime contract file.
+
+In the donor-derived runtime:
+
+- `ServiceManager.ts` sets `#serviceConfigFile = "service.json"`
+- the manager scans for service manifests using a glob under the services root
+
+Current discovery pattern:
+
+- `*/service.json`
+
+So each direct service folder under the services root is expected to provide a `service.json`.
+
+---
+
+## 2. Discovery Behavior
+
+When the runtime reloads:
+
+1. it clears the current service list
+2. it locates service config files
+3. it parses each `service.json`
+4. it turns each parsed config into a `ServiceConfig`
+5. it constructs `Service` objects from those configs
+6. it updates global env
+7. it sorts services
+8. it notifies the UI/app callbacks with service list + global env
+
+This means `service.json` is loaded very early and is the starting point for almost all runtime behavior.
+
+---
+
+## 3. Path Resolution Behavior
+
+For each discovered `service.json`, the manager derives several important paths.
+
+### `servicehome`
+The root service folder containing `service.json`.
+
+### `servicepath`
+The runtime path used for platform-specific execution.
+
+Behavior:
+- if a platform subfolder exists for the current platform (`win32`, `darwin`, `linux`), it prefers that platform folder as the service execution path
+- otherwise it falls back to the service root
+
+### `servicesdataroot`
+A derived data root based on the service folder name.
+
+Implication:
+- service identity is tied closely to the folder name
+- platform-specific binaries/payloads are expected to live under per-platform subfolders when applicable
+
+---
+
+## 4. How `service.json` Is Consumed
+
+Each parsed `service.json` becomes the `options` passed into the `Service` constructor.
+
+This means the runtime logic in `Service.ts` treats `service.json` as the main source of truth for how to:
+
+- prepare the service
+- resolve its executable
+- build commands
+- set env
+- assign ports
+- wait for dependencies
+- check health
+- start/stop/restart it
+
+In other words, `service.json` is not just descriptive metadata — it is an operational runtime contract.
+
+---
+
+## 5. Main Runtime Concerns Driven By `execconfig`
+
+The most important section inside `service.json` is:
+
+- `execconfig`
+
+This section currently drives most service-manager behavior.
+
+### A. Execution/runtime selection
+Fields used include:
+- `executable`
+- `executablecli`
+- `execservice`
+- `execshell`
+- `execcwd`
+
+This determines:
+- which executable to run
+- whether the service runs directly or through another runtime provider
+- current working directory / shell behavior
+
+### B. Command construction
+Fields used include:
+- `commandline`
+- `commandlinecli`
+- `commandconfig`
+
+This determines the actual command/arguments/config expansion used at runtime.
+
+### C. Setup/install behavior
+Fields used include:
+- `setup`
+- `setuparchive`
+
+This determines whether a service needs archive extraction and/or bootstrap steps before runtime.
+
+Important explicit note:
+- install/setup in the current manager can include **exec commands**, not just archive extraction
+- `setuparchive` covers extraction/unpack behavior
+- `setup` covers platform-specific setup command execution
+- both are part of the current install/setup flow
+
+### D. Runtime paths/state
+Fields used include:
+- `datapath`
+
+This influences where service data/state should live.
+
+### E. Networking / ports / URLs
+Fields used include:
+- `serviceport`
+- `serviceportsecondary`
+- `serviceportconsole`
+- `serviceportdebug`
+- `portmapping`
+- `urls`
+
+This determines reserved ports, exposed URLs, and how service endpoints are described.
+
+### F. Health/readiness
+Fields used include:
+- `healthcheck`
+
+This determines how the runtime checks whether a service is started/healthy.
+
+### G. Dependency graph
+Fields used include:
+- `depend_on`
+- `execservice`
+
+This determines both explicit service dependencies and indirect runtime-provider relationships.
+
+### H. Environment generation
+Fields used include:
+- `env`
+- `globalenv`
+- `outputvarregex`
+
+This determines both service-local env and the cross-service/global env propagation behavior.
+
+### I. Auth / behavior flags
+Fields used include:
+- `authentication`
+- `ignoreexiterror`
+- `debuglog`
+
+These influence startup/runtime handling behavior.
+
+---
+
+## 6. Global Environment Behavior
+
+The service manager aggregates global environment variables across services.
+
+Behavior:
+- each service may expose `globalenv`
+- the manager merges these into a shared global environment map
+- the merged global env is then pushed back into services
+- the manager also emits this global env outward to the UI/app callbacks
+
+Current clarified design direction:
+- services should be sandboxed from OS-level environment variables
+- service creators must explicitly specify what a service needs
+- services should be spawned only with the Service Lasso-controlled environment model (shared `globalenv` plus explicit service env derived from it)
+
+Implication:
+- `service.json` is currently part of a cross-service env propagation system
+- services do not live in total isolation; they contribute to a shared runtime environment graph
+- future Service Lasso should treat env exposure as explicit contract, not host-machine leakage
+
+This is one of the strongest reasons the manifest format matters so much.
+
+---
+
+## 7. Startup Ordering Behavior
+
+The manager sorts services using:
+
+- `execconfig.serviceorder`
+
+with a default fallback if not provided.
+
+This means `service.json` currently affects:
+- orchestration order
+- startup sequencing
+- the relative priority of base/runtime/infrastructure services
+
+This is another reason the file is more than just metadata.
+
+---
+
+## 8. Dependency Behavior
+
+The current runtime uses dependencies in two ways:
+
+### Explicit dependencies
+- `depend_on`
+
+### Runtime-provider dependencies
+- `execservice`
+
+Meaning:
+- a service can directly depend on named services
+- a service can also depend on another service to provide the executable/runtime used to launch it
+
+This is a powerful model and one of the more important donor concepts worth preserving.
+
+---
+
+## 9. Setup / Install Behavior
+
+The current runtime includes service-local setup logic directly in the service contract.
+
+Examples of behavior supported by the current manager:
+- unpacking archives before use
+- running setup commands before runtime
+- preparing dependent/runtime-provider services first when required
+- writing setup state markers used to decide whether the service is already prepared
+
+Important clarified finding from donor code review:
+- current donor `setup` is not just a narrow installer stage
+- it is functioning as a combined preparation flow that includes install/bootstrap behavior and some config/preparation behavior
+- because of that, donor `setup` should be treated as evidence of current entanglement, not as the ideal future action model
+- this is one of the strongest code-level reasons to keep future `install` and `config` separate in Service Lasso even though donor currently mixes them
+- capturing output values back into env via regex parsing
+
+Important interpretation:
+- current install behavior is not just “download + unzip”
+- it is a compound install/setup flow that can include both archive extraction and exec-command-based setup steps
+- this precedent is important for the future `install` action design
+
+Implication:
+- the current manager already mixes install/bootstrap and runtime behavior in the same manifest-driven flow
+- this is useful, but also a reason to normalize/split concerns more cleanly in the future
+
+---
+
+## 10. Why JSON Was Useful Here
+
+The current manager behavior makes it clear why JSON was practical.
+
+`service.json` currently serves as a portable machine-readable contract for:
+
+- service discovery
+- path resolution
+- startup ordering
+- dependency graph
+- runtime provider selection
+- setup/install instructions
+- command construction
+- env/global env generation
+- health checks
+- ports and URLs
+
+So JSON was not just chosen for convenience as metadata storage.
+It became the core runtime/orchestration contract file.
+
+---
+
+## 11. Current Status-Band Observation
+
+The current service status model uses numeric-ish string codes that are already grouped in rough bands.
+
+Examples observed:
+- invalid/error band: negative values
+- loaded/setup/archive/install band: `1` -> `30`
+- resolve/available band: `35` -> `50`
+- stopping/stopped band: `65` -> `80`
+- starting/dependencies/health band: `90` -> `120`
+- completion band: `200`+
+
+Important interpretation:
+- these values are not random
+- they already imply grouped lifecycle bands/categories in the current design
+- this supports the idea that future Service Lasso can keep the conceptual banding while still improving the clarity of the state model
+- the single state machine also has value because it gives one central place for action/lifecycle decisions
+
+So the critique is not that the current model has no structure.
+The critique is that the current grouped states are still overloaded into one broad enum that mixes several concerns.
+
+## 12. Main Design Tension Exposed By Current Behavior
+
+The current manifest is useful, but overloaded.
+
+A single `service.json` currently mixes:
+
+- identity/metadata
+- source/install concerns
+- runtime execution concerns
+- env concerns
+- dependency concerns
+- health concerns
+- routing/network concerns
+
+This is one of the central design tensions to resolve in Service Lasso.
+
+Future Service Lasso may still keep JSON, but should likely normalize the structure more clearly.
+
+---
+
+## 13. Working Summary
+
+The current donor-derived service manager uses `service.json` as the canonical runtime contract file for discovery, orchestration, setup, execution, env propagation, and health/status behavior.
+
+This confirms that JSON was serving a real system-level purpose, not just acting as descriptive metadata.
+
+It also confirms that a future Service Lasso refactor should treat the manifest contract as a first-class architectural element, even if the schema is cleaned up and split into clearer conceptual sections.
+
+---
+
+_Add more current-manager behavior notes here as we continue dissecting the runtime._

--- a/docs/service-contract.md
+++ b/docs/service-contract.md
@@ -1,0 +1,14 @@
+# Service Contract
+
+This starter repo demonstrates the first-pass Service Lasso service contract.
+
+Key starter files:
+- `service.json` - service manifest
+- `verify/service-harness.json` - harness validation contract
+- `scripts/verify.*` - thin wrappers that call the shared harness binary
+- `scripts/package.*` - reference packaging entrypoints
+- `runtime/` - sample payload/runtime files
+- `config/` - example config inputs
+- `docs/service-json-reference.md` - one-stop reference for `service.json` fields, healthcheck setup, and first-pass contract guidance
+
+This starter is intentionally minimal. It is meant to prove the contract shape, not to be a full production service.

--- a/docs/service-json-reference.md
+++ b/docs/service-json-reference.md
@@ -1,0 +1,394 @@
+# service.json Reference
+
+_Status: first-pass reference_
+
+This doc is the one-stop reference for the current `service.json` direction inside `service-template`.
+
+It is meant to make the template usable without forcing service authors to reconstruct the contract from scattered notes.
+
+## What this doc covers
+
+- top-level manifest purpose
+- common top-level fields
+- `actions`
+- `execconfig`
+- env / dependencies / ports
+- healthcheck direction
+- examples
+- what is currently canonical vs still illustrative
+
+## Important current rule
+
+The current template direction is:
+- **default health model = `process`**
+- other health models are used only when explicitly declared by service config
+
+Ref/code-backed donor healthcheck types observed:
+- `http`
+- `tcp`
+- `file`
+- `variable`
+
+## Purpose of `service.json`
+
+`service.json` is the canonical service manifest used by Service Lasso to understand how a service should be discovered, prepared, executed, and monitored.
+
+At a high level it carries:
+- identity
+- operator metadata
+- lifecycle/action hints
+- runtime execution settings
+- environment settings
+- dependency hints
+- health expectations
+
+## Current sample manifest
+
+The current sample in this repo is:
+
+```json
+{
+  "id": "echo-service",
+  "name": "Echo Service",
+  "description": "Minimal sample service used to prove the service-template contract.",
+  "enabled": true,
+  "version": "0.1.0",
+  "logoutput": true,
+  "icon": "terminal",
+  "servicetype": 50,
+  "servicelocation": 10,
+  "actions": {
+    "install": {
+      "description": "Prepare the sample runtime payload if needed."
+    },
+    "config": {
+      "description": "Materialize effective runtime config for the sample service."
+    },
+    "start": {
+      "description": "Start the sample echo service."
+    },
+    "stop": {
+      "description": "Stop the sample echo service gracefully."
+    }
+  },
+  "execconfig": {
+    "serviceorder": 100,
+    "serviceport": 0,
+    "execcwd": "runtime",
+    "executable": "echo-service",
+    "env": {
+      "ECHO_MESSAGE": "hello from service-template"
+    },
+    "depend_on": [],
+    "healthcheck": {
+      "type": "process"
+    }
+  }
+}
+```
+
+## Top-level fields
+
+### `id`
+Unique service identifier.
+
+Example:
+```json
+"id": "echo-service"
+```
+
+Current direction:
+- required
+- should be stable
+- should align with the service repo’s identity
+
+### `name`
+Human-facing display name.
+
+Example:
+```json
+"name": "Echo Service"
+```
+
+### `description`
+Short operator-facing description.
+
+### `enabled`
+Whether the service is enabled by default.
+
+### `version`
+Current package/version identity for the service.
+
+### `logoutput`
+Whether stdout/stderr style runtime logging should be captured/displayed.
+
+### `icon`
+UI/operator-facing icon hint.
+
+### `servicetype`
+Current donor-style service type classification value.
+
+### `servicelocation`
+Current donor-style service location classification value.
+
+## `actions`
+
+`actions` is where the service defines or overrides named lifecycle actions.
+
+Current intended rule:
+- actions correspond to known Service Lasso lifecycle/action names
+- service config can override how a named action behaves for that service
+- if a service does not override a supported action, Lasso default behavior applies
+
+Current sample actions:
+- `install`
+- `config`
+- `start`
+- `stop`
+
+### Current action examples
+
+```json
+"actions": {
+  "install": {
+    "description": "Prepare the sample runtime payload if needed."
+  },
+  "config": {
+    "description": "Materialize effective runtime config for the sample service."
+  },
+  "start": {
+    "description": "Start the sample echo service."
+  },
+  "stop": {
+    "description": "Stop the sample echo service gracefully."
+  }
+}
+```
+
+### Current action semantics direction
+- `install`
+  - prepare/install payload and required local setup
+- `config`
+  - materialize effective config from explicit inputs
+- `start`
+  - launch the service runtime
+- `stop`
+  - stop the service gracefully
+
+Additional action names may exist later, but this first-pass template should stay small and lifecycle-focused.
+
+## `execconfig`
+
+`execconfig` contains the runtime execution contract.
+
+This is where the service tells Lasso how to run and supervise it.
+
+### `serviceorder`
+Startup ordering hint.
+
+Example:
+```json
+"serviceorder": 100
+```
+
+### `serviceport`
+Primary service port.
+
+In the sample, `0` is being used as a simple first-pass placeholder/default meaning “no fixed service port required by this sample”.
+
+### `execcwd`
+Execution working directory.
+
+Example:
+```json
+"execcwd": "runtime"
+```
+
+### `executable`
+Executable or executable key/name used for the service runtime.
+
+Example:
+```json
+"executable": "echo-service"
+```
+
+### `env`
+Service-local environment variables.
+
+Example:
+```json
+"env": {
+  "ECHO_MESSAGE": "hello from service-template"
+}
+```
+
+Current direction:
+- service env should be explicit
+- avoid depending on uncontrolled host-machine env leakage
+
+### `depend_on`
+Explicit dependencies.
+
+Example:
+```json
+"depend_on": []
+```
+
+Current direction:
+- use this for services that require another service/runtime/provider first
+- keep empty for the minimal sample
+
+## Healthcheck
+
+### Default rule
+Current rule:
+- if a service does not explicitly require another model, the default is **`process`**
+
+Example:
+```json
+"healthcheck": {
+  "type": "process"
+}
+```
+
+This is the right default for a simple sample service.
+
+### Observed donor healthcheck types
+The donor runtime/code shows these healthcheck types:
+- `http`
+- `tcp`
+- `file`
+- `variable`
+
+`process` is the current template default direction, even though the donor code paths most explicitly surfaced in ref material are the four types above.
+
+### `process` healthcheck
+Use when:
+- service health is adequately represented by the process being up/running
+- you do not need a deeper readiness endpoint yet
+
+Sample:
+```json
+"healthcheck": {
+  "type": "process"
+}
+```
+
+### `http` healthcheck
+Use when:
+- the service exposes an HTTP readiness or health endpoint
+
+Sample:
+```json
+"healthcheck": {
+  "type": "http",
+  "url": "http://localhost:${SERVICE_PORT}/health",
+  "expected_status": 200
+}
+```
+
+### `tcp` healthcheck
+Use when:
+- readiness is best represented by a socket accepting connections
+
+Sample:
+```json
+"healthcheck": {
+  "type": "tcp"
+}
+```
+
+Current donor behavior suggests this relies on the configured service host/port.
+
+### `file` healthcheck
+Use when:
+- the service creates a file that represents successful readiness/setup
+
+Sample:
+```json
+"healthcheck": {
+  "type": "file",
+  "file": "${SERVICE_HOME}/.state/runtime/ready.txt"
+}
+```
+
+### `variable` healthcheck
+Use when:
+- a specific resolved/exported variable is the readiness signal
+
+Sample:
+```json
+"healthcheck": {
+  "type": "variable",
+  "variable": "${SERVICE_URL}"
+}
+```
+
+## Other important manifest aspects
+
+### Environment generation
+Current broader Service Lasso direction includes:
+- explicit service-local env via `env`
+- possible cross-service/global env behavior via `globalenv`
+
+The sample template keeps this minimal for now.
+
+### Ports and URLs
+Donor material shows additional fields such as:
+- `serviceportsecondary`
+- `serviceportconsole`
+- `serviceportdebug`
+- `portmapping`
+- `urls`
+
+These are not all used in the minimal sample, but they remain relevant for more complex services.
+
+### Runtime-provider relationships
+Donor material also shows patterns such as:
+- `execservice`
+
+This is relevant when a service is run via another runtime-provider service such as Node, Python, or Java.
+
+The minimal sample does not use this yet.
+
+## Canonical vs illustrative right now
+
+### Treat as current first-pass canonical direction
+- one service per repo
+- `service.json` as the main service contract file
+- lifecycle-focused `actions`
+- `execconfig` as the execution contract section
+- explicit `env`
+- explicit `depend_on`
+- default health model of `process`
+- explicit override to other health models when needed
+
+### Still illustrative / not fully locked yet
+- exact numeric meaning of `servicetype`
+- exact numeric meaning of `servicelocation`
+- final exact schema shape for all optional `execconfig` fields
+- final exact health schema normalization
+- final exact release artifact conventions across all service types
+
+## Recommended authoring guidance
+
+For the first template-based service:
+1. keep the manifest small
+2. use `process` health unless another model is clearly needed
+3. explicitly declare env and dependencies
+4. avoid donor baggage that mixes generated runtime state into package content
+5. prefer clarity over trying to model every advanced donor feature on day one
+
+## Related docs
+
+Start here for the broader template contract:
+- `docs/service-contract.md`
+- `docs/validation.md`
+- `docs/packaging.md`
+- `docs/openspec-drafts/SPEC-SERVICE-TEMPLATE-REPO.md`
+
+For deeper donor/runtime context:
+- `docs/reference/shared-runtime/SERVICE-MANAGER-BEHAVIOR.md`
+- `docs/reference/SERVICE-STRUCTURE-REVIEW.md`
+- `docs/reference/shared-runtime/QUESTION-LIST-AND-CODE-VALIDATION.md`
+- `docs/reference/shared-runtime/ARCHITECTURE-DECISIONS.md`

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,23 @@
+# Validation
+
+Reference validation files:
+- `verify/service-harness.json`
+- `scripts/verify.ps1`
+- `scripts/verify.sh`
+
+Current first-pass direction:
+- consumer repos should call the shared released `service-lasso-harness` binary
+- the template provides the example contract and thin wrappers
+- local and CI usage should share the same harness contract path
+- default health model is `process`; other health models should come from explicit service config
+
+Ref/code-backed donor healthcheck types observed:
+- `http`
+- `tcp`
+- `file`
+- `variable`
+
+Current starter implementation status:
+- GitHub Actions now packages starter release archives on Windows/Linux/macOS
+- GitHub Actions now runs basic starter tests on each platform
+- GitHub Actions now downloads the released `service-lasso-harness` binary and runs the template verify flow through that harness path

--- a/runtime/darwin/echo-service.sh
+++ b/runtime/darwin/echo-service.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "${ECHO_MESSAGE:-hello from service-template}"
+sleep 2

--- a/runtime/linux/echo-service.sh
+++ b/runtime/linux/echo-service.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "${ECHO_MESSAGE:-hello from service-template}"
+sleep 2

--- a/runtime/win32/echo-service.ps1
+++ b/runtime/win32/echo-service.ps1
@@ -1,0 +1,10 @@
+param(
+  [string]$Message = $env:ECHO_MESSAGE
+)
+
+if ([string]::IsNullOrWhiteSpace($Message)) {
+  $Message = 'hello from service-template'
+}
+
+Write-Output $Message
+Start-Sleep -Seconds 2

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -8,9 +8,9 @@ import {
   Search,
   Sun,
 } from 'lucide-react'
-import { useTheme } from '@/context/theme-provider'
-import { useSearch } from '@/context/search-provider'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import { useSearch } from '@/context/search-provider'
+import { useTheme } from '@/context/theme-provider'
 import {
   CommandDialog,
   CommandEmpty,

--- a/src/components/dependency-graph-canvas.tsx
+++ b/src/components/dependency-graph-canvas.tsx
@@ -8,8 +8,8 @@ import {
   type OnEdgesChange,
   type OnNodesChange,
 } from '@xyflow/react'
-import { useTheme } from '@/context/theme-provider'
 import '@xyflow/react/dist/style.css'
+import { useTheme } from '@/context/theme-provider'
 
 type GraphLegendItem = {
   label: string
@@ -60,7 +60,11 @@ export function DependencyGraphCanvas({
   return (
     <div className='space-y-3'>
       <div
-        className={isDark ? 'rounded-lg border bg-slate-950' : 'rounded-lg border bg-slate-50'}
+        className={
+          isDark
+            ? 'rounded-lg border bg-slate-950'
+            : 'rounded-lg border bg-slate-50'
+        }
         style={{ height }}
       >
         <ReactFlow
@@ -80,7 +84,11 @@ export function DependencyGraphCanvas({
           nodesConnectable={false}
           proOptions={{ hideAttribution: true }}
         >
-          <Background gap={20} size={1} color={isDark ? '#1f2937' : '#cbd5e1'} />
+          <Background
+            gap={20}
+            size={1}
+            color={isDark ? '#1f2937' : '#cbd5e1'}
+          />
           {showControls ? (
             <Controls
               className={
@@ -95,8 +103,14 @@ export function DependencyGraphCanvas({
               pannable
               zoomable
               nodeColor={miniMapNodeColor}
-              maskColor={isDark ? 'rgba(2, 6, 23, 0.5)' : 'rgba(226, 232, 240, 0.65)'}
-              className={isDark ? '!border !border-slate-700 !bg-slate-900' : '!border !border-slate-300 !bg-white'}
+              maskColor={
+                isDark ? 'rgba(2, 6, 23, 0.5)' : 'rgba(226, 232, 240, 0.65)'
+              }
+              className={
+                isDark
+                  ? '!border !border-slate-700 !bg-slate-900'
+                  : '!border !border-slate-300 !bg-white'
+              }
             />
           ) : null}
         </ReactFlow>

--- a/src/components/dependency-graph-panel.tsx
+++ b/src/components/dependency-graph-panel.tsx
@@ -28,7 +28,9 @@ export function DependencyGraphPanel({
             <CardTitle>{title}</CardTitle>
             <CardDescription>{description}</CardDescription>
           </div>
-          {actions ? <div className='flex items-center gap-2'>{actions}</div> : null}
+          {actions ? (
+            <div className='flex items-center gap-2'>{actions}</div>
+          ) : null}
         </div>
       </CardHeader>
       <CardContent className='space-y-3'>{graph}</CardContent>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,5 +1,5 @@
-import { useLayout } from '@/context/layout-provider'
 import { useAuthStore } from '@/stores/auth-store'
+import { useLayout } from '@/context/layout-provider'
 import {
   Sidebar,
   SidebarContent,

--- a/src/components/local-table-toolbar.tsx
+++ b/src/components/local-table-toolbar.tsx
@@ -157,7 +157,8 @@ export function LocalTableToolbar({
   onReset,
 }: LocalTableToolbarProps) {
   const isFiltered =
-    searchValue.trim().length > 0 || filters.some((filter) => filter.selectedValues.length > 0)
+    searchValue.trim().length > 0 ||
+    filters.some((filter) => filter.selectedValues.length > 0)
 
   return (
     <div className='flex items-center justify-between'>
@@ -174,7 +175,11 @@ export function LocalTableToolbar({
           ))}
         </div>
         {isFiltered && onReset ? (
-          <Button variant='ghost' onClick={onReset} className='h-8 px-2 lg:px-3'>
+          <Button
+            variant='ghost'
+            onClick={onReset}
+            className='h-8 px-2 lg:px-3'
+          >
             Reset
             <Cross2Icon className='ms-2 h-4 w-4' />
           </Button>

--- a/src/components/profile-dropdown.tsx
+++ b/src/components/profile-dropdown.tsx
@@ -2,11 +2,7 @@ import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { ChevronsUpDown, LogOut, Settings } from 'lucide-react'
 import { useAuthStore } from '@/stores/auth-store'
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from '@/components/ui/avatar'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -56,12 +52,18 @@ export function ProfileDropdown() {
             <ChevronsUpDown className='ml-auto size-4' />
           </SidebarMenuButton>
         </DropdownMenuTrigger>
-        <DropdownMenuContent className='w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg' align='end' sideOffset={4}>
+        <DropdownMenuContent
+          className='w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg'
+          align='end'
+          sideOffset={4}
+        >
           <DropdownMenuLabel className='p-0 font-normal'>
             <div className='flex items-center gap-2 px-1 py-1.5 text-left text-sm'>
               <Avatar className='size-8 rounded-lg'>
                 <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback className='rounded-lg'>{initials}</AvatarFallback>
+                <AvatarFallback className='rounded-lg'>
+                  {initials}
+                </AvatarFallback>
               </Avatar>
               <div className='grid flex-1 text-left text-sm leading-tight'>
                 <span className='truncate font-medium'>{user.name}</span>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -26,7 +26,7 @@ export function Search({ className, placeholder = 'Search' }: SearchProps) {
       type='button'
       onClick={() => setOpen(true)}
       className={cn(
-        'bg-background text-muted-foreground inline-flex h-9 w-fit items-center gap-2 rounded-md border px-3 text-sm shadow-xs transition-colors hover:bg-accent/40',
+        'inline-flex h-9 w-fit items-center gap-2 rounded-md border bg-background px-3 text-sm text-muted-foreground shadow-xs transition-colors hover:bg-accent/40',
         className
       )}
     >

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -76,7 +76,6 @@ function SidebarProvider({
       } else {
         _setOpen(openState)
       }
-
     },
     [setOpenProp, open]
   )

--- a/src/context/layout-provider.tsx
+++ b/src/context/layout-provider.tsx
@@ -30,9 +30,8 @@ type LayoutProviderProps = {
 }
 
 export function LayoutProvider({ children }: LayoutProviderProps) {
-  const [collapsible, _setCollapsible] = useState<Collapsible>(
-    DEFAULT_COLLAPSIBLE
-  )
+  const [collapsible, _setCollapsible] =
+    useState<Collapsible>(DEFAULT_COLLAPSIBLE)
 
   const [variant, _setVariant] = useState<Variant>(DEFAULT_VARIANT)
 

--- a/src/features/dependencies/index.tsx
+++ b/src/features/dependencies/index.tsx
@@ -20,7 +20,7 @@ import {
   Workflow,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import { useTheme } from '@/context/theme-provider'
+import { usePageMetadata } from '@/lib/page-metadata'
 import {
   buildApiUsageEdge,
   buildDependencyEdge,
@@ -30,13 +30,13 @@ import {
   getGraphCategory,
   getServiceNodeImage,
 } from '@/lib/service-graph'
-import { usePageMetadata } from '@/lib/page-metadata'
 import {
   useFavoriteFeatureState,
   useServices,
   useToggleFavorite,
 } from '@/lib/service-lasso-dashboard/hooks'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+import { useTheme } from '@/context/theme-provider'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -703,7 +703,11 @@ export function Dependencies() {
                           <ArrowRight className='size-4' />
                         )}
                         <span className='sr-only'>
-                          Switch graph to {graphOrientation === 'horizontal' ? 'vertical' : 'horizontal'} layout
+                          Switch graph to{' '}
+                          {graphOrientation === 'horizontal'
+                            ? 'vertical'
+                            : 'horizontal'}{' '}
+                          layout
                         </span>
                       </Button>
                       <Separator orientation='vertical' className='h-6' />

--- a/src/features/help-center/index.tsx
+++ b/src/features/help-center/index.tsx
@@ -270,7 +270,7 @@ export function HelpCenter() {
                           >
                             <div className='flex items-start justify-between gap-2'>
                               <div className='min-w-0'>
-                                <div className='truncate text-sm font-medium leading-5'>
+                                <div className='truncate text-sm leading-5 font-medium'>
                                   {doc.title}
                                 </div>
                                 <div className='truncate text-[11px] text-muted-foreground'>

--- a/src/features/installed/index.tsx
+++ b/src/features/installed/index.tsx
@@ -36,12 +36,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
 import {
   DataTableColumnHeader,
   DataTablePagination,
   DataTableToolbar,
 } from '@/components/data-table'
-import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
@@ -218,7 +218,9 @@ export function Installed() {
   const runtimes = useMemo(
     () =>
       Array.from(
-        new Set((servicesQuery.data ?? []).map((service) => service.metadata.runtime))
+        new Set(
+          (servicesQuery.data ?? []).map((service) => service.metadata.runtime)
+        )
       ).sort(),
     [servicesQuery.data]
   )
@@ -261,7 +263,8 @@ export function Installed() {
                 <PackageCheck className='size-4' /> Installed services
               </CardTitle>
               <CardDescription>
-                {table.getFilteredRowModel().rows.length} services shown with package, version, and path details.
+                {table.getFilteredRowModel().rows.length} services shown with
+                package, version, and path details.
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
@@ -313,14 +316,20 @@ export function Installed() {
                         <TableRow key={row.id}>
                           {row.getVisibleCells().map((cell) => (
                             <TableCell key={cell.id}>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                              )}
                             </TableCell>
                           ))}
                         </TableRow>
                       ))
                     ) : (
                       <TableRow>
-                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                        <TableCell
+                          colSpan={columns.length}
+                          className='h-24 text-center'
+                        >
                           No installed services match the current filters.
                         </TableCell>
                       </TableRow>

--- a/src/features/logs/index.tsx
+++ b/src/features/logs/index.tsx
@@ -8,16 +8,16 @@ import {
 } from 'react'
 import { Link, getRouteApi } from '@tanstack/react-router'
 import { LazyLog, ScrollFollow } from '@melloware/react-logviewer'
-import { Activity, PauseCircle, PlayCircle, ScrollText, Wifi } from 'lucide-react'
-import { useServices } from '@/lib/service-lasso-dashboard/hooks'
-import { usePageMetadata } from '@/lib/page-metadata'
-import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import {
-  debugLogs,
-  fetchServiceLogChunk,
-  fetchServiceLogInfo,
-  type ServiceLogInfo,
-} from './provider'
+  Activity,
+  PauseCircle,
+  PlayCircle,
+  ScrollText,
+  Wifi,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -43,6 +43,12 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  debugLogs,
+  fetchServiceLogChunk,
+  fetchServiceLogInfo,
+  type ServiceLogInfo,
+} from './provider'
 
 const route = getRouteApi('/_authenticated/logs/')
 
@@ -50,12 +56,16 @@ function selectedServiceFromSearch(
   services: DashboardService[],
   selectedId?: string
 ) {
-  return services.find((service) => service.id === selectedId) ?? services[0] ?? null
+  return (
+    services.find((service) => service.id === selectedId) ?? services[0] ?? null
+  )
 }
 
 function StatusBadge({ status }: { status: DashboardService['status'] }) {
   if (status === 'running') {
-    return <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    return (
+      <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    )
   }
   if (status === 'degraded') return <Badge variant='secondary'>Degraded</Badge>
   return <Badge variant='outline'>Stopped</Badge>
@@ -76,7 +86,6 @@ function LogsLoading() {
     </div>
   )
 }
-
 
 const DEFAULT_LOG_CHUNK_SIZE = 100
 const LOAD_OLDER_THRESHOLD_PX = 48
@@ -267,7 +276,12 @@ function ServiceLazyLogViewer({
         setError(null)
         const [info, chunk] = await Promise.all([
           fetchServiceLogInfo(service, 'default'),
-          fetchServiceLogChunk(service, 'default', undefined, DEFAULT_LOG_CHUNK_SIZE),
+          fetchServiceLogChunk(
+            service,
+            'default',
+            undefined,
+            DEFAULT_LOG_CHUNK_SIZE
+          ),
         ])
 
         if (cancelled) return
@@ -438,11 +452,17 @@ function ServiceLazyLogViewer({
       <div className='space-y-1 text-xs text-muted-foreground'>
         <div
           className='truncate whitespace-nowrap'
-          title={logInfo?.path ?? service.metadata.logPath ?? 'resolved by service endpoint'}
+          title={
+            logInfo?.path ??
+            service.metadata.logPath ??
+            'resolved by service endpoint'
+          }
         >
           Source:{' '}
           <span className='font-medium'>
-            {logInfo?.path ?? service.metadata.logPath ?? 'resolved by service endpoint'}
+            {logInfo?.path ??
+              service.metadata.logPath ??
+              'resolved by service endpoint'}
           </span>
         </div>
         <div
@@ -471,22 +491,18 @@ function ServiceLazyLogViewer({
 export function Logs() {
   usePageMetadata({
     title: 'Service Admin - Logs',
-    description: 'Service Admin log viewing surface for Service Lasso services.',
+    description:
+      'Service Admin log viewing surface for Service Lasso services.',
   })
 
   const searchState = route.useSearch()
   const servicesQuery = useServices()
   const [paused, setPaused] = useState(true)
   const [serviceQuery, setServiceQuery] = useState('')
-  const [selectedServiceId, setSelectedServiceId] = useState(searchState.service ?? '')
+  const [selectedServiceId, setSelectedServiceId] = useState('')
 
   const services = servicesQuery.data ?? []
-
-  useEffect(() => {
-    if (searchState.service) {
-      setSelectedServiceId(searchState.service)
-    }
-  }, [searchState.service])
+  const effectiveSelectedServiceId = searchState.service ?? selectedServiceId
 
   const filteredServices = useMemo(() => {
     const normalized = serviceQuery.trim().toLowerCase()
@@ -502,10 +518,11 @@ export function Logs() {
 
   const selectedService = useMemo(() => {
     return (
-      filteredServices.find((service) => service.id === selectedServiceId) ??
-      selectedServiceFromSearch(services, selectedServiceId)
+      filteredServices.find(
+        (service) => service.id === effectiveSelectedServiceId
+      ) ?? selectedServiceFromSearch(services, effectiveSelectedServiceId)
     )
-  }, [filteredServices, selectedServiceId, services])
+  }, [effectiveSelectedServiceId, filteredServices, services])
 
   return (
     <>
@@ -528,10 +545,14 @@ export function Logs() {
           </div>
           <div className='flex flex-wrap gap-2'>
             <Button variant='outline' size='sm' asChild>
-              <Link to='/services' search={{}}>Services</Link>
+              <Link to='/services' search={{}}>
+                Services
+              </Link>
             </Button>
             <Button variant='outline' size='sm' asChild>
-              <Link to='/runtime' search={{}}>Runtime</Link>
+              <Link to='/runtime' search={{}}>
+                Runtime
+              </Link>
             </Button>
           </div>
         </div>
@@ -567,7 +588,8 @@ export function Logs() {
                     {paused ? 'Paused' : 'Following'}
                   </div>
                   <p className='text-xs text-muted-foreground'>
-                    Uses the resolved service log endpoint and scroll-follow behavior.
+                    Uses the resolved service log endpoint and scroll-follow
+                    behavior.
                   </p>
                 </CardContent>
               </Card>
@@ -582,7 +604,8 @@ export function Logs() {
                     {selectedService?.metadata.logPath ?? 'Resolved by API'}
                   </div>
                   <p className='text-xs text-muted-foreground'>
-                    The browser only requests service + type. The server resolves the real path.
+                    The browser only requests service + type. The server
+                    resolves the real path.
                   </p>
                 </CardContent>
               </Card>
@@ -593,7 +616,8 @@ export function Logs() {
                 <CardHeader>
                   <CardTitle>Services</CardTitle>
                   <CardDescription>
-                    Search and select the service whose logs you want to inspect.
+                    Search and select the service whose logs you want to
+                    inspect.
                   </CardDescription>
                 </CardHeader>
                 <CardContent className='space-y-4'>
@@ -617,13 +641,21 @@ export function Logs() {
                             <TableRow
                               key={service.id}
                               className='cursor-pointer'
-                              data-state={selectedService?.id === service.id ? 'selected' : undefined}
+                              data-state={
+                                selectedService?.id === service.id
+                                  ? 'selected'
+                                  : undefined
+                              }
                               onClick={() => setSelectedServiceId(service.id)}
                             >
                               <TableCell>
                                 <div className='flex min-w-0 flex-col'>
-                                  <span className='font-medium'>{service.name}</span>
-                                  <span className='text-xs text-muted-foreground'>{service.id}</span>
+                                  <span className='font-medium'>
+                                    {service.name}
+                                  </span>
+                                  <span className='text-xs text-muted-foreground'>
+                                    {service.id}
+                                  </span>
                                 </div>
                               </TableCell>
                               <TableCell>
@@ -678,7 +710,10 @@ export function Logs() {
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <ServiceLazyLogViewer service={selectedService} paused={paused} />
+                  <ServiceLazyLogViewer
+                    service={selectedService}
+                    paused={paused}
+                  />
                 </CardContent>
               </Card>
             </div>

--- a/src/features/logs/provider.runtime.test.ts
+++ b/src/features/logs/provider.runtime.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const service = {
   id: 'service-admin',
   metadata: {
-    logPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
+    logPath:
+      'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
   },
 } as const
 
@@ -46,7 +47,10 @@ describe('logs provider configured api mode', () => {
             hasMore: true,
             nextBefore: 40,
             limit: 100,
-            lines: Array.from({ length: 100 }, (_, index) => `line ${index + 41}`),
+            lines: Array.from(
+              { length: 100 },
+              (_, index) => `line ${index + 41}`
+            ),
           }),
           {
             status: 200,
@@ -57,7 +61,8 @@ describe('logs provider configured api mode', () => {
 
     vi.stubGlobal('fetch', fetchMock)
 
-    const { fetchServiceLogChunk, fetchServiceLogInfo } = await import('./provider')
+    const { fetchServiceLogChunk, fetchServiceLogInfo } =
+      await import('./provider')
 
     const info = await fetchServiceLogInfo(service as never, 'default')
     const chunk = await fetchServiceLogChunk(service as never, 'default')
@@ -83,18 +88,19 @@ describe('logs provider configured api mode', () => {
 
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () =>
-        new Response('<!doctype html><html><body>wrong</body></html>', {
-          status: 200,
-          headers: { 'Content-Type': 'text/html' },
-        })
+      vi.fn(
+        async () =>
+          new Response('<!doctype html><html><body>wrong</body></html>', {
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+          })
       )
     )
 
     const { fetchServiceLogChunk } = await import('./provider')
 
-    await expect(fetchServiceLogChunk(service as never, 'default')).rejects.toThrow(
-      'Live logs are unavailable right now.'
-    )
+    await expect(
+      fetchServiceLogChunk(service as never, 'default')
+    ).rejects.toThrow('Live logs are unavailable right now.')
   })
 })

--- a/src/features/logs/provider.stub.test.ts
+++ b/src/features/logs/provider.stub.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const service = {
   id: 'service-admin',
   metadata: {
-    logPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
+    logPath:
+      'C:\\projects\\service-lasso\\lasso-@serviceadmin\\logs\\service-admin.log',
   },
 } as const
 
@@ -46,7 +47,10 @@ describe('logs provider relative api mode', () => {
             hasMore: true,
             nextBefore: 22,
             limit: 100,
-            lines: Array.from({ length: 100 }, (_, index) => `line ${index + 23}`),
+            lines: Array.from(
+              { length: 100 },
+              (_, index) => `line ${index + 23}`
+            ),
           }),
           {
             status: 200,
@@ -57,7 +61,8 @@ describe('logs provider relative api mode', () => {
 
     vi.stubGlobal('fetch', fetchMock)
 
-    const { fetchServiceLogChunk, fetchServiceLogInfo } = await import('./provider')
+    const { fetchServiceLogChunk, fetchServiceLogInfo } =
+      await import('./provider')
 
     const info = await fetchServiceLogInfo(service as never, 'default')
     const chunk = await fetchServiceLogChunk(service as never, 'default')

--- a/src/features/logs/provider.ts
+++ b/src/features/logs/provider.ts
@@ -2,7 +2,8 @@ import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 
 const logsDebugEnabled =
-  import.meta.env.DEV || import.meta.env.VITE_SERVICE_LASSO_LOGS_DEBUG === 'true'
+  import.meta.env.DEV ||
+  import.meta.env.VITE_SERVICE_LASSO_LOGS_DEBUG === 'true'
 const relativeLogsApiBaseUrl = ''
 
 export type ServiceLogInfo = {
@@ -27,6 +28,7 @@ export type ServiceLogChunk = {
 
 export function debugLogs(message: string, details?: Record<string, unknown>) {
   if (!logsDebugEnabled) return
+  // eslint-disable-next-line no-console
   console.log('[logs-debug]', message, details ?? {})
 }
 

--- a/src/features/network/index.tsx
+++ b/src/features/network/index.tsx
@@ -36,12 +36,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
 import {
   DataTableColumnHeader,
   DataTablePagination,
   DataTableToolbar,
 } from '@/components/data-table'
-import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
@@ -84,7 +84,9 @@ const columns: ColumnDef<NetworkRow>[] = [
         >
           {row.original.service.name}
         </Link>
-        <span className='text-xs text-muted-foreground'>{row.original.service.id}</span>
+        <span className='text-xs text-muted-foreground'>
+          {row.original.service.id}
+        </span>
       </div>
     ),
     enableHiding: false,
@@ -105,7 +107,7 @@ const columns: ColumnDef<NetworkRow>[] = [
     ),
     cell: ({ row }) => (
       <div className='flex items-start gap-2'>
-        <span className='max-w-[360px] break-all text-sm text-muted-foreground'>
+        <span className='max-w-[360px] text-sm break-all text-muted-foreground'>
           {row.original.endpoint.url}
         </span>
         <Button
@@ -118,7 +120,12 @@ const columns: ColumnDef<NetworkRow>[] = [
         >
           <Copy className='size-3.5' />
         </Button>
-        <Button variant='outline' size='icon' className='size-7 shrink-0' asChild>
+        <Button
+          variant='outline'
+          size='icon'
+          className='size-7 shrink-0'
+          asChild
+        >
           <a href={row.original.endpoint.url} target='_blank' rel='noreferrer'>
             <ExternalLink className='size-3.5' />
           </a>
@@ -157,7 +164,9 @@ const columns: ColumnDef<NetworkRow>[] = [
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title='Exposure' />
     ),
-    cell: ({ row }) => <Badge variant='outline'>{row.original.endpoint.exposure}</Badge>,
+    cell: ({ row }) => (
+      <Badge variant='outline'>{row.original.endpoint.exposure}</Badge>
+    ),
     filterFn: (row, id, value) => value.includes(row.getValue(id)),
   },
 ]
@@ -190,7 +199,7 @@ export function Network() {
     [rows]
   )
 
-  const table = useReactTable({
+  const table = useReactTable<NetworkRow>({
     data: rows,
     columns,
     state: {
@@ -245,7 +254,8 @@ export function Network() {
                 <NetworkIcon className='size-4' /> Service endpoints
               </CardTitle>
               <CardDescription>
-                {table.getFilteredRowModel().rows.length} endpoints shown with copy and open actions.
+                {table.getFilteredRowModel().rows.length} endpoints shown with
+                copy and open actions.
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
@@ -298,14 +308,20 @@ export function Network() {
                         <TableRow key={row.id}>
                           {row.getVisibleCells().map((cell) => (
                             <TableCell key={cell.id}>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                              )}
                             </TableCell>
                           ))}
                         </TableRow>
                       ))
                     ) : (
                       <TableRow>
-                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                        <TableCell
+                          colSpan={columns.length}
+                          className='h-24 text-center'
+                        >
                           No endpoints match the current filters.
                         </TableCell>
                       </TableRow>

--- a/src/features/runtime/index.tsx
+++ b/src/features/runtime/index.tsx
@@ -35,12 +35,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
 import {
   DataTableColumnHeader,
   DataTablePagination,
   DataTableToolbar,
 } from '@/components/data-table'
-import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
@@ -63,7 +63,9 @@ function RuntimeLoading() {
 
 function StatusBadge({ status }: { status: DashboardService['status'] }) {
   if (status === 'running') {
-    return <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    return (
+      <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    )
   }
   if (status === 'degraded') return <Badge variant='secondary'>Degraded</Badge>
   return <Badge variant='outline'>Stopped</Badge>
@@ -82,7 +84,7 @@ const columns: ColumnDef<DashboardService>[] = [
       <DataTableColumnHeader column={column} title='Service' />
     ),
     cell: ({ row }) => (
-      <div className='flex min-w-0 max-w-[180px] flex-col'>
+      <div className='flex max-w-[180px] min-w-0 flex-col'>
         <Link
           to='/services/$serviceId'
           params={{ serviceId: row.original.id }}
@@ -91,7 +93,10 @@ const columns: ColumnDef<DashboardService>[] = [
         >
           {row.original.name}
         </Link>
-        <span className='truncate text-xs text-muted-foreground' title={row.original.id}>
+        <span
+          className='truncate text-xs text-muted-foreground'
+          title={row.original.id}
+        >
           {row.original.id}
         </span>
       </div>
@@ -130,9 +135,9 @@ const columns: ColumnDef<DashboardService>[] = [
       <DataTableColumnHeader column={column} title='Summary' />
     ),
     cell: ({ row }) => (
-      <div className='min-w-0 max-w-[320px]'>
+      <div className='max-w-[320px] min-w-0'>
         <div
-          className='overflow-hidden text-ellipsis whitespace-nowrap text-sm text-muted-foreground'
+          className='overflow-hidden text-sm text-ellipsis whitespace-nowrap text-muted-foreground'
           title={row.original.runtimeHealth.summary}
         >
           {row.original.runtimeHealth.summary}
@@ -223,7 +228,10 @@ export function Runtime() {
   )
 
   const runtimes = useMemo(
-    () => Array.from(new Set((servicesQuery.data ?? []).map((service) => service.role))).sort(),
+    () =>
+      Array.from(
+        new Set((servicesQuery.data ?? []).map((service) => service.role))
+      ).sort(),
     [servicesQuery.data]
   )
 
@@ -243,7 +251,8 @@ export function Runtime() {
           <div>
             <h2 className='text-2xl font-bold tracking-tight'>Runtime</h2>
             <p className='text-muted-foreground'>
-              Runtime state, health, and check history in the standard operator table.
+              Runtime state, health, and check history in the standard operator
+              table.
             </p>
           </div>
           <div className='flex flex-wrap gap-2'>
@@ -265,7 +274,8 @@ export function Runtime() {
                 <Activity className='size-4' /> Runtime status
               </CardTitle>
               <CardDescription>
-                {table.getFilteredRowModel().rows.length} services shown, {unhealthyCount} with warning or critical health.
+                {table.getFilteredRowModel().rows.length} services shown,{' '}
+                {unhealthyCount} with warning or critical health.
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
@@ -318,14 +328,20 @@ export function Runtime() {
                         <TableRow key={row.id}>
                           {row.getVisibleCells().map((cell) => (
                             <TableCell key={cell.id} className='min-w-0'>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                              )}
                             </TableCell>
                           ))}
                         </TableRow>
                       ))
                     ) : (
                       <TableRow>
-                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                        <TableCell
+                          colSpan={columns.length}
+                          className='h-24 text-center'
+                        >
                           No runtime rows match the current filters.
                         </TableCell>
                       </TableRow>

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { LazyLog, ScrollFollow } from '@melloware/react-logviewer'
-import { toast } from 'sonner'
 import {
   Position,
   useEdgesState,
@@ -23,8 +22,9 @@ import {
   Undo2,
   Wrench,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { copyText } from '@/lib/copy-text'
-import { useTheme } from '@/context/theme-provider'
+import { usePageMetadata } from '@/lib/page-metadata'
 import {
   buildApiUsageEdge,
   buildDependencyEdge,
@@ -32,9 +32,8 @@ import {
   buildServiceNodeStyle,
   getServiceNodeImage,
 } from '@/lib/service-graph'
-import { usePageMetadata } from '@/lib/page-metadata'
-import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
 import { useDashboardService } from '@/lib/service-lasso-dashboard/hooks'
+import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
 import type {
   DashboardService,
   ServiceAction,
@@ -44,6 +43,7 @@ import type {
   ServiceLogPreviewEntry,
   ServiceStatus,
 } from '@/lib/service-lasso-dashboard/types'
+import { useTheme } from '@/context/theme-provider'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -53,14 +53,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -69,6 +63,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { DependencyGraphCanvas } from '@/components/dependency-graph-canvas'
 import { DependencyGraphPanel } from '@/components/dependency-graph-panel'
@@ -223,7 +218,11 @@ type GraphOrientation = 'horizontal' | 'vertical'
 
 type GraphLayoutMap = Record<string, { x: number; y: number }>
 
-async function persistNodeLayoutToMeta(serviceId: string, x: number, y: number) {
+async function persistNodeLayoutToMeta(
+  serviceId: string,
+  x: number,
+  y: number
+) {
   if (!serviceLassoApiBaseUrl) {
     throw new Error('Service Lasso API base URL is not configured')
   }
@@ -282,27 +281,29 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
       })
     )
 
-    const dependentNodes: Node[] = service.dependents.map((dependent, index) => ({
-      id: `dnt-${dependent.id}`,
-      position:
-        layoutMap[`dnt-${dependent.id}`] ??
-        (graphOrientation === 'horizontal'
-          ? { x: xStep * 2, y: index * yStep + 30 }
-          : { x: index * xStep, y: yStep * 2 }),
-      data: {
-        label: buildServiceNodeLabel({
-          name: dependent.name,
-          id: dependent.id,
-          serviceType: 'dependent',
-          isDark,
-        }),
-      },
-      style: buildServiceNodeStyle({ selected: false, isDark }),
-      sourcePosition:
-        graphOrientation === 'horizontal' ? Position.Right : Position.Bottom,
-      targetPosition:
-        graphOrientation === 'horizontal' ? Position.Left : Position.Top,
-    }))
+    const dependentNodes: Node[] = service.dependents.map(
+      (dependent, index) => ({
+        id: `dnt-${dependent.id}`,
+        position:
+          layoutMap[`dnt-${dependent.id}`] ??
+          (graphOrientation === 'horizontal'
+            ? { x: xStep * 2, y: index * yStep + 30 }
+            : { x: index * xStep, y: yStep * 2 }),
+        data: {
+          label: buildServiceNodeLabel({
+            name: dependent.name,
+            id: dependent.id,
+            serviceType: 'dependent',
+            isDark,
+          }),
+        },
+        style: buildServiceNodeStyle({ selected: false, isDark }),
+        sourcePosition:
+          graphOrientation === 'horizontal' ? Position.Right : Position.Bottom,
+        targetPosition:
+          graphOrientation === 'horizontal' ? Position.Left : Position.Top,
+      })
+    )
 
     const centerNode: Node = {
       id: `svc-${service.id}`,
@@ -312,14 +313,16 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
           ? {
               x: xStep,
               y:
-                Math.max(dependencyNodes.length, dependentNodes.length) * yStep *
+                Math.max(dependencyNodes.length, dependentNodes.length) *
+                  yStep *
                   0.5 +
                 30,
             }
           : {
               x:
-                Math.max(dependencyNodes.length, dependentNodes.length) * xStep *
-                  0.5,
+                Math.max(dependencyNodes.length, dependentNodes.length) *
+                xStep *
+                0.5,
               y: yStep,
             }),
       data: {
@@ -420,7 +423,10 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
     try {
       await Promise.all(
         Object.entries(layoutMap).map(([nodeId, position]) => {
-          const serviceId = nodeId.replace(/^dep-/, '').replace(/^dnt-/, '').replace(/^svc-/, '')
+          const serviceId = nodeId
+            .replace(/^dep-/, '')
+            .replace(/^dnt-/, '')
+            .replace(/^svc-/, '')
           return persistNodeLayoutToMeta(serviceId, position.x, position.y)
         })
       )
@@ -705,12 +711,13 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
   const serviceQuery = useDashboardService(serviceId)
   const serviceName = serviceQuery.data?.name ?? serviceId
   const [activeTab, setActiveTab] = useState<
-    'overview' | 'dependencies' | 'metadata' | 'endpoints' | 'variables' | 'logs'
+    | 'overview'
+    | 'dependencies'
+    | 'metadata'
+    | 'endpoints'
+    | 'variables'
+    | 'logs'
   >('overview')
-
-  useEffect(() => {
-    setActiveTab('overview')
-  }, [serviceId])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -821,37 +828,48 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                   </div>
                 </div>
 
-                <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)} className='space-y-4'>
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(value) =>
+                    setActiveTab(value as typeof activeTab)
+                  }
+                  className='space-y-4'
+                >
                   <TabsList className='flex h-auto w-full flex-wrap justify-start gap-1 rounded-2xl border border-border bg-muted/70 p-1 text-muted-foreground shadow-sm dark:border-slate-700/70 dark:bg-slate-900/90 dark:text-slate-400 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]'>
                     <TabsTrigger
                       value='overview'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Overview <span className='ml-1 italic opacity-80'>(1)</span>
+                      Overview{' '}
+                      <span className='ml-1 italic opacity-80'>(1)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='dependencies'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Dependencies <span className='ml-1 italic opacity-80'>(2)</span>
+                      Dependencies{' '}
+                      <span className='ml-1 italic opacity-80'>(2)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='metadata'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Metadata <span className='ml-1 italic opacity-80'>(3)</span>
+                      Metadata{' '}
+                      <span className='ml-1 italic opacity-80'>(3)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='endpoints'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Endpoints <span className='ml-1 italic opacity-80'>(4)</span>
+                      Endpoints{' '}
+                      <span className='ml-1 italic opacity-80'>(4)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='variables'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Variables <span className='ml-1 italic opacity-80'>(5)</span>
+                      Variables{' '}
+                      <span className='ml-1 italic opacity-80'>(5)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='logs'
@@ -884,7 +902,8 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           </div>
                           <div className='text-muted-foreground'>
                             Last restart:{' '}
-                            {service.runtimeHealth.lastRestartAt ?? 'Not recorded'}
+                            {service.runtimeHealth.lastRestartAt ??
+                              'Not recorded'}
                           </div>
                         </CardContent>
                       </Card>
@@ -899,7 +918,9 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           <div>Runtime: {service.metadata.runtime}</div>
                           <div>Version: {service.metadata.version}</div>
                           <div>Build: {service.metadata.build}</div>
-                          <div>Installed: {service.installed ? 'Yes' : 'No'}</div>
+                          <div>
+                            Installed: {service.installed ? 'Yes' : 'No'}
+                          </div>
                         </CardContent>
                       </Card>
                       <Card>
@@ -1006,8 +1027,8 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       <CardHeader>
                         <CardTitle>Environment variables</CardTitle>
                         <CardDescription>
-                          Service-local and shared environment values surfaced in a
-                          searchable top-level Variables page as well.
+                          Service-local and shared environment values surfaced
+                          in a searchable top-level Variables page as well.
                         </CardDescription>
                       </CardHeader>
                       <CardContent className='space-y-4'>
@@ -1017,7 +1038,10 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                         />
                         <div className='flex justify-end'>
                           <Button variant='outline' size='sm' asChild>
-                            <Link to='/variables' search={{ service: service.id }}>
+                            <Link
+                              to='/variables'
+                              search={{ service: service.id }}
+                            >
                               Open all variables
                             </Link>
                           </Button>
@@ -1059,7 +1083,10 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                             <Link to='/network'>Open network view</Link>
                           </Button>
                           <Button variant='outline' asChild>
-                            <Link to='/runtime' search={{ service: service.id }}>
+                            <Link
+                              to='/runtime'
+                              search={{ service: service.id }}
+                            >
                               Open runtime view
                             </Link>
                           </Button>

--- a/src/features/variables/index.tsx
+++ b/src/features/variables/index.tsx
@@ -35,12 +35,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
 import {
   DataTableColumnHeader,
   DataTablePagination,
   DataTableToolbar,
 } from '@/components/data-table'
-import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
@@ -93,7 +93,7 @@ const columns: ColumnDef<VariableRow>[] = [
     ),
     cell: ({ row }) => (
       <div className='flex items-start gap-2'>
-        <span className='max-w-[320px] break-all text-sm text-muted-foreground'>
+        <span className='max-w-[320px] text-sm break-all text-muted-foreground'>
           {row.original.secret === 'secret' ? '••••••••' : row.original.value}
         </span>
         <Button
@@ -125,7 +125,9 @@ const columns: ColumnDef<VariableRow>[] = [
       <DataTableColumnHeader column={column} title='Visibility' />
     ),
     cell: ({ row }) => (
-      <Badge variant={row.original.secret === 'secret' ? 'secondary' : 'outline'}>
+      <Badge
+        variant={row.original.secret === 'secret' ? 'secondary' : 'outline'}
+      >
         {row.original.secret}
       </Badge>
     ),
@@ -149,7 +151,13 @@ const columns: ColumnDef<VariableRow>[] = [
     cell: ({ row }) => (
       <div className='flex flex-wrap gap-2'>
         {row.original.services.map((service) => (
-          <Button key={service.id} variant='outline' size='sm' className='h-8' asChild>
+          <Button
+            key={service.id}
+            variant='outline'
+            size='sm'
+            className='h-8'
+            asChild
+          >
             <Link to='/services/$serviceId' params={{ serviceId: service.id }}>
               {service.name}
             </Link>
@@ -167,7 +175,9 @@ export function Variables({ service, keyFilter }: VariablesProps) {
   })
 
   const servicesQuery = useServices()
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'key', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'key', desc: false },
+  ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
     keyFilter ? [{ id: 'key', value: keyFilter }] : []
   )
@@ -269,7 +279,8 @@ export function Variables({ service, keyFilter }: VariablesProps) {
                 <SlidersHorizontal className='size-4' /> Environment variables
               </CardTitle>
               <CardDescription>
-                {table.getFilteredRowModel().rows.length} variable rows shown across all services.
+                {table.getFilteredRowModel().rows.length} variable rows shown
+                across all services.
               </CardDescription>
             </CardHeader>
             <CardContent className='space-y-4'>
@@ -289,7 +300,10 @@ export function Variables({ service, keyFilter }: VariablesProps) {
                   {
                     columnId: 'source',
                     title: 'Source',
-                    options: sources.map((source) => ({ label: source, value: source })),
+                    options: sources.map((source) => ({
+                      label: source,
+                      value: source,
+                    })),
                   },
                   {
                     columnId: 'secret',
@@ -326,14 +340,20 @@ export function Variables({ service, keyFilter }: VariablesProps) {
                         <TableRow key={row.id}>
                           {row.getVisibleCells().map((cell) => (
                             <TableCell key={cell.id}>
-                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                              )}
                             </TableCell>
                           ))}
                         </TableRow>
                       ))
                     ) : (
                       <TableRow>
-                        <TableCell colSpan={columns.length} className='h-24 text-center'>
+                        <TableCell
+                          colSpan={columns.length}
+                          className='h-24 text-center'
+                        >
                           No variables match the current filters.
                         </TableCell>
                       </TableRow>

--- a/src/lib/service-graph.tsx
+++ b/src/lib/service-graph.tsx
@@ -1,3 +1,4 @@
+import { MarkerType, type Edge, type Node } from '@xyflow/react'
 import {
   AppWindow,
   Boxes,
@@ -8,19 +9,24 @@ import {
   Workflow,
   type LucideIcon,
 } from 'lucide-react'
-import { MarkerType, type Edge, type Node } from '@xyflow/react'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 
-const serviceImageModules = import.meta.glob('../../public/images/services/*.svg', {
-  query: '?url',
-  import: 'default',
-  eager: true,
-}) as Record<string, string>
+const serviceImageModules = import.meta.glob(
+  '../../public/images/services/*.svg',
+  {
+    query: '?url',
+    import: 'default',
+    eager: true,
+  }
+) as Record<string, string>
 
 const serviceImageUrlByName = new Map<string, string>()
 
 for (const [modulePath, assetUrl] of Object.entries(serviceImageModules)) {
-  const filename = modulePath.split('/').pop()?.replace(/\.svg$/i, '')
+  const filename = modulePath
+    .split('/')
+    .pop()
+    ?.replace(/\.svg$/i, '')
   if (!filename) continue
   serviceImageUrlByName.set(filename.toLowerCase(), assetUrl)
 }
@@ -111,7 +117,7 @@ export function buildServiceNodeLabel({
   const accent = categoryNodeColor(category)
 
   return (
-    <div className='flex min-w-[170px] w-max max-w-[420px] items-center gap-3'>
+    <div className='flex w-max max-w-[420px] min-w-[170px] items-center gap-3'>
       <div
         className='flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border'
         style={{
@@ -130,7 +136,7 @@ export function buildServiceNodeLabel({
         )}
       </div>
       <div className='min-w-0 flex-1'>
-        <div className='text-sm font-semibold leading-tight break-words'>
+        <div className='text-sm leading-tight font-semibold break-words'>
           {name}
         </div>
         <div className='mt-0.5 text-xs leading-tight break-all text-muted-foreground'>
@@ -206,13 +212,25 @@ export function buildDependencyEdge({
     labelBgBorderRadius: 6,
     markerEnd: {
       type: MarkerType.ArrowClosed,
-      color: selected ? (isDark ? '#22c55e' : '#16a34a') : isDark ? '#64748b' : '#94a3b8',
+      color: selected
+        ? isDark
+          ? '#22c55e'
+          : '#16a34a'
+        : isDark
+          ? '#64748b'
+          : '#94a3b8',
       width: 18,
       height: 18,
     },
     animated: selected,
     style: {
-      stroke: selected ? (isDark ? '#22c55e' : '#16a34a') : isDark ? '#64748b' : '#94a3b8',
+      stroke: selected
+        ? isDark
+          ? '#22c55e'
+          : '#16a34a'
+        : isDark
+          ? '#64748b'
+          : '#94a3b8',
       strokeWidth: selected ? 2.5 : 1.25,
     },
   }
@@ -277,10 +295,7 @@ export function getServiceNodeImage(
 
   const candidates = [service.name, service.id].flatMap((value) => {
     const normalized = normalizeServiceAssetName(value)
-    return [
-      `${normalized}_${isDark ? 'dark' : 'light'}`,
-      normalized,
-    ]
+    return [`${normalized}_${isDark ? 'dark' : 'light'}`, normalized]
   })
 
   for (const candidate of candidates) {

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -42,7 +42,9 @@ async function fetchRemoteServiceMeta(): Promise<RemoteServiceMeta[] | null> {
 function applyRemoteServiceMeta(serviceMeta: RemoteServiceMeta[]) {
   if (serviceMeta.length === 0) return
 
-  const remoteMetaById = new Map(serviceMeta.map((service) => [service.id, service]))
+  const remoteMetaById = new Map(
+    serviceMeta.map((service) => [service.id, service])
+  )
 
   services = services.map((service) => {
     const remoteMeta = remoteMetaById.get(service.id)
@@ -232,8 +234,7 @@ let services: DashboardService[] = [
       configPath:
         'C:\\projects\\service-lasso\\lasso-@serviceadmin\\vite.config.ts',
       dataPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\dist',
-      logPath:
-        '/services/service-admin/service.log',
+      logPath: '/services/service-admin/service.log',
       workPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin',
       profile: 'develop',
     },
@@ -705,7 +706,8 @@ export function resolveStubServiceLogInfo(
   const service = services.find((item) => item.id === serviceId)
   if (!service) return null
 
-  const defaultPath = service.metadata.logPath ?? '/mock-logs/service-sample.log'
+  const defaultPath =
+    service.metadata.logPath ?? '/mock-logs/service-sample.log'
   const availableTypes: Array<'default' | 'access' | 'error'> = ['default']
 
   return {

--- a/src/routes/_authenticated/services.$serviceId.tsx
+++ b/src/routes/_authenticated/services.$serviceId.tsx
@@ -4,7 +4,7 @@ import { ServiceDetail } from '@/features/service-detail'
 
 function ServicesDetailRoute() {
   const { serviceId } = Route.useParams()
-  return <ServiceDetail serviceId={serviceId} />
+  return <ServiceDetail key={serviceId} serviceId={serviceId} />
 }
 
 export const Route = createFileRoute('/_authenticated/services/$serviceId')({

--- a/src/test/render-route.tsx
+++ b/src/test/render-route.tsx
@@ -1,14 +1,14 @@
-import { act, render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
   createMemoryHistory,
   createRouter,
 } from '@tanstack/react-router'
+import { routeTree } from '@/routeTree.gen'
+import { act, render } from '@testing-library/react'
 import { DirectionProvider } from '@/context/direction-provider'
 import { FontProvider } from '@/context/font-provider'
 import { ThemeProvider } from '@/context/theme-provider'
-import { routeTree } from '@/routeTree.gen'
 
 export async function renderRoute(path: string) {
   const queryClient = new QueryClient({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -21,6 +21,7 @@ class IntersectionObserverMock {
   unobserve() {}
 }
 
+// eslint-disable-next-line no-console
 const originalConsoleError = console.error
 
 beforeAll(() => {
@@ -65,10 +66,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation((...args) => {
     const first = args[0]
-    if (
-      typeof first === 'string' &&
-      first.includes('not wrapped in act')
-    ) {
+    if (typeof first === 'string' && first.includes('not wrapped in act')) {
       return
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
-import { promises as fs } from 'fs'
 import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
+import { promises as fs } from 'fs'
+import type { IncomingMessage, ServerResponse } from 'http'
 
 const DEFAULT_LOG_READ_LIMIT = 100
 const MAX_LOG_READ_LIMIT = 1000
@@ -57,7 +58,10 @@ async function resolveStubServiceLogInfo(
 
   const resolvedPath = path.isAbsolute(configuredPath)
     ? configuredPath
-    : path.resolve(path.dirname(loadedServiceDefinition.serviceJsonPath), configuredPath)
+    : path.resolve(
+        path.dirname(loadedServiceDefinition.serviceJsonPath),
+        configuredPath
+      )
 
   return {
     serviceId,
@@ -113,11 +117,12 @@ function normalizeLogReadBefore(value: string | null, totalLines: number) {
   return Math.max(0, Math.min(totalLines, Math.trunc(parsed)))
 }
 
-function attachLogMiddlewares(
-  middlewares: {
-    use: (path: string, handler: (req: any, res: any) => void | Promise<void>) => void
-  }
-) {
+function attachLogMiddlewares(middlewares: {
+  use: (
+    path: string,
+    handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>
+  ) => void
+}) {
   middlewares.use('/api/services/log-info', async (req, res) => {
     try {
       const requestUrl = new URL(req.url ?? '', 'http://localhost')
@@ -151,7 +156,9 @@ function attachLogMiddlewares(
       res.end(
         JSON.stringify({
           error:
-            error instanceof Error ? error.message : 'Failed to resolve service log info',
+            error instanceof Error
+              ? error.message
+              : 'Failed to resolve service log info',
         })
       )
     }
@@ -188,7 +195,9 @@ function attachLogMiddlewares(
     } catch (error) {
       res.statusCode = 500
       res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-      res.end(error instanceof Error ? error.message : 'Failed to read log file')
+      res.end(
+        error instanceof Error ? error.message : 'Failed to read log file'
+      )
     }
   })
 
@@ -246,7 +255,8 @@ function attachLogMiddlewares(
       res.setHeader('Content-Type', 'application/json')
       res.end(
         JSON.stringify({
-          error: error instanceof Error ? error.message : 'Failed to read log file',
+          error:
+            error instanceof Error ? error.message : 'Failed to read log file',
         })
       )
     }


### PR DESCRIPTION
## Summary
- import the remaining service-template workflow/docs/reference files into service-admin
- adapt validate-template for the Service Admin build path
- include the working-tree fixes and formatting needed to keep local validation green

## Validation
- npm run lint
- npm run format:check
- npm run build
- pwsh -NoLogo -NoProfile -File .\\scripts\\test.ps1
- pwsh -NoLogo -NoProfile -File .\\scripts\\package.ps1
