### PR TITLE
fix: use execservice provider semantics for @serviceadmin

### DIFF
--- a/service.json
+++ b/service.json
@@ -26,19 +26,17 @@
     "serviceorder": 100,
     "serviceport": 17700,
     "execcwd": ".",
-    "executable": "node",
+    "executable": "NODE",
     "args": [
       "runtime/server.js"
     ],
-    "env": {
-      "SERVICE_PORT": "17700",
-      "SERVICE_HOST": "127.0.0.1"
-    },
     "depend_on": [
-      "traefik"
+      "@traefik",
+      "@node"
     ],
     "healthcheck": {
       "type": "process"
-    }
+    },
+    "execservice": "@node"
   }
 }


### PR DESCRIPTION
## Summary
- remove direct runtime env usage from service manifest
- set execconfig to provider model (xecservice: @node)
- set executable key to provider-resolved token (NODE)
- align dependency naming to @traefik and include @node

## Why
Service execution should resolve executable from the runtime provider service per ref semantics, not hardcode 
ode in this service manifest.
