### PR TITLE
ISS-137: Surface recovery status in Service Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Service update UI contract:
 - service detail actions call `POST /api/updates/check`, `POST /api/services/:serviceId/update/download`, and `POST /api/services/:serviceId/update/install`
 - when `VITE_SERVICE_LASSO_API_BASE_URL` is not set, update actions are visible against the local stub data but do not call a runtime API
 
+Recovery UI contract:
+
+- the dashboard, services table, and service detail page display recovery states from Service Lasso runtime history
+- the stub layer loads recovery state from `GET /api/recovery`
+- the dashboard shows a global recovery message banner when monitor, doctor, restart, or hook events need review
+- service detail exposes a bounded doctor/preflight action that calls `POST /api/services/:serviceId/recovery/doctor`
+- when `VITE_SERVICE_LASSO_API_BASE_URL` is not set, recovery actions are visible against local stub data but do not call a runtime API
+
 ![alt text](public/images/shadcn-admin.png)
 
 [![Sponsored by Clerk](https://img.shields.io/badge/Sponsored%20by-Clerk-5b6ee1?logo=clerk)](https://go.clerk.com/GttUAaK)

--- a/src/components/service-recovery-status.tsx
+++ b/src/components/service-recovery-status.tsx
@@ -1,0 +1,115 @@
+import { ShieldCheck, Stethoscope } from 'lucide-react'
+import { useServiceRecoveryDoctorAction } from '@/lib/service-lasso-dashboard/hooks'
+import type {
+  ServiceRecoveryEvent,
+  ServiceRecoveryHistoryState,
+} from '@/lib/service-lasso-dashboard/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+
+export function getLatestRecoveryEvent(
+  recovery?: ServiceRecoveryHistoryState
+): ServiceRecoveryEvent | null {
+  return recovery?.events[recovery.events.length - 1] ?? null
+}
+
+export function getServiceRecoveryLabel(
+  recovery?: ServiceRecoveryHistoryState
+) {
+  const event = getLatestRecoveryEvent(recovery)
+  if (!event) return 'No recovery'
+
+  if (event.kind === 'monitor') {
+    return event.action === 'healthy' ? 'Monitor healthy' : 'Monitor review'
+  }
+
+  if (event.kind === 'doctor') {
+    return event.blocked ? 'Doctor blocked' : 'Doctor ok'
+  }
+
+  if (event.kind === 'hook') {
+    return event.blocked ? 'Hook blocked' : 'Hook ok'
+  }
+
+  return event.ok === false ? 'Restart failed' : 'Restart ok'
+}
+
+export function getServiceRecoveryDescription(
+  recovery?: ServiceRecoveryHistoryState
+) {
+  const event = getLatestRecoveryEvent(recovery)
+  if (!event) return 'No recovery, doctor, restart, or hook history yet.'
+
+  if (event.kind === 'monitor') {
+    return event.message ?? `Monitor ${event.action ?? 'event'}: ${event.reason ?? 'unknown'}`
+  }
+
+  if (event.kind === 'doctor') {
+    const failed = event.steps?.find((step) => !step.ok)
+    if (failed) {
+      return `${failed.name} ${event.blocked ? 'blocked' : 'reported'} doctor status.`
+    }
+    return `${event.steps?.length ?? 0} doctor step(s) passed.`
+  }
+
+  if (event.kind === 'hook') {
+    return `${event.phase ?? 'Hook'} ${event.blocked ? 'blocked' : 'completed'} with ${event.steps?.length ?? 0} step(s).`
+  }
+
+  return event.message ?? (event.ok === false ? 'Restart failed.' : 'Restart completed.')
+}
+
+export function ServiceRecoveryBadge({
+  recovery,
+}: {
+  recovery?: ServiceRecoveryHistoryState
+}) {
+  const event = getLatestRecoveryEvent(recovery)
+  const needsAttention =
+    (event?.kind === 'monitor' &&
+      event.action !== 'healthy' &&
+      event.reason !== 'healthy') ||
+    event?.blocked === true ||
+    event?.ok === false
+
+  if (!event) {
+    return <Badge variant='outline'>No recovery</Badge>
+  }
+
+  if (needsAttention) {
+    return <Badge variant='destructive'>{getServiceRecoveryLabel(recovery)}</Badge>
+  }
+
+  return (
+    <Badge className='bg-emerald-600 hover:bg-emerald-600'>
+      {getServiceRecoveryLabel(recovery)}
+    </Badge>
+  )
+}
+
+export function ServiceRecoveryDoctorButton({
+  serviceId,
+  disabled,
+}: {
+  serviceId: string
+  disabled?: boolean
+}) {
+  const doctorAction = useServiceRecoveryDoctorAction()
+
+  return (
+    <Button
+      type='button'
+      size='sm'
+      variant='outline'
+      disabled={disabled || doctorAction.isPending}
+      onClick={() => doctorAction.mutate(serviceId)}
+    >
+      {doctorAction.isPending ? (
+        <ShieldCheck className='mr-2 size-4 animate-pulse' />
+      ) : (
+        <Stethoscope className='mr-2 size-4' />
+      )}
+      Run doctor
+    </Button>
+  )
+}

--- a/src/features/dashboard/index.tsx
+++ b/src/features/dashboard/index.tsx
@@ -6,6 +6,7 @@ import {
   PackageOpen,
   Play,
   RefreshCcw,
+  ShieldCheck,
   ShieldAlert,
   Star,
 } from 'lucide-react'
@@ -39,6 +40,10 @@ import {
   getServiceUpdateDescription,
   ServiceUpdateBadge,
 } from '@/components/service-update-status'
+import {
+  getServiceRecoveryDescription,
+  ServiceRecoveryBadge,
+} from '@/components/service-recovery-status'
 import { ThemeSwitch } from '@/components/theme-switch'
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
@@ -144,6 +149,15 @@ function ServiceCard({ service }: { service: DashboardService }) {
           </div>
           <p className='mt-1 text-muted-foreground'>
             {getServiceUpdateDescription(service.updates)}
+          </p>
+        </div>
+        <div className='rounded-md border border-emerald-500/20 bg-emerald-500/5 p-2 text-xs'>
+          <div className='flex items-center justify-between gap-2'>
+            <span className='font-medium'>Recovery</span>
+            <ServiceRecoveryBadge recovery={service.recovery} />
+          </div>
+          <p className='mt-1 text-muted-foreground'>
+            {getServiceRecoveryDescription(service.recovery)}
           </p>
         </div>
         <div className='flex flex-wrap gap-2'>
@@ -296,6 +310,30 @@ export function Dashboard() {
             </CardContent>
           </Card>
         ) : null}
+        {summary.recoveryNotifications.messages.length > 0 ? (
+          <Card className='border-emerald-500/30 bg-emerald-500/5'>
+            <CardHeader className='pb-3'>
+              <CardTitle className='flex items-center gap-2 text-base'>
+                <ShieldCheck className='size-4 text-emerald-600' />
+                Recovery events need review
+              </CardTitle>
+              <CardDescription>
+                These messages come from Service Lasso recovery history and
+                match doctor, monitor, restart, and hook state.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-2 sm:grid-cols-2 lg:grid-cols-4'>
+              {summary.recoveryNotifications.messages.map((message) => (
+                <div
+                  key={message}
+                  className='rounded-lg border bg-background p-3 text-sm'
+                >
+                  {message}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        ) : null}
         <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5'>
           <SummaryCard
             title='Runtime health'
@@ -353,6 +391,17 @@ export function Dashboard() {
             )}
             description={`${summary.updateNotifications.failedCount} failed check(s)`}
             icon={ShieldAlert}
+          />
+          <SummaryCard
+            title='Recovery'
+            value={String(
+              summary.recoveryNotifications.monitorAttentionCount +
+                summary.recoveryNotifications.doctorBlockedCount +
+                summary.recoveryNotifications.hookBlockedCount +
+                summary.recoveryNotifications.restartFailureCount
+            )}
+            description='Monitor, doctor, restart, and hook events needing review'
+            icon={ShieldCheck}
           />
         </div>
         <div className='grid grid-cols-1 gap-4 lg:grid-cols-7'>

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -79,6 +79,11 @@ import {
   ServiceUpdateActions,
   ServiceUpdateBadge,
 } from '@/components/service-update-status'
+import {
+  getServiceRecoveryDescription,
+  ServiceRecoveryBadge,
+  ServiceRecoveryDoctorButton,
+} from '@/components/service-recovery-status'
 import { ThemeSwitch } from '@/components/theme-switch'
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
@@ -818,6 +823,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       <StatusBadge status={service.status} />
                       <HealthBadge health={service.runtimeHealth.health} />
                       <ServiceUpdateBadge updates={service.updates} />
+                      <ServiceRecoveryBadge recovery={service.recovery} />
                     </div>
                     <div>
                       <h2 className='text-2xl font-bold tracking-tight'>
@@ -965,6 +971,26 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                               })
                             }
                           />
+                        </CardContent>
+                      </Card>
+                      <Card>
+                        <CardHeader className='pb-2'>
+                          <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+                            <HeartPulse className='size-4' /> Recovery
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent className='space-y-3 text-sm'>
+                          <div className='flex items-center justify-between gap-3'>
+                            <span className='font-medium'>Status</span>
+                            <ServiceRecoveryBadge recovery={service.recovery} />
+                          </div>
+                          <p className='text-muted-foreground'>
+                            {getServiceRecoveryDescription(service.recovery)}
+                          </p>
+                          <div className='text-xs text-muted-foreground'>
+                            Events: {service.recovery?.events.length ?? 0}
+                          </div>
+                          <ServiceRecoveryDoctorButton serviceId={service.id} />
                         </CardContent>
                       </Card>
                       <Card>

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -15,6 +15,10 @@ import {
   getServiceUpdateDescription,
   ServiceUpdateBadge,
 } from '@/components/service-update-status'
+import {
+  getServiceRecoveryDescription,
+  ServiceRecoveryBadge,
+} from '@/components/service-recovery-status'
 import { DataTableRowActions } from './data-table-row-actions'
 
 function renderStatusBadge(status: DashboardService['status']) {
@@ -120,6 +124,26 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
           <ServiceUpdateBadge updates={service.updates} />
           <span className='line-clamp-2 text-xs text-muted-foreground'>
             {getServiceUpdateDescription(service.updates)}
+          </span>
+        </div>
+      )
+    },
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    id: 'recovery',
+    accessorFn: (row) =>
+      row.recovery?.events[row.recovery.events.length - 1]?.kind ?? 'none',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Recovery' />
+    ),
+    cell: ({ row }) => {
+      const service = row.original
+      return (
+        <div className='flex max-w-[220px] flex-col gap-1'>
+          <ServiceRecoveryBadge recovery={service.recovery} />
+          <span className='line-clamp-2 text-xs text-muted-foreground'>
+            {getServiceRecoveryDescription(service.recovery)}
           </span>
         </div>
       )

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -6,6 +6,7 @@ import {
   fetchDashboardSummary,
   fetchServices,
   runDashboardAction,
+  runServiceRecoveryDoctorAction,
   runServiceUpdateAction,
 } from './stub'
 import type {
@@ -108,6 +109,30 @@ export function useServiceUpdateAction() {
       for (const service of allServices) {
         queryClient.setQueryData([...dashboardQueryKey, service.id], service)
       }
+    },
+  })
+}
+
+export function useServiceRecoveryDoctorAction() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (serviceId: string) => runServiceRecoveryDoctorAction(serviceId),
+    onSuccess: (result) => {
+      const patchService = (service: DashboardService) =>
+        service.id === result.serviceId
+          ? { ...service, recovery: result.recovery }
+          : service
+
+      queryClient.setQueryData<DashboardService[]>(
+        [...dashboardQueryKey, 'services'],
+        (services) => services?.map(patchService)
+      )
+      queryClient.setQueryData<DashboardService | null>(
+        [...dashboardQueryKey, result.serviceId],
+        (service) => (service ? patchService(service) : service)
+      )
+      queryClient.invalidateQueries({ queryKey: dashboardQueryKey })
     },
   })
 }

