### PR TITLE
test: add service admin unit and UI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,17 @@ jobs:
       - name: Run Prettier check
         run: npm run format:check
 
+      - name: Run unit tests
+        run: npm run test:unit
+
       - name: Build the project
         run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser UI tests
+        run: npm run test:ui
 
       - name: Run service template checks
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,10 @@ jobs:
         shell: bash
         run: npm ci --legacy-peer-deps
 
+      - name: Run unit tests
+        shell: bash
+        run: npm run test:unit
+
       - name: Build app
         shell: bash
         run: npm run build
@@ -61,8 +65,35 @@ jobs:
           name: serviceadmin-${{ matrix.platform }}
           path: ${{ matrix.artifact }}
 
+  browser-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright browser
+        shell: bash
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser UI tests
+        shell: bash
+        run: npm run test:ui
+
   release:
-    needs: build
+    needs:
+      - build
+      - browser-e2e
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 .package/
 output/
+playwright-report/
+test-results/
 verify/service-harness.ci.json
 dist-ssr
 *.local

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,14 @@
 !README.md
 !eslint.config.js
 !postcss.config.js
+!playwright.config.mjs
+!tests
+!.github/
+.github/*
+!.github/workflows/
+.github/workflows/*
+!.github/workflows/ci.yml
+!.github/workflows/release.yml
 
 # Ignore auto generated routeTree.gen.ts
 /src/routeTree.gen.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.4.0",
+        "@playwright/test": "^1.59.1",
         "@tanstack/eslint-plugin-query": "^5.95.2",
         "@tanstack/react-query-devtools": "^5.95.2",
         "@tanstack/react-router-devtools": "^1.166.11",
@@ -2285,6 +2286,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -10681,6 +10698,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "knip": "knip",
     "test": "vitest run",
     "test:unit": "vitest run",
+    "test:ui": "playwright test",
     "test:logs:unit": "vitest run src/features/logs/provider.stub.test.ts src/features/logs/provider.runtime.test.ts",
     "test:logs:e2e": "start-server-and-test \"vite --host 127.0.0.1 --port 4175 --strictPort\" http://127.0.0.1:4175 \"cypress run --config baseUrl=http://127.0.0.1:4175 --spec cypress/e2e/logs/logs-page.cy.js\""
   },
@@ -69,6 +70,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@faker-js/faker": "^10.4.0",
+    "@playwright/test": "^1.59.1",
     "@tanstack/eslint-plugin-query": "^5.95.2",
     "@tanstack/react-query-devtools": "^5.95.2",
     "@tanstack/react-router-devtools": "^1.166.11",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const port = Number(process.env.UI_TEST_PORT ?? 4175)
+
+export default defineConfig({
+  testDir: './tests/ui',
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npx vite --host 127.0.0.1 --port ${port} --strictPort`,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/src/lib/service-graph.test.tsx
+++ b/src/lib/service-graph.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildApiUsageEdge,
+  buildDependencyEdge,
+  buildServiceNodeStyle,
+  categoryNodeColor,
+  getGraphCategory,
+  getServiceNodeImage,
+} from './service-graph'
+import type { DashboardService } from './service-lasso-dashboard/types'
+
+describe('service graph helpers', () => {
+  it.each([
+    ['ui-admin', 'app'],
+    ['node-runtime', 'runtime'],
+    ['core-platform', 'infrastructure'],
+    ['utility-tool', 'utility'],
+    ['identity-provider', 'security'],
+    ['workflow-engine', 'workflow'],
+    ['unknown', 'other'],
+  ] as const)('maps %s to %s', (serviceType, category) => {
+    expect(getGraphCategory(serviceType)).toBe(category)
+  })
+
+  it('provides stable category colors for graph legends', () => {
+    expect(categoryNodeColor('app')).toBe('#0ea5e9')
+    expect(categoryNodeColor('security')).toBe('#d97706')
+    expect(categoryNodeColor('other')).toBe('#6b7280')
+  })
+
+  it('builds selected and unselected node styles for light and dark themes', () => {
+    expect(
+      buildServiceNodeStyle({ selected: true, isDark: false })
+    ).toMatchObject({
+      border: '2px solid #16a34a',
+      background: '#dcfce7',
+    })
+    expect(
+      buildServiceNodeStyle({ selected: false, isDark: true })
+    ).toMatchObject({
+      border: '1px solid #334155',
+      background: '#0f172a',
+    })
+  })
+
+  it('builds dependency and api usage edges with expected direction and labels', () => {
+    expect(
+      buildDependencyEdge({
+        id: 'traefik->serviceadmin',
+        source: 'traefik',
+        target: '@serviceadmin',
+        selected: true,
+        isDark: false,
+      })
+    ).toMatchObject({
+      id: 'traefik->serviceadmin',
+      source: 'traefik',
+      target: '@serviceadmin',
+      label: 'depends_on',
+      animated: true,
+    })
+
+    expect(
+      buildApiUsageEdge({
+        id: 'serviceadmin->ui',
+        source: '@serviceadmin',
+        target: 'ui',
+        isDark: true,
+        label: 'child_of',
+      })
+    ).toMatchObject({
+      id: 'serviceadmin->ui',
+      source: '@serviceadmin',
+      target: 'ui',
+      label: 'child_of',
+      animated: true,
+    })
+  })
+
+  it('resolves public service icon URLs without importing from the public directory', () => {
+    const service = {
+      id: '@serviceadmin',
+      name: 'Service Admin UI',
+      metadata: {},
+    } as DashboardService
+
+    expect(getServiceNodeImage(service, false)).toBe(
+      '/images/services/service-admin.svg'
+    )
+    expect(
+      getServiceNodeImage(
+        {
+          ...service,
+          id: 'zitadel',
+          name: 'ZITADEL',
+        },
+        true
+      )
+    ).toBe('/images/services/zitadel_dark.svg')
+  })
+})

--- a/src/lib/service-graph.tsx
+++ b/src/lib/service-graph.tsx
@@ -11,25 +11,14 @@ import {
 } from 'lucide-react'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 
-const serviceImageModules = import.meta.glob(
-  '../../public/images/services/*.svg',
-  {
-    query: '?url',
-    import: 'default',
-    eager: true,
-  }
-) as Record<string, string>
-
-const serviceImageUrlByName = new Map<string, string>()
-
-for (const [modulePath, assetUrl] of Object.entries(serviceImageModules)) {
-  const filename = modulePath
-    .split('/')
-    .pop()
-    ?.replace(/\.svg$/i, '')
-  if (!filename) continue
-  serviceImageUrlByName.set(filename.toLowerCase(), assetUrl)
-}
+const serviceImageNames = new Set([
+  'dagu',
+  'secrets-broker',
+  'service-admin',
+  'traefik',
+  'zitadel_dark',
+  'zitadel_light',
+])
 
 export type GraphCategory =
   | 'app'
@@ -284,7 +273,7 @@ export function buildApiUsageEdge({
 }
 
 function normalizeServiceAssetName(value: string) {
-  return value.trim().toLowerCase().replace(/\s+/g, '_')
+  return value.trim().toLowerCase().replace(/^@/, '').replace(/\s+/g, '_')
 }
 
 export function getServiceNodeImage(
@@ -295,12 +284,22 @@ export function getServiceNodeImage(
 
   const candidates = [service.name, service.id].flatMap((value) => {
     const normalized = normalizeServiceAssetName(value)
-    return [`${normalized}_${isDark ? 'dark' : 'light'}`, normalized]
+    const hyphenated = normalized.replace(/_/g, '-')
+    return [
+      `${normalized}_${isDark ? 'dark' : 'light'}`,
+      `${hyphenated}_${isDark ? 'dark' : 'light'}`,
+      normalized,
+      hyphenated,
+    ]
   })
 
+  if (service.id === '@serviceadmin') {
+    candidates.unshift('service-admin')
+  }
+
   for (const candidate of candidates) {
-    const match = serviceImageUrlByName.get(candidate)
-    if (match) return match
+    if (serviceImageNames.has(candidate))
+      return `/images/services/${candidate}.svg`
   }
 
   return undefined

--- a/src/lib/service-lasso-dashboard/stub.test.ts
+++ b/src/lib/service-lasso-dashboard/stub.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadStub() {
+  vi.resetModules()
+  return import('./stub')
+}
+
+describe('service lasso dashboard stub', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds a summary from the current service inventory', async () => {
+    const { fetchDashboardSummary } = await loadStub()
+
+    const summary = await fetchDashboardSummary()
+
+    expect(summary.servicesTotal).toBe(5)
+    expect(summary.servicesRunning).toBe(3)
+    expect(summary.servicesStopped).toBe(1)
+    expect(summary.servicesDegraded).toBe(1)
+    expect(summary.installedCount).toBe(5)
+    expect(summary.networkExposureCount).toBe(7)
+    expect(summary.runtime.status).toBe('warning')
+    expect(summary.warnings).toEqual([
+      'One or more services are degraded and need attention.',
+      'At least one managed service is currently stopped.',
+    ])
+    expect(summary.favorites.map((service) => service.id)).toEqual([
+      'traefik',
+      '@serviceadmin',
+    ])
+    expect(summary.problemServices.map((service) => service.id)).toEqual([
+      'zitadel',
+      'dagu',
+    ])
+  })
+
+  it('starts stopped services and refreshes runtime health metadata', async () => {
+    const { fetchDashboardService, runDashboardAction } = await loadStub()
+
+    const before = await fetchDashboardService('dagu')
+    expect(before?.status).toBe('stopped')
+    expect(before?.runtimeHealth.health).toBe('critical')
+
+    const summary = await runDashboardAction('start-services')
+    const after = await fetchDashboardService('dagu')
+
+    expect(after?.status).toBe('running')
+    expect(after?.runtimeHealth.state).toBe('running')
+    expect(after?.runtimeHealth.health).toBe('healthy')
+    expect(after?.runtimeHealth.summary).toBe(
+      'Service was started from the dashboard action.'
+    )
+    expect(after?.recentLogs[0]).toMatchObject({
+      level: 'info',
+      source: 'supervisor',
+      message: 'Service started from dashboard bulk action.',
+    })
+    expect(summary.servicesStopped).toBe(0)
+    expect(summary.problemServices.map((service) => service.id)).toEqual([
+      'zitadel',
+    ])
+  })
+
+  it('toggles favorite state and returns cloned service data', async () => {
+    const { fetchDashboardService, fetchServices, runDashboardAction } =
+      await loadStub()
+
+    const services = await fetchServices()
+    services[0].name = 'mutated by test'
+
+    expect((await fetchDashboardService('traefik'))?.name).toBe('Traefik')
+
+    const summary = await runDashboardAction({
+      kind: 'toggle-favorite',
+      serviceId: 'dagu',
+    })
+
+    expect((await fetchDashboardService('dagu'))?.favorite).toBe(true)
+    expect(summary.favorites.map((service) => service.id)).toContain('dagu')
+  })
+
+  it('resolves stub log metadata for known services only', async () => {
+    const { buildStubServiceLogUrl, resolveStubServiceLogInfo } =
+      await loadStub()
+
+    expect(resolveStubServiceLogInfo('@serviceadmin')).toMatchObject({
+      serviceId: '@serviceadmin',
+      type: 'default',
+      availableTypes: ['default'],
+    })
+    expect(resolveStubServiceLogInfo('missing-service')).toBeNull()
+    expect(buildStubServiceLogUrl('@serviceadmin')).toBe(
+      '/api/logs/content?service=%40serviceadmin&type=default'
+    )
+  })
+})

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+
+test('dashboard renders and starts stopped services', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+  await expect(page.getByText('Runtime health')).toBeVisible()
+  await expect(page.getByText('1 stopped, 1 degraded')).toBeVisible()
+  await expect(page.getByText('3/5')).toBeVisible()
+  await expect(page.getByText('Dagu').first()).toBeVisible()
+  await expect(page.getByText('Stopped').first()).toBeVisible()
+
+  await page.getByRole('button', { name: /start services/i }).click()
+
+  await expect(page.getByText('4/5')).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: /dagu add favorite running/i })
+  ).toBeVisible()
+})
+
+test('services table filters and opens service detail', async ({ page }) => {
+  await page.goto('/services')
+
+  await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible()
+  await page
+    .getByPlaceholder(
+      'Search services and open details from the matching row...'
+    )
+    .fill('Service Admin')
+
+  await expect(page.getByText('Service Admin UI')).toBeVisible()
+  await expect(page.getByText('Traefik')).toHaveCount(0)
+
+  await page.getByRole('link', { name: /details/i }).click()
+  await expect(page).toHaveURL(/\/services\/%40serviceadmin$/)
+  await expect(
+    page.getByRole('heading', { name: 'Service Admin UI' })
+  ).toBeVisible()
+  await expect(
+    page.getByText('Operator dashboard for Service Lasso')
+  ).toBeVisible()
+  await page.getByRole('tab', { name: /variables/i }).click()
+  await expect(page.getByText('VITE_SERVICE_LASSO_API_BASE_URL')).toBeVisible()
+})
+
+test('runtime, network, installed, and variables tables render', async ({
+  page,
+}) => {
+  await page.goto('/runtime')
+  await expect(page.getByRole('heading', { name: 'Runtime' })).toBeVisible()
+  await expect(page.getByText('Runtime status')).toBeVisible()
+  await expect(page.getByText('Service Admin UI')).toBeVisible()
+
+  await page.goto('/network')
+  await expect(page.getByRole('heading', { name: 'Network' })).toBeVisible()
+  await expect(page.getByText('Service endpoints')).toBeVisible()
+  await expect(page.getByText('http://localhost:17700')).toBeVisible()
+
+  await page.goto('/installed')
+  await expect(page.getByRole('heading', { name: 'Installed' })).toBeVisible()
+  await expect(page.getByText('Installed services')).toBeVisible()
+  await expect(
+    page.getByRole('cell', { name: 'lasso-@serviceadmin', exact: true })
+  ).toBeVisible()
+
+  await page.goto('/variables')
+  await expect(page.getByRole('heading', { name: 'Variables' })).toBeVisible()
+  await expect(page.getByText('Environment variables')).toBeVisible()
+  await expect(page.getByText('SERVICE_LASSO_ROOT').first()).toBeVisible()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       globals: true,
+      exclude: ['**/node_modules/**', '**/dist/**', '**/tests/ui/**'],
       setupFiles: './src/test/setup.ts',
     },
   })


### PR DESCRIPTION
Adds Service Admin unit tests for dashboard/service graph behavior and Playwright browser UI tests for the key operator screens.\n\nCI/release changes:\n- PR CI now runs unit tests and browser UI tests.\n- Release now runs unit tests in the package matrix and browser UI tests before publishing.\n\nLocal validation:\n- npm run test:unit\n- npm run test:ui\n- npm run format:check\n- npm run lint\n- npm run build\n- ./scripts/test.ps1\n- ./scripts/package.ps1