### PR TITLE
Add Service Admin release checksum artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,19 @@ jobs:
           set -euo pipefail
           cp service.json release-assets/service.json
 
+      - name: Generate release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd release-assets
+            sha256sum \
+              @serviceadmin-win32.zip \
+              @serviceadmin-linux.tar.gz \
+              @serviceadmin-darwin.tar.gz \
+              service.json > SHA256SUMS.txt
+          )
+
       - name: Compute release version
         id: version
         shell: bash
@@ -102,4 +115,5 @@ jobs:
             release-assets/@serviceadmin-linux.tar.gz
             release-assets/@serviceadmin-darwin.tar.gz
             release-assets/service.json
+            release-assets/SHA256SUMS.txt
           generate_release_notes: true

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -8,3 +8,10 @@ Current first-pass direction:
 - package the minimal sample service into a release artifact under `dist/`
 - include `service.json`, runtime payload, and config
 - use the produced artifact as the thing later consumed by the shared harness
+
+Release assets:
+- `@serviceadmin-win32.zip`
+- `@serviceadmin-linux.tar.gz`
+- `@serviceadmin-darwin.tar.gz`
+- `service.json`
+- `SHA256SUMS.txt`

--- a/src/features/logs/provider.runtime.test.ts
+++ b/src/features/logs/provider.runtime.test.ts
@@ -69,11 +69,11 @@ describe('logs provider configured api mode', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      'http://api.test/api/services/log-info?service=@serviceadmin&type=default'
+      'http://api.test/api/services/log-info?service=%40serviceadmin&type=default'
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      'http://api.test/api/logs/read?service=@serviceadmin&type=default&limit=100'
+      'http://api.test/api/logs/read?service=%40serviceadmin&type=default&limit=100'
     )
 
     expect(info.path).toBe('C:\\runtime\\@serviceadmin.log')

--- a/src/features/logs/provider.stub.test.ts
+++ b/src/features/logs/provider.stub.test.ts
@@ -69,11 +69,11 @@ describe('logs provider relative api mode', () => {
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      '/api/services/log-info?service=@serviceadmin&type=default'
+      '/api/services/log-info?service=%40serviceadmin&type=default'
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      '/api/logs/read?service=@serviceadmin&type=default&limit=100'
+      '/api/logs/read?service=%40serviceadmin&type=default&limit=100'
     )
 
     expect(info.path).toBe('C:\\runtime\\@serviceadmin.log')


### PR DESCRIPTION
## Intent
Closes #14 by adding the missing checksum artifact to Service Admin GitHub releases.

## Change
- Generate `SHA256SUMS.txt` during the release aggregation job.
- Upload `SHA256SUMS.txt` with the three platform archives and `service.json`.
- Document the expected release asset set.
- Update stale log-provider test expectations so encoded `@serviceadmin` URLs match current `URLSearchParams` behavior.

## Verification
- `npm test`
- `npm run build`
- `./scripts/package.ps1`
- `$env:SERVICE_LASSO_HARNESS_BIN='C:\projects\service-lasso\service-lasso-harness\service-lasso-harness.exe'; ./scripts/verify.ps1`
- `git diff --check`

## Risk
Low. Runtime packaging behavior is unchanged except for the additional checksum file in releases. The test updates only align assertions with existing encoded URL behavior.