--- a/src/lib/service-lasso-dashboard/recovery.test.ts
+++ b/src/lib/service-lasso-dashboard/recovery.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+import { applyRemoteRecoveryStates, buildRecoveryNotifications } from './stub'
+import type { DashboardService, ServiceRecoveryHistoryState } from './types'
+
+function recoveryState(
+  serviceId: string,
+  event: ServiceRecoveryHistoryState['events'][number]
+): ServiceRecoveryHistoryState {
+  return {
+    serviceId,
+    updatedAt: event.at,
+    events: [event],
+  }
+}
+
+function service(
+  id: string,
+  recovery: ServiceRecoveryHistoryState
+): DashboardService {
+  return {
+    id,
+    name: id,
+    status: 'running',
+    favorite: false,
+    note: '',
+    links: [],
+    installed: true,
+    role: '',
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '1m',
+      lastCheckAt: '2026-04-27T00:00:00.000Z',
+      summary: 'Healthy',
+    },
+    endpoints: [],
+    metadata: {
+      serviceType: 'test',
+      runtime: 'test',
+      version: '1.0.0',
+      build: 'test',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [],
+    recentLogs: [],
+    actions: [],
+    recovery,
+  }
+}
+
+describe('service recovery notifications', () => {
+  it('summarizes monitor, doctor, hook, and restart events needing attention', () => {
+    const summary = buildRecoveryNotifications([
+      service(
+        'healthy-monitor',
+        recoveryState('healthy-monitor', {
+          kind: 'monitor',
+          serviceId: 'healthy-monitor',
+          action: 'healthy',
+          reason: 'healthy',
+          message: 'Service is healthy.',
+          at: '2026-04-27T00:00:00.000Z',
+        })
+      ),
+      service(
+        'monitor-review',
+        recoveryState('monitor-review', {
+          kind: 'monitor',
+          serviceId: 'monitor-review',
+          action: 'skip',
+          reason: 'unhealthy_threshold',
+          message: 'Threshold not reached.',
+          at: '2026-04-27T00:00:00.000Z',
+        })
+      ),
+      service(
+        'doctor-blocked',
+        recoveryState('doctor-blocked', {
+          kind: 'doctor',
+          serviceId: 'doctor-blocked',
+          ok: false,
+          blocked: true,
+          steps: [],
+          at: '2026-04-27T00:00:00.000Z',
+        })
+      ),
+      service(
+        'hook-blocked',
+        recoveryState('hook-blocked', {
+          kind: 'hook',
+          serviceId: 'hook-blocked',
+          phase: 'postUpgrade',
+          ok: false,
+          blocked: true,
+          steps: [],
+          at: '2026-04-27T00:00:00.000Z',
+        })
+      ),
+      service(
+        'restart-failed',
+        recoveryState('restart-failed', {
+          kind: 'restart',
+          serviceId: 'restart-failed',
+          ok: false,
+          message: 'Readiness failed.',
+          at: '2026-04-27T00:00:00.000Z',
+        })
+      ),
+    ])
+
+    expect(summary.monitorAttentionCount).toBe(1)
+    expect(summary.doctorBlockedCount).toBe(1)
+    expect(summary.hookBlockedCount).toBe(1)
+    expect(summary.restartFailureCount).toBe(1)
+    expect(summary.messages).toContain('1 service monitor event(s) need review.')
+    expect(summary.messages).toContain(
+      '1 doctor/preflight check(s) are blocked.'
+    )
+    expect(summary.messages).toContain('1 lifecycle hook run(s) are blocked.')
+    expect(summary.messages).toContain('1 restart attempt(s) failed readiness.')
+  })
+
+  it('accepts remote recovery state payloads from the Service Lasso API shape', () => {
+    expect(() =>
+      applyRemoteRecoveryStates([
+        {
+          serviceId: 'service-admin',
+          recovery: recoveryState('service-admin', {
+            kind: 'doctor',
+            serviceId: 'service-admin',
+            ok: true,
+            blocked: false,
+            steps: [],
+            at: '2026-04-27T00:00:00.000Z',
+          }),
+        },
+      ])
+    ).not.toThrow()
+  })
+})
+

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -2,6 +2,8 @@ import type {
   DashboardAction,
   DashboardService,
   DashboardSummary,
+  ServiceRecoveryDoctorActionResult,
+  ServiceRecoveryHistoryState,
   ServiceUpdateAction,
   ServiceUpdateState,
 } from './types'
