### PR TITLE
ISS-128: Add service update notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Current UI runtime behavior:
 - set `VITE_SERVICE_LASSO_LOGS_DEBUG=true` to enable Logs screen debug output in the browser console outside dev mode
 - if the endpoint env var is missing or the favorites flag is not enabled, favorite controls stay visible but disabled
 
+Service update UI contract:
+
+- the dashboard, services table, and service detail page display update states from the Service Lasso runtime
+- the stub layer loads update state from `GET /api/updates`
+- the UI surfaces `installed`, `available`, `downloadedCandidate`, `installDeferred`, and `failed` states
+- the dashboard shows a global update message banner when updates are available, downloaded, deferred by install window, or failed
+- service detail actions call `POST /api/updates/check`, `POST /api/services/:serviceId/update/download`, and `POST /api/services/:serviceId/update/install`
+- when `VITE_SERVICE_LASSO_API_BASE_URL` is not set, update actions are visible against the local stub data but do not call a runtime API
+
 ![alt text](public/images/shadcn-admin.png)
 
 [![Sponsored by Clerk](https://img.shields.io/badge/Sponsored%20by-Clerk-5b6ee1?logo=clerk)](https://go.clerk.com/GttUAaK)

--- a/src/components/service-update-status.tsx
+++ b/src/components/service-update-status.tsx
@@ -1,0 +1,125 @@
+import { AlertTriangle, Clock, Download, PackageCheck } from 'lucide-react'
+import type {
+  ServiceUpdateAction,
+  ServiceUpdateState,
+} from '@/lib/service-lasso-dashboard/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+export function getServiceUpdateLabel(updates?: ServiceUpdateState) {
+  if (!updates) return 'Unknown'
+
+  if (updates.state === 'available') return 'Update available'
+  if (updates.state === 'downloadedCandidate') return 'Downloaded'
+  if (updates.state === 'installDeferred') return 'Waiting window'
+  if (updates.state === 'failed') return 'Update failed'
+
+  return updates.lastCheck?.status === 'pinned' ? 'Pinned' : 'Latest'
+}
+
+export function getServiceUpdateDescription(updates?: ServiceUpdateState) {
+  if (!updates) return 'No update state has been reported yet.'
+
+  if (updates.state === 'available') {
+    return `Available: ${updates.available?.tag ?? updates.lastCheck?.latestTag ?? 'unknown'}`
+  }
+  if (updates.state === 'downloadedCandidate') {
+    return `Candidate ready: ${updates.downloadedCandidate?.tag ?? 'unknown'}`
+  }
+  if (updates.state === 'installDeferred') {
+    return updates.installDeferred?.reason ?? 'Install is waiting for policy.'
+  }
+  if (updates.state === 'failed') {
+    return (
+      updates.failed?.reason ??
+      updates.lastCheck?.reason ??
+      'Update check failed.'
+    )
+  }
+
+  return updates.lastCheck?.reason ?? 'Service is on the latest known version.'
+}
+
+export function ServiceUpdateBadge({
+  updates,
+}: {
+  updates?: ServiceUpdateState
+}) {
+  if (!updates || updates.state === 'installed') {
+    return <Badge variant='outline'>{getServiceUpdateLabel(updates)}</Badge>
+  }
+
+  if (updates.state === 'failed') {
+    return (
+      <Badge variant='destructive'>
+        <AlertTriangle className='mr-1 size-3' />
+        {getServiceUpdateLabel(updates)}
+      </Badge>
+    )
+  }
+
+  if (updates.state === 'installDeferred') {
+    return (
+      <Badge variant='secondary'>
+        <Clock className='mr-1 size-3' />
+        {getServiceUpdateLabel(updates)}
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge className='bg-blue-600 hover:bg-blue-600'>
+      {updates.state === 'downloadedCandidate' ? (
+        <Download className='mr-1 size-3' />
+      ) : (
+        <PackageCheck className='mr-1 size-3' />
+      )}
+      {getServiceUpdateLabel(updates)}
+    </Badge>
+  )
+}
+
+export function getAvailableUpdateActions(
+  updates?: ServiceUpdateState
+): ServiceUpdateAction[] {
+  if (!updates || updates.state === 'installed' || updates.state === 'failed') {
+    return ['check']
+  }
+
+  if (updates.state === 'available') {
+    return ['check', 'download']
+  }
+
+  return ['check', 'install']
+}
+
+export function ServiceUpdateActions({
+  updates,
+  pending,
+  onAction,
+}: {
+  updates?: ServiceUpdateState
+  pending?: boolean
+  onAction: (action: ServiceUpdateAction) => void
+}) {
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {getAvailableUpdateActions(updates).map((action) => (
+        <Button
+          key={action}
+          type='button'
+          size='sm'
+          variant={action === 'install' ? 'default' : 'outline'}
+          disabled={pending}
+          onClick={() => onAction(action)}
+        >
+          {action === 'check'
+            ? 'Check updates'
+            : action === 'download'
+              ? 'Download update'
+              : 'Install update'}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/src/features/dashboard/index.tsx
+++ b/src/features/dashboard/index.tsx
@@ -6,6 +6,7 @@ import {
   PackageOpen,
   Play,
   RefreshCcw,
+  ShieldAlert,
   Star,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
@@ -34,6 +35,10 @@ import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
+import {
+  getServiceUpdateDescription,
+  ServiceUpdateBadge,
+} from '@/components/service-update-status'
 import { ThemeSwitch } from '@/components/theme-switch'
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
@@ -132,6 +137,15 @@ function ServiceCard({ service }: { service: DashboardService }) {
             <StatusBadge status={service.status} />
           </div>
         </div>
+        <div className='rounded-md border border-blue-500/20 bg-blue-500/5 p-2 text-xs'>
+          <div className='flex items-center justify-between gap-2'>
+            <span className='font-medium'>Updates</span>
+            <ServiceUpdateBadge updates={service.updates} />
+          </div>
+          <p className='mt-1 text-muted-foreground'>
+            {getServiceUpdateDescription(service.updates)}
+          </p>
+        </div>
         <div className='flex flex-wrap gap-2'>
           {service.links.slice(0, 2).map((link) => (
             <Button
@@ -179,7 +193,7 @@ function DashboardLoading() {
             </p>
           </div>
         </div>
-        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5'>
           {Array.from({ length: 4 }).map((_, index) => (
             <Card key={index}>
               <CardHeader>
@@ -258,7 +272,31 @@ export function Dashboard() {
             </p>
           </div>
         </div>
-        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+        {summary.updateNotifications.messages.length > 0 ? (
+          <Card className='border-blue-500/30 bg-blue-500/5'>
+            <CardHeader className='pb-3'>
+              <CardTitle className='flex items-center gap-2 text-base'>
+                <ShieldAlert className='size-4 text-blue-600' />
+                Service updates need attention
+              </CardTitle>
+              <CardDescription>
+                These messages come from the Service Lasso update API/state and
+                match the CLI update states.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-2 sm:grid-cols-2 lg:grid-cols-4'>
+              {summary.updateNotifications.messages.map((message) => (
+                <div
+                  key={message}
+                  className='rounded-lg border bg-background p-3 text-sm'
+                >
+                  {message}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        ) : null}
+        <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5'>
           <SummaryCard
             title='Runtime health'
             value={summary.runtime.status === 'healthy' ? 'Healthy' : 'Warning'}
@@ -305,6 +343,16 @@ export function Dashboard() {
             value={String(summary.installedCount)}
             description='Installed services tracked by the stub'
             icon={PackageOpen}
+          />
+          <SummaryCard
+            title='Updates'
+            value={String(
+              summary.updateNotifications.availableCount +
+                summary.updateNotifications.downloadedCount +
+                summary.updateNotifications.deferredCount
+            )}
+            description={`${summary.updateNotifications.failedCount} failed check(s)`}
+            icon={ShieldAlert}
           />
         </div>
         <div className='grid grid-cols-1 gap-4 lg:grid-cols-7'>

--- a/src/features/logs/index.tsx
+++ b/src/features/logs/index.tsx
@@ -6,18 +6,18 @@ import {
   useRef,
   useState,
 } from 'react'
-import { Link, getRouteApi } from '@tanstack/react-router'
+import { Link, getRouteApi, useNavigate } from '@tanstack/react-router'
 import { LazyLog, ScrollFollow } from '@melloware/react-logviewer'
-import { Activity, PauseCircle, PlayCircle, ScrollText, Wifi } from 'lucide-react'
-import { useServices } from '@/lib/service-lasso-dashboard/hooks'
-import { usePageMetadata } from '@/lib/page-metadata'
-import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import {
-  debugLogs,
-  fetchServiceLogChunk,
-  fetchServiceLogInfo,
-  type ServiceLogInfo,
-} from './provider'
+  Activity,
+  PauseCircle,
+  PlayCircle,
+  ScrollText,
+  Wifi,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -43,6 +43,12 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  debugLogs,
+  fetchServiceLogChunk,
+  fetchServiceLogInfo,
+  type ServiceLogInfo,
+} from './provider'
 
 const route = getRouteApi('/_authenticated/logs/')
 
@@ -50,12 +56,16 @@ function selectedServiceFromSearch(
   services: DashboardService[],
   selectedId?: string
 ) {
-  return services.find((service) => service.id === selectedId) ?? services[0] ?? null
+  return (
+    services.find((service) => service.id === selectedId) ?? services[0] ?? null
+  )
 }
 
 function StatusBadge({ status }: { status: DashboardService['status'] }) {
   if (status === 'running') {
-    return <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    return (
+      <Badge className='bg-emerald-600 hover:bg-emerald-600'>Running</Badge>
+    )
   }
   if (status === 'degraded') return <Badge variant='secondary'>Degraded</Badge>
   return <Badge variant='outline'>Stopped</Badge>
@@ -76,7 +86,6 @@ function LogsLoading() {
     </div>
   )
 }
-
 
 const DEFAULT_LOG_CHUNK_SIZE = 100
 const LOAD_OLDER_THRESHOLD_PX = 48
@@ -267,7 +276,12 @@ function ServiceLazyLogViewer({
         setError(null)
         const [info, chunk] = await Promise.all([
           fetchServiceLogInfo(service, 'default'),
-          fetchServiceLogChunk(service, 'default', undefined, DEFAULT_LOG_CHUNK_SIZE),
+          fetchServiceLogChunk(
+            service,
+            'default',
+            undefined,
+            DEFAULT_LOG_CHUNK_SIZE
+          ),
         ])
 
         if (cancelled) return
@@ -438,11 +452,17 @@ function ServiceLazyLogViewer({
       <div className='space-y-1 text-xs text-muted-foreground'>
         <div
           className='truncate whitespace-nowrap'
-          title={logInfo?.path ?? service.metadata.logPath ?? 'resolved by service endpoint'}
+          title={
+            logInfo?.path ??
+            service.metadata.logPath ??
+            'resolved by service endpoint'
+          }
         >
           Source:{' '}
           <span className='font-medium'>
-            {logInfo?.path ?? service.metadata.logPath ?? 'resolved by service endpoint'}
+            {logInfo?.path ??
+              service.metadata.logPath ??
+              'resolved by service endpoint'}
           </span>
         </div>
         <div
@@ -471,22 +491,18 @@ function ServiceLazyLogViewer({
 export function Logs() {
   usePageMetadata({
     title: 'Service Admin - Logs',
-    description: 'Service Admin log viewing surface for Service Lasso services.',
+    description:
+      'Service Admin log viewing surface for Service Lasso services.',
   })
 
   const searchState = route.useSearch()
+  const navigate = useNavigate()
   const servicesQuery = useServices()
   const [paused, setPaused] = useState(true)
   const [serviceQuery, setServiceQuery] = useState('')
-  const [selectedServiceId, setSelectedServiceId] = useState(searchState.service ?? '')
+  const selectedServiceId = searchState.service ?? ''
 
-  const services = servicesQuery.data ?? []
-
-  useEffect(() => {
-    if (searchState.service) {
-      setSelectedServiceId(searchState.service)
-    }
-  }, [searchState.service])
+  const services = useMemo(() => servicesQuery.data ?? [], [servicesQuery.data])
 
   const filteredServices = useMemo(() => {
     const normalized = serviceQuery.trim().toLowerCase()
@@ -528,10 +544,14 @@ export function Logs() {
           </div>
           <div className='flex flex-wrap gap-2'>
             <Button variant='outline' size='sm' asChild>
-              <Link to='/services' search={{}}>Services</Link>
+              <Link to='/services' search={{}}>
+                Services
+              </Link>
             </Button>
             <Button variant='outline' size='sm' asChild>
-              <Link to='/runtime' search={{}}>Runtime</Link>
+              <Link to='/runtime' search={{}}>
+                Runtime
+              </Link>
             </Button>
           </div>
         </div>
@@ -567,7 +587,8 @@ export function Logs() {
                     {paused ? 'Paused' : 'Following'}
                   </div>
                   <p className='text-xs text-muted-foreground'>
-                    Uses the resolved service log endpoint and scroll-follow behavior.
+                    Uses the resolved service log endpoint and scroll-follow
+                    behavior.
                   </p>
                 </CardContent>
               </Card>
@@ -582,7 +603,8 @@ export function Logs() {
                     {selectedService?.metadata.logPath ?? 'Resolved by API'}
                   </div>
                   <p className='text-xs text-muted-foreground'>
-                    The browser only requests service + type. The server resolves the real path.
+                    The browser only requests service + type. The server
+                    resolves the real path.
                   </p>
                 </CardContent>
               </Card>
@@ -593,7 +615,8 @@ export function Logs() {
                 <CardHeader>
                   <CardTitle>Services</CardTitle>
                   <CardDescription>
-                    Search and select the service whose logs you want to inspect.
+                    Search and select the service whose logs you want to
+                    inspect.
                   </CardDescription>
                 </CardHeader>
                 <CardContent className='space-y-4'>
@@ -617,13 +640,26 @@ export function Logs() {
                             <TableRow
                               key={service.id}
                               className='cursor-pointer'
-                              data-state={selectedService?.id === service.id ? 'selected' : undefined}
-                              onClick={() => setSelectedServiceId(service.id)}
+                              data-state={
+                                selectedService?.id === service.id
+                                  ? 'selected'
+                                  : undefined
+                              }
+                              onClick={() => {
+                                void navigate({
+                                  to: '/logs',
+                                  search: { service: service.id },
+                                })
+                              }}
                             >
                               <TableCell>
                                 <div className='flex min-w-0 flex-col'>
-                                  <span className='font-medium'>{service.name}</span>
-                                  <span className='text-xs text-muted-foreground'>{service.id}</span>
+                                  <span className='font-medium'>
+                                    {service.name}
+                                  </span>
+                                  <span className='text-xs text-muted-foreground'>
+                                    {service.id}
+                                  </span>
                                 </div>
                               </TableCell>
                               <TableCell>
@@ -678,7 +714,10 @@ export function Logs() {
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <ServiceLazyLogViewer service={selectedService} paused={paused} />
+                  <ServiceLazyLogViewer
+                    service={selectedService}
+                    paused={paused}
+                  />
                 </CardContent>
               </Card>
             </div>

--- a/src/features/logs/provider.ts
+++ b/src/features/logs/provider.ts
@@ -1,0 +1,130 @@
+import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+
+const logsDebugEnabled =
+  import.meta.env.DEV ||
+  import.meta.env.VITE_SERVICE_LASSO_LOGS_DEBUG === 'true'
+const relativeLogsApiBaseUrl = ''
+
+export type ServiceLogInfo = {
+  serviceId: string
+  type: 'default' | 'access' | 'error'
+  path: string
+  availableTypes: string[]
+}
+
+export type ServiceLogChunk = {
+  serviceId: string
+  type: 'default' | 'access' | 'error'
+  path: string
+  totalLines: number
+  start: number
+  end: number
+  hasMore: boolean
+  nextBefore: number
+  limit: number
+  lines: string[]
+}
+
+export function debugLogs(message: string, details?: Record<string, unknown>) {
+  if (!logsDebugEnabled) return
+  // eslint-disable-next-line no-console
+  console.log('[logs-debug]', message, details ?? {})
+}
+
+async function parseJsonResponse<T>(response: Response) {
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (!response.ok) {
+    throw new Error('Live logs are unavailable right now.')
+  }
+
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error('Live logs are unavailable right now.')
+  }
+
+  return (await response.json()) as T
+}
+
+function resolveLogsApiBaseUrl() {
+  return serviceLassoApiBaseUrl ?? relativeLogsApiBaseUrl
+}
+
+function buildLogsApiUrl(
+  pathname: '/api/services/log-info' | '/api/logs/read',
+  params: URLSearchParams
+) {
+  return `${resolveLogsApiBaseUrl()}${pathname}?${params.toString()}`
+}
+
+export async function fetchServiceLogInfo(
+  service: DashboardService,
+  type: 'default' | 'access' | 'error'
+) {
+  const params = new URLSearchParams({
+    service: service.id,
+    type,
+  })
+  const infoUrl = buildLogsApiUrl('/api/services/log-info', params)
+
+  debugLogs('requesting log info', {
+    serviceId: service.id,
+    type,
+    infoUrl,
+  })
+
+  const response = await fetch(infoUrl)
+  const info = await parseJsonResponse<ServiceLogInfo>(response)
+
+  debugLogs('log info loaded', {
+    serviceId: info.serviceId,
+    type: info.type,
+    path: info.path,
+    availableTypes: info.availableTypes,
+  })
+
+  return info
+}
+
+export async function fetchServiceLogChunk(
+  service: DashboardService,
+  type: 'default' | 'access' | 'error',
+  before?: number,
+  limit = 100
+) {
+  const params = new URLSearchParams({
+    service: service.id,
+    type,
+    limit: String(limit),
+  })
+
+  if (typeof before === 'number') {
+    params.set('before', String(before))
+  }
+
+  const chunkUrl = buildLogsApiUrl('/api/logs/read', params)
+
+  debugLogs('requesting log chunk', {
+    serviceId: service.id,
+    type,
+    before: before ?? null,
+    limit,
+    chunkUrl,
+  })
+
+  const response = await fetch(chunkUrl)
+  const chunk = await parseJsonResponse<ServiceLogChunk>(response)
+
+  debugLogs('log chunk loaded', {
+    serviceId: chunk.serviceId,
+    type: chunk.type,
+    before: before ?? null,
+    lineCount: chunk.lines.length,
+    totalLines: chunk.totalLines,
+    hasMore: chunk.hasMore,
+    nextBefore: chunk.nextBefore,
+    firstLinePreview: chunk.lines[0]?.slice(0, 120) ?? null,
+  })
+
+  return chunk
+}

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { LazyLog, ScrollFollow } from '@melloware/react-logviewer'
-import { toast } from 'sonner'
 import {
   Position,
   useEdgesState,
@@ -23,8 +22,9 @@ import {
   Undo2,
   Wrench,
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { copyText } from '@/lib/copy-text'
-import { useTheme } from '@/context/theme-provider'
+import { usePageMetadata } from '@/lib/page-metadata'
 import {
   buildApiUsageEdge,
   buildDependencyEdge,
@@ -32,9 +32,11 @@ import {
   buildServiceNodeStyle,
   getServiceNodeImage,
 } from '@/lib/service-graph'
-import { usePageMetadata } from '@/lib/page-metadata'
+import {
+  useDashboardService,
+  useServiceUpdateAction,
+} from '@/lib/service-lasso-dashboard/hooks'
 import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
-import { useDashboardService } from '@/lib/service-lasso-dashboard/hooks'
 import type {
   DashboardService,
   ServiceAction,
@@ -44,6 +46,7 @@ import type {
   ServiceLogPreviewEntry,
   ServiceStatus,
 } from '@/lib/service-lasso-dashboard/types'
+import { useTheme } from '@/context/theme-provider'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -53,14 +56,8 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Separator } from '@/components/ui/separator'
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -69,6 +66,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { DependencyGraphCanvas } from '@/components/dependency-graph-canvas'
 import { DependencyGraphPanel } from '@/components/dependency-graph-panel'
@@ -76,6 +74,11 @@ import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
+import {
+  getServiceUpdateDescription,
+  ServiceUpdateActions,
+  ServiceUpdateBadge,
+} from '@/components/service-update-status'
 import { ThemeSwitch } from '@/components/theme-switch'
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
@@ -223,7 +226,11 @@ type GraphOrientation = 'horizontal' | 'vertical'
 
 type GraphLayoutMap = Record<string, { x: number; y: number }>
 
-async function persistNodeLayoutToMeta(serviceId: string, x: number, y: number) {
+async function persistNodeLayoutToMeta(
+  serviceId: string,
+  x: number,
+  y: number
+) {
   if (!serviceLassoApiBaseUrl) {
     throw new Error('Service Lasso API base URL is not configured')
   }
@@ -282,27 +289,29 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
       })
     )
 
-    const dependentNodes: Node[] = service.dependents.map((dependent, index) => ({
-      id: `dnt-${dependent.id}`,
-      position:
-        layoutMap[`dnt-${dependent.id}`] ??
-        (graphOrientation === 'horizontal'
-          ? { x: xStep * 2, y: index * yStep + 30 }
-          : { x: index * xStep, y: yStep * 2 }),
-      data: {
-        label: buildServiceNodeLabel({
-          name: dependent.name,
-          id: dependent.id,
-          serviceType: 'dependent',
-          isDark,
-        }),
-      },
-      style: buildServiceNodeStyle({ selected: false, isDark }),
-      sourcePosition:
-        graphOrientation === 'horizontal' ? Position.Right : Position.Bottom,
-      targetPosition:
-        graphOrientation === 'horizontal' ? Position.Left : Position.Top,
-    }))
+    const dependentNodes: Node[] = service.dependents.map(
+      (dependent, index) => ({
+        id: `dnt-${dependent.id}`,
+        position:
+          layoutMap[`dnt-${dependent.id}`] ??
+          (graphOrientation === 'horizontal'
+            ? { x: xStep * 2, y: index * yStep + 30 }
+            : { x: index * xStep, y: yStep * 2 }),
+        data: {
+          label: buildServiceNodeLabel({
+            name: dependent.name,
+            id: dependent.id,
+            serviceType: 'dependent',
+            isDark,
+          }),
+        },
+        style: buildServiceNodeStyle({ selected: false, isDark }),
+        sourcePosition:
+          graphOrientation === 'horizontal' ? Position.Right : Position.Bottom,
+        targetPosition:
+          graphOrientation === 'horizontal' ? Position.Left : Position.Top,
+      })
+    )
 
     const centerNode: Node = {
       id: `svc-${service.id}`,
@@ -312,14 +321,16 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
           ? {
               x: xStep,
               y:
-                Math.max(dependencyNodes.length, dependentNodes.length) * yStep *
+                Math.max(dependencyNodes.length, dependentNodes.length) *
+                  yStep *
                   0.5 +
                 30,
             }
           : {
               x:
-                Math.max(dependencyNodes.length, dependentNodes.length) * xStep *
-                  0.5,
+                Math.max(dependencyNodes.length, dependentNodes.length) *
+                xStep *
+                0.5,
               y: yStep,
             }),
       data: {
@@ -420,7 +431,10 @@ function LocalDependencyGraph({ service }: { service: DashboardService }) {
     try {
       await Promise.all(
         Object.entries(layoutMap).map(([nodeId, position]) => {
-          const serviceId = nodeId.replace(/^dep-/, '').replace(/^dnt-/, '').replace(/^svc-/, '')
+          const serviceId = nodeId
+            .replace(/^dep-/, '')
+            .replace(/^dnt-/, '')
+            .replace(/^svc-/, '')
           return persistNodeLayoutToMeta(serviceId, position.x, position.y)
         })
       )
@@ -701,16 +715,27 @@ function ServiceDetailLoading() {
   )
 }
 
+type ServiceDetailTab =
+  | 'overview'
+  | 'dependencies'
+  | 'metadata'
+  | 'endpoints'
+  | 'variables'
+  | 'logs'
+
 export function ServiceDetail({ serviceId }: { serviceId: string }) {
   const serviceQuery = useDashboardService(serviceId)
+  const updateAction = useServiceUpdateAction()
   const serviceName = serviceQuery.data?.name ?? serviceId
-  const [activeTab, setActiveTab] = useState<
-    'overview' | 'dependencies' | 'metadata' | 'endpoints' | 'variables' | 'logs'
-  >('overview')
-
-  useEffect(() => {
-    setActiveTab('overview')
-  }, [serviceId])
+  const [tabState, setTabState] = useState<{
+    serviceId: string
+    activeTab: ServiceDetailTab
+  }>({ serviceId, activeTab: 'overview' })
+  const activeTab =
+    tabState.serviceId === serviceId ? tabState.activeTab : 'overview'
+  const setActiveTab = (nextTab: ServiceDetailTab) => {
+    setTabState({ serviceId, activeTab: nextTab })
+  }
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -728,14 +753,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
         '4': 'endpoints',
         '5': 'variables',
         '6': 'logs',
-      }[event.key] as
-        | 'overview'
-        | 'dependencies'
-        | 'metadata'
-        | 'endpoints'
-        | 'variables'
-        | 'logs'
-        | undefined
+      }[event.key] as ServiceDetailTab | undefined
 
       if (!nextTab) return
       event.preventDefault()
@@ -799,6 +817,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       </Button>
                       <StatusBadge status={service.status} />
                       <HealthBadge health={service.runtimeHealth.health} />
+                      <ServiceUpdateBadge updates={service.updates} />
                     </div>
                     <div>
                       <h2 className='text-2xl font-bold tracking-tight'>
@@ -821,37 +840,48 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                   </div>
                 </div>
 
-                <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)} className='space-y-4'>
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(value) =>
+                    setActiveTab(value as typeof activeTab)
+                  }
+                  className='space-y-4'
+                >
                   <TabsList className='flex h-auto w-full flex-wrap justify-start gap-1 rounded-2xl border border-border bg-muted/70 p-1 text-muted-foreground shadow-sm dark:border-slate-700/70 dark:bg-slate-900/90 dark:text-slate-400 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]'>
                     <TabsTrigger
                       value='overview'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Overview <span className='ml-1 italic opacity-80'>(1)</span>
+                      Overview{' '}
+                      <span className='ml-1 italic opacity-80'>(1)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='dependencies'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Dependencies <span className='ml-1 italic opacity-80'>(2)</span>
+                      Dependencies{' '}
+                      <span className='ml-1 italic opacity-80'>(2)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='metadata'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Metadata <span className='ml-1 italic opacity-80'>(3)</span>
+                      Metadata{' '}
+                      <span className='ml-1 italic opacity-80'>(3)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='endpoints'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Endpoints <span className='ml-1 italic opacity-80'>(4)</span>
+                      Endpoints{' '}
+                      <span className='ml-1 italic opacity-80'>(4)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='variables'
                       className='h-11 rounded-xl border-transparent px-5 text-base font-semibold text-muted-foreground data-[state=active]:border-border data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm dark:text-slate-400 dark:data-[state=active]:border-slate-600 dark:data-[state=active]:bg-slate-800 dark:data-[state=active]:text-white dark:data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.10),0_1px_2px_rgba(0,0,0,0.45)]'
                     >
-                      Variables <span className='ml-1 italic opacity-80'>(5)</span>
+                      Variables{' '}
+                      <span className='ml-1 italic opacity-80'>(5)</span>
                     </TabsTrigger>
                     <TabsTrigger
                       value='logs'
@@ -862,7 +892,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                   </TabsList>
 
                   <TabsContent value='overview' className='mt-0'>
-                    <div className='grid gap-4 md:grid-cols-3'>
+                    <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
                       <Card>
                         <CardHeader className='pb-2'>
                           <CardTitle className='flex items-center gap-2 text-sm font-medium'>
@@ -884,7 +914,8 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           </div>
                           <div className='text-muted-foreground'>
                             Last restart:{' '}
-                            {service.runtimeHealth.lastRestartAt ?? 'Not recorded'}
+                            {service.runtimeHealth.lastRestartAt ??
+                              'Not recorded'}
                           </div>
                         </CardContent>
                       </Card>
@@ -899,7 +930,41 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           <div>Runtime: {service.metadata.runtime}</div>
                           <div>Version: {service.metadata.version}</div>
                           <div>Build: {service.metadata.build}</div>
-                          <div>Installed: {service.installed ? 'Yes' : 'No'}</div>
+                          <div>
+                            Installed: {service.installed ? 'Yes' : 'No'}
+                          </div>
+                        </CardContent>
+                      </Card>
+                      <Card>
+                        <CardHeader className='pb-2'>
+                          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+                            <PackageCheck className='size-4' /> Updates
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent className='space-y-3 text-sm'>
+                          <div className='flex items-center justify-between gap-3'>
+                            <span className='font-medium'>Status</span>
+                            <ServiceUpdateBadge updates={service.updates} />
+                          </div>
+                          <p className='text-muted-foreground'>
+                            {getServiceUpdateDescription(service.updates)}
+                          </p>
+                          {service.updates?.installDeferred?.nextEligibleAt ? (
+                            <p className='text-xs text-muted-foreground'>
+                              Next eligible:{' '}
+                              {service.updates.installDeferred.nextEligibleAt}
+                            </p>
+                          ) : null}
+                          <ServiceUpdateActions
+                            updates={service.updates}
+                            pending={updateAction.isPending}
+                            onAction={(action) =>
+                              updateAction.mutate({
+                                action,
+                                serviceId: service.id,
+                              })
+                            }
+                          />
                         </CardContent>
                       </Card>
                       <Card>
@@ -1006,8 +1071,8 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       <CardHeader>
                         <CardTitle>Environment variables</CardTitle>
                         <CardDescription>
-                          Service-local and shared environment values surfaced in a
-                          searchable top-level Variables page as well.
+                          Service-local and shared environment values surfaced
+                          in a searchable top-level Variables page as well.
                         </CardDescription>
                       </CardHeader>
                       <CardContent className='space-y-4'>
@@ -1017,7 +1082,10 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                         />
                         <div className='flex justify-end'>
                           <Button variant='outline' size='sm' asChild>
-                            <Link to='/variables' search={{ service: service.id }}>
+                            <Link
+                              to='/variables'
+                              search={{ service: service.id }}
+                            >
                               Open all variables
                             </Link>
                           </Button>
@@ -1059,7 +1127,10 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                             <Link to='/network'>Open network view</Link>
                           </Button>
                           <Button variant='outline' asChild>
-                            <Link to='/runtime' search={{ service: service.id }}>
+                            <Link
+                              to='/runtime'
+                              search={{ service: service.id }}
+                            >
                               Open runtime view
                             </Link>
                           </Button>

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -11,6 +11,10 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { DataTableColumnHeader } from '@/components/data-table'
 import { LongText } from '@/components/long-text'
+import {
+  getServiceUpdateDescription,
+  ServiceUpdateBadge,
+} from '@/components/service-update-status'
 import { DataTableRowActions } from './data-table-row-actions'
 
 function renderStatusBadge(status: DashboardService['status']) {
@@ -102,6 +106,25 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
         statusSortRank[rowB.getValue(columnId) as DashboardService['status']]
       return left - right
     },
+  },
+  {
+    id: 'updates',
+    accessorFn: (row) => row.updates?.state ?? 'unknown',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Updates' />
+    ),
+    cell: ({ row }) => {
+      const service = row.original
+      return (
+        <div className='flex max-w-[220px] flex-col gap-1'>
+          <ServiceUpdateBadge updates={service.updates} />
+          <span className='line-clamp-2 text-xs text-muted-foreground'>
+            {getServiceUpdateDescription(service.updates)}
+          </span>
+        </div>
+      )
+    },
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
   },
   {
     id: 'favorite',

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -6,8 +6,13 @@ import {
   fetchDashboardSummary,
   fetchServices,
   runDashboardAction,
+  runServiceUpdateAction,
 } from './stub'
-import type { DashboardAction, DashboardService } from './types'
+import type {
+  DashboardAction,
+  DashboardService,
+  ServiceUpdateAction,
+} from './types'
 
 const dashboardQueryKey = ['service-lasso-dashboard']
 
@@ -80,4 +85,29 @@ export function useFavoriteFeatureState() {
   return {
     enabled: favoritesMutationEnabled,
   }
+}
+
+export function useServiceUpdateAction() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (options: {
+      action: ServiceUpdateAction
+      serviceId: string
+      force?: boolean
+    }) => runServiceUpdateAction(options),
+    onSuccess: (data) => {
+      queryClient.setQueryData(dashboardQueryKey, data)
+
+      const allServices = [
+        ...data.favorites,
+        ...data.others,
+      ] satisfies DashboardService[]
+      queryClient.setQueryData([...dashboardQueryKey, 'services'], allServices)
+
+      for (const service of allServices) {
+        queryClient.setQueryData([...dashboardQueryKey, service.id], service)
+      }
+    },
+  })
 }

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -2,6 +2,8 @@ import type {
   DashboardAction,
   DashboardService,
   DashboardSummary,
+  ServiceUpdateAction,
+  ServiceUpdateState,
 } from './types'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -22,6 +24,33 @@ type RemoteServiceMeta = {
   imageUrl?: string
 }
 
+type RemoteServiceUpdate = {
+  serviceId: string
+  update: ServiceUpdateState
+}
+
+function createEmptyUpdateState(serviceId: string): ServiceUpdateState {
+  return {
+    serviceId,
+    state: 'installed',
+    updatedAt: new Date('2026-04-11T10:00:00+10:00').toISOString(),
+    lastCheck: {
+      checkedAt: new Date('2026-04-11T10:00:00+10:00').toISOString(),
+      status: 'latest',
+      reason: 'No newer update has been reported.',
+      sourceRepo: null,
+      track: null,
+      installedTag: null,
+      manifestTag: null,
+      latestTag: null,
+    },
+    available: null,
+    downloadedCandidate: null,
+    installDeferred: null,
+    failed: null,
+  }
+}
+
 async function fetchRemoteServiceMeta(): Promise<RemoteServiceMeta[] | null> {
   if (!serviceLassoApiBaseUrl) return null
 
@@ -39,10 +68,31 @@ async function fetchRemoteServiceMeta(): Promise<RemoteServiceMeta[] | null> {
   }
 }
 
+async function fetchRemoteUpdateStates(): Promise<
+  RemoteServiceUpdate[] | null
+> {
+  if (!serviceLassoApiBaseUrl) return null
+
+  try {
+    const response = await fetch(`${serviceLassoApiBaseUrl}/api/updates`)
+    if (!response.ok) return null
+
+    const payload = (await response.json()) as {
+      services?: RemoteServiceUpdate[]
+    }
+
+    return payload.services ?? []
+  } catch {
+    return null
+  }
+}
+
 function applyRemoteServiceMeta(serviceMeta: RemoteServiceMeta[]) {
   if (serviceMeta.length === 0) return
 
-  const remoteMetaById = new Map(serviceMeta.map((service) => [service.id, service]))
+  const remoteMetaById = new Map(
+    serviceMeta.map((service) => [service.id, service])
+  )
 
   services = services.map((service) => {
     const remoteMeta = remoteMetaById.get(service.id)
@@ -62,10 +112,29 @@ function applyRemoteServiceMeta(serviceMeta: RemoteServiceMeta[]) {
   })
 }
 
-async function syncFavoriteStateFromApi() {
-  const remoteServiceMeta = await fetchRemoteServiceMeta()
+export function applyRemoteUpdateStates(updateStates: RemoteServiceUpdate[]) {
+  if (updateStates.length === 0) return
+
+  const updateById = new Map(
+    updateStates.map((service) => [service.serviceId, service.update])
+  )
+
+  services = services.map((service) => ({
+    ...service,
+    updates: updateById.get(service.id) ?? service.updates,
+  }))
+}
+
+async function syncRemoteStateFromApi() {
+  const [remoteServiceMeta, remoteUpdateStates] = await Promise.all([
+    fetchRemoteServiceMeta(),
+    fetchRemoteUpdateStates(),
+  ])
   if (remoteServiceMeta) {
     applyRemoteServiceMeta(remoteServiceMeta)
+  }
+  if (remoteUpdateStates) {
+    applyRemoteUpdateStates(remoteUpdateStates)
   }
 }
 
@@ -182,6 +251,7 @@ let services: DashboardService[] = [
       { id: 'open_logs', label: 'Open logs', kind: 'open_logs' },
       { id: 'open_admin', label: 'Open dashboard', kind: 'open_admin' },
     ],
+    updates: createEmptyUpdateState('traefik'),
   },
   {
     id: 'service-admin',
@@ -232,8 +302,7 @@ let services: DashboardService[] = [
       configPath:
         'C:\\projects\\service-lasso\\lasso-@serviceadmin\\vite.config.ts',
       dataPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin\\dist',
-      logPath:
-        '/services/service-admin/service.log',
+      logPath: '/services/service-admin/service.log',
       workPath: 'C:\\projects\\service-lasso\\lasso-@serviceadmin',
       profile: 'develop',
     },
@@ -296,6 +365,31 @@ let services: DashboardService[] = [
       { id: 'open_logs', label: 'Open logs', kind: 'open_logs' },
       { id: 'open_config', label: 'Open config', kind: 'open_config' },
     ],
+    updates: {
+      ...createEmptyUpdateState('service-admin'),
+      state: 'available',
+      updatedAt: new Date('2026-04-11T10:12:00+10:00').toISOString(),
+      lastCheck: {
+        checkedAt: new Date('2026-04-11T10:12:00+10:00').toISOString(),
+        status: 'update_available',
+        reason: 'A newer Service Admin release is available.',
+        sourceRepo: 'service-lasso/lasso-serviceadmin',
+        track: 'latest',
+        installedTag: '2026.4.18-170a1af',
+        manifestTag: '2026.4.18-170a1af',
+        latestTag: '2026.4.26-demo',
+      },
+      available: {
+        tag: '2026.4.26-demo',
+        version: '2026.4.26-demo',
+        releaseUrl:
+          'https://github.com/service-lasso/lasso-serviceadmin/releases/tag/2026.4.26-demo',
+        publishedAt: new Date('2026-04-26T00:00:00Z').toISOString(),
+        assetName: '@serviceadmin-win32.zip',
+        assetUrl:
+          'https://github.com/service-lasso/lasso-serviceadmin/releases/download/2026.4.26-demo/@serviceadmin-win32.zip',
+      },
+    },
   },
   {
     id: 'zitadel',
@@ -396,6 +490,26 @@ let services: DashboardService[] = [
       { id: 'open_logs', label: 'Open logs', kind: 'open_logs' },
       { id: 'open_admin', label: 'Open auth UI', kind: 'open_admin' },
     ],
+    updates: {
+      ...createEmptyUpdateState('zitadel'),
+      state: 'failed',
+      updatedAt: new Date('2026-04-11T10:14:00+10:00').toISOString(),
+      lastCheck: {
+        checkedAt: new Date('2026-04-11T10:14:00+10:00').toISOString(),
+        status: 'check_failed',
+        reason: 'Release source returned an error.',
+        sourceRepo: 'service-lasso/zitadel',
+        track: 'latest',
+        installedTag: '2.57.0',
+        manifestTag: '2.57.0',
+        latestTag: null,
+      },
+      failed: {
+        reason: 'Release source returned an error.',
+        failedAt: new Date('2026-04-11T10:14:00+10:00').toISOString(),
+        sourceStatus: 'check_failed',
+      },
+    },
   },
   {
     id: 'dagu',
@@ -481,6 +595,31 @@ let services: DashboardService[] = [
       { id: 'open_logs', label: 'Open logs', kind: 'open_logs' },
       { id: 'open_admin', label: 'Open workflow UI', kind: 'open_admin' },
     ],
+    updates: {
+      ...createEmptyUpdateState('dagu'),
+      state: 'downloadedCandidate',
+      updatedAt: new Date('2026-04-11T10:15:00+10:00').toISOString(),
+      lastCheck: {
+        checkedAt: new Date('2026-04-11T10:15:00+10:00').toISOString(),
+        status: 'update_available',
+        reason: 'Update candidate has been downloaded.',
+        sourceRepo: 'service-lasso/dagu',
+        track: 'latest',
+        installedTag: '0.17.1',
+        manifestTag: '0.17.1',
+        latestTag: '0.18.0',
+      },
+      downloadedCandidate: {
+        tag: '0.18.0',
+        version: '0.18.0',
+        assetName: 'dagu-win32.zip',
+        assetUrl: 'https://example.invalid/dagu-win32.zip',
+        archivePath:
+          'C:\\service-lasso\\dagu\\.state\\update-candidates\\0.18.0\\dagu-win32.zip',
+        extractedPath: null,
+        downloadedAt: new Date('2026-04-11T10:15:00+10:00').toISOString(),
+      },
+    },
   },
   {
     id: 'secrets-broker',
@@ -583,6 +722,26 @@ let services: DashboardService[] = [
       { id: 'open_config', label: 'Open config', kind: 'open_config' },
       { id: 'uninstall', label: 'Uninstall service', kind: 'uninstall' },
     ],
+    updates: {
+      ...createEmptyUpdateState('secrets-broker'),
+      state: 'installDeferred',
+      updatedAt: new Date('2026-04-11T10:16:00+10:00').toISOString(),
+      lastCheck: {
+        checkedAt: new Date('2026-04-11T10:16:00+10:00').toISOString(),
+        status: 'update_available',
+        reason: 'Install is waiting for the maintenance window.',
+        sourceRepo: 'service-lasso/secrets-broker',
+        track: 'latest',
+        installedTag: 'v0.4.0-dev',
+        manifestTag: 'v0.4.0-dev',
+        latestTag: 'v0.4.1',
+      },
+      installDeferred: {
+        reason: 'Current time is outside updates.installWindow.',
+        deferredAt: new Date('2026-04-11T10:16:00+10:00').toISOString(),
+        nextEligibleAt: new Date('2026-04-12T02:00:00+10:00').toISOString(),
+      },
+    },
   },
 ]
 
@@ -606,11 +765,60 @@ function buildWarnings(currentServices: DashboardService[]) {
     warnings.push('No favorite services are configured for quick access.')
   }
 
+  const updateNotifications = buildUpdateNotifications(currentServices)
+  warnings.push(...updateNotifications.messages)
+
   return warnings
+}
+
+export function buildUpdateNotifications(currentServices: DashboardService[]) {
+  const latestCount = currentServices.filter(
+    (service) => service.updates?.state === 'installed'
+  ).length
+  const availableCount = currentServices.filter(
+    (service) => service.updates?.state === 'available'
+  ).length
+  const downloadedCount = currentServices.filter(
+    (service) => service.updates?.state === 'downloadedCandidate'
+  ).length
+  const deferredCount = currentServices.filter(
+    (service) => service.updates?.state === 'installDeferred'
+  ).length
+  const failedCount = currentServices.filter(
+    (service) => service.updates?.state === 'failed'
+  ).length
+  const messages: string[] = []
+
+  if (availableCount > 0) {
+    messages.push(`${availableCount} service update(s) are available.`)
+  }
+  if (downloadedCount > 0) {
+    messages.push(
+      `${downloadedCount} downloaded update candidate(s) are ready.`
+    )
+  }
+  if (deferredCount > 0) {
+    messages.push(
+      `${deferredCount} update install(s) are waiting for a window.`
+    )
+  }
+  if (failedCount > 0) {
+    messages.push(`${failedCount} update check(s) need attention.`)
+  }
+
+  return {
+    latestCount,
+    availableCount,
+    downloadedCount,
+    deferredCount,
+    failedCount,
+    messages,
+  }
 }
 
 function buildSummary(): DashboardSummary {
   const warnings = buildWarnings(services)
+  const updateNotifications = buildUpdateNotifications(services)
   const favorites = services.filter((service) => service.favorite)
   const others = services.filter((service) => !service.favorite)
 
@@ -639,6 +847,7 @@ function buildSummary(): DashboardSummary {
     problemServices: services.filter(
       (service) => service.status === 'degraded' || service.status === 'stopped'
     ),
+    updateNotifications,
   }
 }
 
@@ -679,23 +888,78 @@ async function updateFavoriteViaApi(serviceId: string, favorite: boolean) {
 
 export async function fetchDashboardSummary() {
   await wait(120)
-  await syncFavoriteStateFromApi()
+  await syncRemoteStateFromApi()
   return structuredClone(buildSummary())
 }
 
 export async function fetchServices() {
   await wait(120)
-  await syncFavoriteStateFromApi()
+  await syncRemoteStateFromApi()
   return structuredClone(services)
 }
 
 export async function fetchDashboardService(serviceId: string) {
   await wait(120)
-  await syncFavoriteStateFromApi()
+  await syncRemoteStateFromApi()
   return (
     structuredClone(services.find((service) => service.id === serviceId)) ??
     null
   )
+}
+
+function applyServiceUpdateState(
+  serviceId: string,
+  update: ServiceUpdateState
+) {
+  services = services.map((service) =>
+    service.id === serviceId ? { ...service, updates: update } : service
+  )
+}
+
+export async function runServiceUpdateAction(options: {
+  action: ServiceUpdateAction
+  serviceId: string
+  force?: boolean
+}) {
+  await wait(120)
+
+  if (!serviceLassoApiBaseUrl) {
+    return structuredClone(buildSummary())
+  }
+
+  const endpoint =
+    options.action === 'check'
+      ? `${serviceLassoApiBaseUrl}/api/updates/check`
+      : `${serviceLassoApiBaseUrl}/api/services/${options.serviceId}/update/${options.action}`
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body:
+      options.action === 'check'
+        ? JSON.stringify({ serviceId: options.serviceId })
+        : JSON.stringify({ force: options.force === true }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Update ${options.action} failed for ${options.serviceId}`)
+  }
+
+  const payload = (await response.json()) as {
+    update?: ServiceUpdateState
+    services?: Array<{ serviceId: string; update: ServiceUpdateState }>
+  }
+  const update =
+    payload.update ??
+    payload.services?.find((service) => service.serviceId === options.serviceId)
+      ?.update
+
+  if (update) {
+    applyServiceUpdateState(options.serviceId, update)
+  }
+
+  return structuredClone(buildSummary())
 }
 
 export function resolveStubServiceLogInfo(
@@ -705,7 +969,8 @@ export function resolveStubServiceLogInfo(
   const service = services.find((item) => item.id === serviceId)
   if (!service) return null
 
-  const defaultPath = service.metadata.logPath ?? '/mock-logs/service-sample.log'
+  const defaultPath =
+    service.metadata.logPath ?? '/mock-logs/service-sample.log'
   const availableTypes: Array<'default' | 'access' | 'error'> = ['default']
 
   return {

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -77,6 +77,63 @@ export type ServiceAction = {
     | 'open_admin'
 }
 
+export type ServiceUpdateStateKind =
+  | 'installed'
+  | 'available'
+  | 'downloadedCandidate'
+  | 'installDeferred'
+  | 'failed'
+
+export type ServiceUpdateState = {
+  serviceId: string
+  state: ServiceUpdateStateKind
+  updatedAt: string
+  lastCheck: {
+    checkedAt: string
+    status:
+      | 'latest'
+      | 'update_available'
+      | 'pinned'
+      | 'unavailable'
+      | 'check_failed'
+    reason: string
+    sourceRepo: string | null
+    track: string | null
+    installedTag: string | null
+    manifestTag: string | null
+    latestTag: string | null
+  } | null
+  available: {
+    tag: string | null
+    version: string | null
+    releaseUrl: string | null
+    publishedAt: string | null
+    assetName: string | null
+    assetUrl: string | null
+  } | null
+  downloadedCandidate: {
+    tag: string
+    version: string | null
+    assetName: string
+    assetUrl: string
+    archivePath: string
+    extractedPath: string | null
+    downloadedAt: string
+  } | null
+  installDeferred: {
+    reason: string
+    deferredAt: string
+    nextEligibleAt: string | null
+  } | null
+  failed: {
+    reason: string
+    failedAt: string
+    sourceStatus: string | null
+  } | null
+}
+
+export type ServiceUpdateAction = 'check' | 'download' | 'install'
+
 export type DashboardService = {
   id: string
   name: string
@@ -94,6 +151,7 @@ export type DashboardService = {
   environmentVariables: ServiceEnvironmentVariable[]
   recentLogs: ServiceLogPreviewEntry[]
   actions: ServiceAction[]
+  updates?: ServiceUpdateState
 }
 
 export type DashboardRuntime = {
@@ -114,6 +172,14 @@ export type DashboardSummary = {
   others: DashboardService[]
   warnings: string[]
   problemServices: DashboardService[]
+  updateNotifications: {
+    latestCount: number
+    availableCount: number
+    downloadedCount: number
+    deferredCount: number
+    failedCount: number
+    messages: string[]
+  }
 }
 
 export type DashboardAction =

--- a/src/lib/service-lasso-dashboard/updates.test.ts
+++ b/src/lib/service-lasso-dashboard/updates.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { applyRemoteUpdateStates, buildUpdateNotifications } from './stub'
+import type { DashboardService, ServiceUpdateState } from './types'
+
+function updateState(
+  serviceId: string,
+  state: ServiceUpdateState['state']
+): ServiceUpdateState {
+  return {
+    serviceId,
+    state,
+    updatedAt: '2026-04-26T00:00:00.000Z',
+    lastCheck: null,
+    available:
+      state === 'available'
+        ? {
+            tag: '2026.4.26-new',
+            version: '2026.4.26-new',
+            releaseUrl: null,
+            publishedAt: null,
+            assetName: 'service.zip',
+            assetUrl: 'https://example.invalid/service.zip',
+          }
+        : null,
+    downloadedCandidate:
+      state === 'downloadedCandidate'
+        ? {
+            tag: '2026.4.26-new',
+            version: '2026.4.26-new',
+            assetName: 'service.zip',
+            assetUrl: 'https://example.invalid/service.zip',
+            archivePath: '/tmp/service.zip',
+            extractedPath: null,
+            downloadedAt: '2026-04-26T00:00:00.000Z',
+          }
+        : null,
+    installDeferred:
+      state === 'installDeferred'
+        ? {
+            reason: 'Current time is outside updates.installWindow.',
+            deferredAt: '2026-04-26T00:00:00.000Z',
+            nextEligibleAt: '2026-04-26T02:00:00.000Z',
+          }
+        : null,
+    failed:
+      state === 'failed'
+        ? {
+            reason: 'Release source failed.',
+            failedAt: '2026-04-26T00:00:00.000Z',
+            sourceStatus: 'check_failed',
+          }
+        : null,
+  }
+}
+
+function service(
+  id: string,
+  state: ServiceUpdateState['state']
+): DashboardService {
+  return {
+    id,
+    name: id,
+    status: 'running',
+    favorite: false,
+    note: '',
+    links: [],
+    installed: true,
+    role: '',
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '1m',
+      lastCheckAt: '2026-04-26T00:00:00.000Z',
+      summary: 'Healthy',
+    },
+    endpoints: [],
+    metadata: {
+      serviceType: 'test',
+      runtime: 'test',
+      version: '1.0.0',
+      build: 'test',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [],
+    recentLogs: [],
+    actions: [],
+    updates: updateState(id, state),
+  }
+}
+
+describe('service update notifications', () => {
+  it('summarizes available, downloaded, deferred, failed, and latest update states', () => {
+    const summary = buildUpdateNotifications([
+      service('latest', 'installed'),
+      service('available', 'available'),
+      service('downloaded', 'downloadedCandidate'),
+      service('deferred', 'installDeferred'),
+      service('failed', 'failed'),
+    ])
+
+    expect(summary.latestCount).toBe(1)
+    expect(summary.availableCount).toBe(1)
+    expect(summary.downloadedCount).toBe(1)
+    expect(summary.deferredCount).toBe(1)
+    expect(summary.failedCount).toBe(1)
+    expect(summary.messages).toContain('1 service update(s) are available.')
+    expect(summary.messages).toContain(
+      '1 downloaded update candidate(s) are ready.'
+    )
+    expect(summary.messages).toContain(
+      '1 update install(s) are waiting for a window.'
+    )
+    expect(summary.messages).toContain('1 update check(s) need attention.')
+  })
+
+  it('accepts remote update state payloads from the Service Lasso API shape', () => {
+    expect(() =>
+      applyRemoteUpdateStates([
+        {
+          serviceId: 'service-admin',
+          update: updateState('service-admin', 'available'),
+        },
+      ])
+    ).not.toThrow()
+  })
+})

--- a/src/routes/_authenticated/logs/index.tsx
+++ b/src/routes/_authenticated/logs/index.tsx
@@ -1,0 +1,12 @@
+import z from 'zod'
+import { createFileRoute } from '@tanstack/react-router'
+import { Logs } from '@/features/logs'
+
+const logsSearchSchema = z.object({
+  service: z.string().optional().catch(undefined),
+})
+
+export const Route = createFileRoute('/_authenticated/logs/')({
+  validateSearch: logsSearchSchema,
+  component: Logs,
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach, beforeAll, beforeEach, vi } from 'vitest'
@@ -65,10 +66,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation((...args) => {
     const first = args[0]
-    if (
-      typeof first === 'string' &&
-      first.includes('not wrapped in act')
-    ) {
+    if (typeof first === 'string' && first.includes('not wrapped in act')) {
       return
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
-import { promises as fs } from 'fs'
 import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
+import { promises as fs } from 'fs'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 
 const DEFAULT_LOG_READ_LIMIT = 100
 const MAX_LOG_READ_LIMIT = 1000
@@ -57,7 +58,10 @@ async function resolveStubServiceLogInfo(
 
   const resolvedPath = path.isAbsolute(configuredPath)
     ? configuredPath
-    : path.resolve(path.dirname(loadedServiceDefinition.serviceJsonPath), configuredPath)
+    : path.resolve(
+        path.dirname(loadedServiceDefinition.serviceJsonPath),
+        configuredPath
+      )
 
   return {
     serviceId,
@@ -113,11 +117,12 @@ function normalizeLogReadBefore(value: string | null, totalLines: number) {
   return Math.max(0, Math.min(totalLines, Math.trunc(parsed)))
 }
 
-function attachLogMiddlewares(
-  middlewares: {
-    use: (path: string, handler: (req: any, res: any) => void | Promise<void>) => void
-  }
-) {
+function attachLogMiddlewares(middlewares: {
+  use: (
+    path: string,
+    handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>
+  ) => void
+}) {
   middlewares.use('/api/services/log-info', async (req, res) => {
     try {
       const requestUrl = new URL(req.url ?? '', 'http://localhost')
@@ -151,7 +156,9 @@ function attachLogMiddlewares(
       res.end(
         JSON.stringify({
           error:
-            error instanceof Error ? error.message : 'Failed to resolve service log info',
+            error instanceof Error
+              ? error.message
+              : 'Failed to resolve service log info',
         })
       )
     }
@@ -188,7 +195,9 @@ function attachLogMiddlewares(
     } catch (error) {
       res.statusCode = 500
       res.setHeader('Content-Type', 'text/plain; charset=utf-8')
-      res.end(error instanceof Error ? error.message : 'Failed to read log file')
+      res.end(
+        error instanceof Error ? error.message : 'Failed to read log file'
+      )
     }
   })
 
@@ -246,7 +255,8 @@ function attachLogMiddlewares(
       res.setHeader('Content-Type', 'application/json')
       res.end(
         JSON.stringify({
-          error: error instanceof Error ? error.message : 'Failed to read log file',
+          error:
+            error instanceof Error ? error.message : 'Failed to read log file',
         })
       )
     }


### PR DESCRIPTION
## Summary
- surfaces Service Lasso update state on the dashboard, services table, and service detail view
- adds per-service check/download/install action wiring to the runtime update API
- documents the Service Admin update UI contract and restores the ignored logs route/provider needed for clean builds

## Verification
- npm test
- npm run build
- npm run lint

Core issue: service-lasso/service-lasso#128