@@ -29,6 +31,11 @@ type RemoteServiceUpdate = {
   update: ServiceUpdateState
 }
 
+type RemoteServiceRecovery = {
+  serviceId: string
+  recovery: ServiceRecoveryHistoryState
+}
+
 function createEmptyUpdateState(serviceId: string): ServiceUpdateState {
   return {
     serviceId,
@@ -48,6 +55,14 @@ function createEmptyUpdateState(serviceId: string): ServiceUpdateState {
     downloadedCandidate: null,
     installDeferred: null,
     failed: null,
+  }
+}
+
+function createEmptyRecoveryState(serviceId: string): ServiceRecoveryHistoryState {
+  return {
+    serviceId,
+    updatedAt: new Date('2026-04-11T10:00:00+10:00').toISOString(),
+    events: [],
   }
 }
 
@@ -79,6 +94,25 @@ async function fetchRemoteUpdateStates(): Promise<
 
     const payload = (await response.json()) as {
       services?: RemoteServiceUpdate[]
+    }
+
+    return payload.services ?? []
+  } catch {
+    return null
+  }
+}
+
+async function fetchRemoteRecoveryStates(): Promise<
+  RemoteServiceRecovery[] | null
+> {
+  if (!serviceLassoApiBaseUrl) return null
+
+  try {
+    const response = await fetch(`${serviceLassoApiBaseUrl}/api/recovery`)
+    if (!response.ok) return null
+
+    const payload = (await response.json()) as {
+      services?: RemoteServiceRecovery[]
     }
 
     return payload.services ?? []
@@ -125,16 +159,36 @@ export function applyRemoteUpdateStates(updateStates: RemoteServiceUpdate[]) {
   }))
 }
 
+export function applyRemoteRecoveryStates(
+  recoveryStates: RemoteServiceRecovery[]
+) {
+  if (recoveryStates.length === 0) return
+
+  const recoveryById = new Map(
+    recoveryStates.map((service) => [service.serviceId, service.recovery])
+  )
+
+  services = services.map((service) => ({
+    ...service,
+    recovery: recoveryById.get(service.id) ?? service.recovery,
+  }))
+}
+
 async function syncRemoteStateFromApi() {
-  const [remoteServiceMeta, remoteUpdateStates] = await Promise.all([
-    fetchRemoteServiceMeta(),
-    fetchRemoteUpdateStates(),
-  ])
+  const [remoteServiceMeta, remoteUpdateStates, remoteRecoveryStates] =
+    await Promise.all([
+      fetchRemoteServiceMeta(),
+      fetchRemoteUpdateStates(),
+      fetchRemoteRecoveryStates(),
+    ])
   if (remoteServiceMeta) {
     applyRemoteServiceMeta(remoteServiceMeta)
   }
   if (remoteUpdateStates) {
     applyRemoteUpdateStates(remoteUpdateStates)
+  }
+  if (remoteRecoveryStates) {
+    applyRemoteRecoveryStates(remoteRecoveryStates)
   }
 }
 
@@ -745,6 +799,99 @@ let services: DashboardService[] = [
   },
 ]
 
+function createDemoRecoveryState(serviceId: string): ServiceRecoveryHistoryState {
+  const base = createEmptyRecoveryState(serviceId)
+  const at = new Date('2026-04-11T10:18:00+10:00').toISOString()
+
+  if (serviceId === 'zitadel') {
+    return {
+      ...base,
+      updatedAt: at,
+      events: [
+        {
+          kind: 'monitor',
+          serviceId,
+          action: 'skip',
+          reason: 'unhealthy_threshold',
+          message: 'Service is unhealthy but has not reached threshold.',
+          at,
+        },
+      ],
+    }
+  }
+
+  if (serviceId === 'dagu') {
+    return {
+      ...base,
+      updatedAt: at,
+      events: [
+        {
+          kind: 'restart',
+          serviceId,
+          ok: false,
+          message: 'Restart readiness check failed.',
+          at,
+        },
+      ],
+    }
+  }
+
+  if (serviceId === 'secrets-broker') {
+    return {
+      ...base,
+      updatedAt: at,
+      events: [
+        {
+          kind: 'hook',
+          serviceId,
+          phase: 'postUpgrade',
+          ok: false,
+          blocked: true,
+          steps: [
+            {
+              phase: 'postUpgrade',
+              name: 'reload-secrets',
+              command: 'node ./hooks/reload-secrets.mjs',
+              ok: false,
+              exitCode: 7,
+              timedOut: false,
+              failurePolicy: 'block',
+              stdout: '',
+              stderr: 'reload failed',
+              startedAt: new Date('2026-04-11T10:17:50+10:00').toISOString(),
+              finishedAt: new Date('2026-04-11T10:17:51+10:00').toISOString(),
+            },
+          ],
+          at,
+        },
+      ],
+    }
+  }
+
+  return {
+    ...base,
+    updatedAt: at,
+    events: [
+      {
+        kind: serviceId === 'service-admin' ? 'doctor' : 'monitor',
+        serviceId,
+        action: serviceId === 'service-admin' ? undefined : 'healthy',
+        reason: serviceId === 'service-admin' ? undefined : 'healthy',
+        ok: serviceId === 'service-admin' ? true : undefined,
+        blocked: serviceId === 'service-admin' ? false : undefined,
+        message: serviceId === 'service-admin' ? undefined : 'Service is healthy.',
+        steps: serviceId === 'service-admin' ? [] : undefined,
+        at,
+      },
+    ],
+  }
+}
+
+services = services.map((service) => ({
+  ...service,
+  recovery: service.recovery ?? createDemoRecoveryState(service.id),
+}))
+
 let runtime = {
   status: 'warning' as const,
   lastReloadedAt: new Date('2026-04-10T19:55:00+10:00').toISOString(),
@@ -767,6 +914,7 @@ function buildWarnings(currentServices: DashboardService[]) {
 
   const updateNotifications = buildUpdateNotifications(currentServices)
   warnings.push(...updateNotifications.messages)
+  warnings.push(...buildRecoveryNotifications(currentServices).messages)
 
   return warnings
 }
@@ -816,9 +964,58 @@ export function buildUpdateNotifications(currentServices: DashboardService[]) {
   }
 }
 
+export function buildRecoveryNotifications(currentServices: DashboardService[]) {
+  const latestEvents = currentServices.flatMap((service) => {
+    const event = service.recovery?.events[
+      service.recovery.events.length - 1
+    ]
+    return event ? [{ service, event }] : []
+  })
+  const monitorAttentionCount = latestEvents.filter(
+    ({ event }) =>
+      event.kind === 'monitor' &&
+      event.action !== 'healthy' &&
+      event.reason !== 'healthy'
+  ).length
+  const doctorBlockedCount = latestEvents.filter(
+    ({ event }) => event.kind === 'doctor' && event.blocked === true
+  ).length
+  const hookBlockedCount = latestEvents.filter(
+    ({ event }) => event.kind === 'hook' && event.blocked === true
+  ).length
+  const restartFailureCount = latestEvents.filter(
+    ({ event }) => event.kind === 'restart' && event.ok === false
+  ).length
+  const messages: string[] = []
+
+  if (monitorAttentionCount > 0) {
+    messages.push(
+      `${monitorAttentionCount} service monitor event(s) need review.`
+    )
+  }
+  if (doctorBlockedCount > 0) {
+    messages.push(`${doctorBlockedCount} doctor/preflight check(s) are blocked.`)
+  }
+  if (hookBlockedCount > 0) {
+    messages.push(`${hookBlockedCount} lifecycle hook run(s) are blocked.`)
+  }
+  if (restartFailureCount > 0) {
+    messages.push(`${restartFailureCount} restart attempt(s) failed readiness.`)
+  }
+
+  return {
+    monitorAttentionCount,
+    doctorBlockedCount,
+    hookBlockedCount,
+    restartFailureCount,
+    messages,
+  }
+}
+
 function buildSummary(): DashboardSummary {
   const warnings = buildWarnings(services)
   const updateNotifications = buildUpdateNotifications(services)
+  const recoveryNotifications = buildRecoveryNotifications(services)
   const favorites = services.filter((service) => service.favorite)
   const others = services.filter((service) => !service.favorite)
 
@@ -848,6 +1045,7 @@ function buildSummary(): DashboardSummary {
       (service) => service.status === 'degraded' || service.status === 'stopped'
     ),
     updateNotifications,
+    recoveryNotifications,
   }
 }
 
@@ -960,6 +1158,63 @@ export async function runServiceUpdateAction(options: {
   }
 
   return structuredClone(buildSummary())
+}
+
+function applyServiceRecoveryState(
+  serviceId: string,
+  recovery: ServiceRecoveryHistoryState
+) {
+  services = services.map((service) =>
+    service.id === serviceId ? { ...service, recovery } : service
+  )
+}
+
+export async function runServiceRecoveryDoctorAction(serviceId: string) {
+  await wait(120)
+
+  if (!serviceLassoApiBaseUrl) {
+    const recovery =
+      services.find((service) => service.id === serviceId)?.recovery ??
+      createEmptyRecoveryState(serviceId)
+    const event = {
+      kind: 'doctor' as const,
+      serviceId,
+      ok: true,
+      blocked: false,
+      steps: [],
+      at: new Date().toISOString(),
+    }
+    const nextRecovery = {
+      ...recovery,
+      updatedAt: event.at,
+      events: [...recovery.events, event],
+    }
+    applyServiceRecoveryState(serviceId, nextRecovery)
+    return structuredClone({
+      serviceId,
+      doctor: { ok: true, blocked: false, steps: [] },
+      recovery: nextRecovery,
+    } satisfies ServiceRecoveryDoctorActionResult)
+  }
+
+  const response = await fetch(
+    `${serviceLassoApiBaseUrl}/api/services/${serviceId}/recovery/doctor`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    }
+  )
+
+  if (!response.ok) {
+    throw new Error(`Doctor check failed for ${serviceId}`)
+  }
+
+  const payload = (await response.json()) as ServiceRecoveryDoctorActionResult
+  applyServiceRecoveryState(serviceId, payload.recovery)
+  return structuredClone(payload)
 }
 
 export function resolveStubServiceLogInfo(

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -134,6 +134,51 @@ export type ServiceUpdateState = {
 
 export type ServiceUpdateAction = 'check' | 'download' | 'install'
 
+export type ServiceRecoveryEventKind = 'monitor' | 'doctor' | 'restart' | 'hook'
+
+export type ServiceRecoveryStepResult = {
+  phase?: string
+  name: string
+  command: string
+  ok: boolean
+  exitCode: number | null
+  timedOut: boolean
+  failurePolicy: string
+  stdout: string
+  stderr: string
+  startedAt: string
+  finishedAt: string
+}
+
+export type ServiceRecoveryEvent = {
+  kind: ServiceRecoveryEventKind
+  serviceId: string
+  action?: 'restart' | 'skip' | 'healthy'
+  reason?: string
+  phase?: string
+  ok?: boolean
+  blocked?: boolean
+  message?: string
+  steps?: ServiceRecoveryStepResult[]
+  at: string
+}
+
+export type ServiceRecoveryHistoryState = {
+  serviceId: string
+  updatedAt: string
+  events: ServiceRecoveryEvent[]
+}
+
+export type ServiceRecoveryDoctorActionResult = {
+  serviceId: string
+  doctor: {
+    ok: boolean
+    blocked: boolean
+    steps: ServiceRecoveryStepResult[]
+  }
+  recovery: ServiceRecoveryHistoryState
+}
+
 export type DashboardService = {
   id: string
   name: string
@@ -152,6 +197,7 @@ export type DashboardService = {
   recentLogs: ServiceLogPreviewEntry[]
   actions: ServiceAction[]
   updates?: ServiceUpdateState
+  recovery?: ServiceRecoveryHistoryState
 }
 
 export type DashboardRuntime = {
@@ -178,6 +224,13 @@ export type DashboardSummary = {
     downloadedCount: number
     deferredCount: number
     failedCount: number
+    messages: string[]
+  }
+  recoveryNotifications: {
+    monitorAttentionCount: number
+    doctorBlockedCount: number
+    hookBlockedCount: number
+    restartFailureCount: number
     messages: string[]
   }
 }


### PR DESCRIPTION
## Summary
- consume Service Lasso recovery history from /api/recovery
- show recovery badges/descriptions in dashboard cards, services table, and service detail
- add service detail manual doctor action using POST /api/services/:id/recovery/doctor
- document the recovery UI contract

## Verification
- npm test (26/26)
- npm run build
- npm run lint (0 errors; warnings only)

Refs service-lasso/service-lasso#137