### PR TITLE
Fix live runtime dashboard status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ Example:
 
 Current UI runtime behavior:
 
-- if `VITE_SERVICE_LASSO_API_BASE_URL` is set, the dashboard stub layer can call the Service Lasso API for service metadata
+- if `VITE_SERVICE_LASSO_API_BASE_URL` is set, dashboard service status, health, runtime actions, and logs are read from the live Service Lasso runtime API
+- if `VITE_SERVICE_LASSO_API_BASE_URL` is missing, the UI uses local demo stub data for development preview only
+- a configured but unavailable runtime API is treated as an error instead of falling back to demo status
 - favorites editing is only enabled when `VITE_SERVICE_LASSO_FAVORITES_ENABLED=true`
 - favorites are expected to load from `GET /api/services/meta`
 - favorites are expected to update through `PATCH /api/services/:serviceId/meta`
+- service status is expected to load from `GET /api/dashboard` and `GET /api/dashboard/services`
+- bulk start is expected to call `POST /api/runtime/actions/startAll`
+- reload is expected to call `POST /api/runtime/actions/reload`
 - set `VITE_SERVICE_LASSO_LOGS_DEBUG=true` to enable Logs screen debug output in the browser console outside dev mode
 - if the endpoint env var is missing or the favorites flag is not enabled, favorite controls stay visible but disabled
 

--- a/src/features/logs/provider.runtime.test.ts
+++ b/src/features/logs/provider.runtime.test.ts
@@ -103,4 +103,89 @@ describe('logs provider configured api mode', () => {
       fetchServiceLogChunk(service as never, 'default')
     ).rejects.toThrow('Live logs are unavailable right now.')
   })
+
+  it('reads runtime logs for Traefik, Service Admin, and Service Broker', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: 'http://api.test',
+    }))
+
+    const serviceLogs = new Map<string, string[]>([
+      [
+        '@traefik',
+        [
+          '2026-04-16T16:00:01.001Z INFO traefik Traefik bootstrap starting',
+          '2026-04-16T16:00:01.214Z INFO traefik Loading dynamic configuration providers',
+          '2026-04-16T16:00:01.602Z INFO traefik EntryPoints web, websecure configured',
+          '2026-04-16T16:00:02.031Z INFO traefik Waiting for first routed requests',
+        ],
+      ],
+      [
+        '@serviceadmin',
+        ['2026-04-16T16:00:02.400Z INFO serviceadmin UI started'],
+      ],
+      [
+        'service-broker',
+        ['2026-04-16T16:00:02.800Z INFO service-broker API started'],
+      ],
+    ])
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url)
+        const serviceId = parsed.searchParams.get('service') ?? ''
+        const lines = serviceLogs.get(serviceId) ?? []
+
+        if (parsed.pathname === '/api/services/log-info') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type: 'default',
+              path: `C:\\runtime\\${serviceId}.log`,
+              availableTypes: ['default'],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/logs/read') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type: 'default',
+              path: `C:\\runtime\\${serviceId}.log`,
+              totalLines: lines.length,
+              start: 0,
+              end: lines.length,
+              hasMore: false,
+              nextBefore: 0,
+              limit: 100,
+              lines,
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        return new Response('not found', { status: 404 })
+      })
+    )
+
+    const { fetchServiceLogChunk, fetchServiceLogInfo } =
+      await import('./provider')
+
+    for (const serviceId of serviceLogs.keys()) {
+      const logService = { id: serviceId, metadata: {} }
+      const info = await fetchServiceLogInfo(logService as never, 'default')
+      const chunk = await fetchServiceLogChunk(logService as never, 'default')
+
+      expect(info.path).toBe(`C:\\runtime\\${serviceId}.log`)
+      expect(chunk.lines).toEqual(serviceLogs.get(serviceId))
+    }
+  })
 })

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  DashboardService,
+  DashboardSummary,
+  ServiceStatus,
+} from './types'
+
+function service(
+  id: string,
+  name: string,
+  status: ServiceStatus,
+  recentLogs: string[] = []
+): DashboardService {
+  return {
+    id,
+    name,
+    status,
+    favorite: id === '@traefik' || id === '@serviceadmin',
+    role: `${name} role`,
+    note:
+      status === 'running'
+        ? `${name} is verified by the runtime API.`
+        : `${name} is not running.`,
+    installed: true,
+    links: [{ label: 'Local', url: 'http://127.0.0.1', kind: 'local' }],
+    runtimeHealth: {
+      state: status,
+      health: status === 'running' ? 'healthy' : 'critical',
+      uptime: status === 'running' ? '3m' : '0m',
+      lastCheckAt: '2026-04-16T16:00:03.000Z',
+      lastRestartAt:
+        status === 'running' ? '2026-04-16T16:00:00.000Z' : undefined,
+      summary:
+        status === 'running'
+          ? `${name} process and health check are up.`
+          : `${name} process is stopped.`,
+    },
+    endpoints: [
+      {
+        label: 'Local',
+        url: 'http://127.0.0.1',
+        bind: '127.0.0.1',
+        port: 8080,
+        protocol: 'http',
+        exposure: 'local',
+      },
+    ],
+    metadata: {
+      serviceType: 'core',
+      runtime: 'service-lasso',
+      version: '2026.4.16-test',
+      build: 'test-build',
+      logPath: `C:\\runtime\\${id}.log`,
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [
+      {
+        key: 'SERVICE_LASSO_ROOT',
+        value: 'C:\\service-lasso',
+        scope: 'global',
+        source: '.env',
+      },
+    ],
+    recentLogs: recentLogs.map((message) => ({
+      timestamp: '2026-04-16T16:00:01.001Z',
+      level: 'info',
+      source: 'app',
+      message,
+    })),
+    actions: [
+      { id: 'start', label: 'Start', kind: 'start' },
+      { id: 'stop', label: 'Stop', kind: 'stop' },
+      { id: 'open_logs', label: 'Open logs', kind: 'open_logs' },
+    ],
+  }
+}
+
+function summary(services: DashboardService[]): DashboardSummary {
+  const favorites = services.filter((item) => item.favorite)
+  const others = services.filter((item) => !item.favorite)
+  const problemServices = services.filter((item) => item.status !== 'running')
+
+  return {
+    runtime: {
+      status: problemServices.length === 0 ? 'healthy' : 'warning',
+      lastReloadedAt: '2026-04-16T16:00:03.000Z',
+      warningCount: problemServices.length,
+    },
+    servicesTotal: services.length,
+    servicesRunning: services.filter((item) => item.status === 'running')
+      .length,
+    servicesStopped: services.filter((item) => item.status === 'stopped')
+      .length,
+    servicesDegraded: services.filter((item) => item.status === 'degraded')
+      .length,
+    networkExposureCount: services.length,
+    installedCount: services.length,
+    favorites,
+    others,
+    warnings: problemServices.map((item) => `${item.name} is not healthy.`),
+    problemServices,
+  }
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('service lasso dashboard runtime client', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses live runtime dashboard status instead of stub service status', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const services = [
+      service('@traefik', 'Traefik', 'stopped', [
+        'Traefik process is not currently running.',
+      ]),
+      service('@serviceadmin', 'Service Admin', 'running', [
+        'Service Admin UI process is serving requests.',
+      ]),
+      service('service-broker', 'Service Broker', 'running', [
+        'Service Broker API process is accepting requests.',
+      ]),
+    ]
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'http://runtime.test/api/dashboard') {
+        return jsonResponse({ summary: summary(services) })
+      }
+
+      if (url === 'http://runtime.test/api/dashboard/services') {
+        return jsonResponse({ services })
+      }
+
+      if (
+        url === 'http://runtime.test/api/dashboard/services/%40traefik'
+      ) {
+        return jsonResponse({ service: services[0] })
+      }
+
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const {
+      buildServiceLogUrl,
+      fetchDashboardService,
+      fetchDashboardSummary,
+      fetchServices,
+    } = await import('./client')
+
+    const runtimeSummary = await fetchDashboardSummary()
+    const runtimeServices = await fetchServices()
+    const traefik = await fetchDashboardService('@traefik')
+
+    expect(runtimeSummary.servicesRunning).toBe(2)
+    expect(runtimeSummary.servicesStopped).toBe(1)
+    expect(runtimeSummary.problemServices.map((item) => item.id)).toEqual([
+      '@traefik',
+    ])
+    expect(runtimeServices.map((item) => [item.id, item.status])).toEqual([
+      ['@traefik', 'stopped'],
+      ['@serviceadmin', 'running'],
+      ['service-broker', 'running'],
+    ])
+    expect(traefik?.runtimeHealth.health).toBe('critical')
+    expect(buildServiceLogUrl('@traefik')).toBe(
+      'http://runtime.test/api/logs/read?service=%40traefik&type=default'
+    )
+  })
+
+  it('runs bulk start through the runtime action API before refreshing dashboard status', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const stoppedServices = [
+      service('@traefik', 'Traefik', 'stopped'),
+      service('@serviceadmin', 'Service Admin', 'running'),
+      service('service-broker', 'Service Broker', 'running'),
+    ]
+    const runningServices = stoppedServices.map((item) => ({
+      ...item,
+      status: 'running' as const,
+      runtimeHealth: {
+        ...item.runtimeHealth,
+        state: 'running' as const,
+        health: 'healthy' as const,
+      },
+    }))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'startAll',
+          ok: true,
+          results: [],
+          skipped: [],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ summary: summary(runningServices) }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { runDashboardAction } = await import('./client')
+
+    const runtimeSummary = await runDashboardAction('start-services')
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://runtime.test/api/runtime/actions/startAll',
+      { method: 'POST' }
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://runtime.test/api/dashboard',
+      undefined
+    )
+    expect(runtimeSummary.servicesRunning).toBe(3)
+    expect(runtimeSummary.problemServices).toEqual([])
+  })
+})

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type {
-  DashboardService,
-  DashboardSummary,
-  ServiceStatus,
-} from './types'
+import type { DashboardService, DashboardSummary, ServiceStatus } from './types'
 
 function service(
   id: string,
@@ -141,9 +137,7 @@ describe('service lasso dashboard runtime client', () => {
         return jsonResponse({ services })
       }
 
-      if (
-        url === 'http://runtime.test/api/dashboard/services/%40traefik'
-      ) {
+      if (url === 'http://runtime.test/api/dashboard/services/%40traefik') {
         return jsonResponse({ service: services[0] })
       }
 
@@ -207,7 +201,9 @@ describe('service lasso dashboard runtime client', () => {
           skipped: [],
         })
       )
-      .mockResolvedValueOnce(jsonResponse({ summary: summary(runningServices) }))
+      .mockResolvedValueOnce(
+        jsonResponse({ summary: summary(runningServices) })
+      )
 
     vi.stubGlobal('fetch', fetchMock)
 

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -56,9 +56,8 @@ function hasRuntimeApi() {
 }
 
 async function fetchRuntimeDashboardSummary() {
-  const payload = await fetchRuntimeJson<DashboardSummaryResponse>(
-    '/api/dashboard'
-  )
+  const payload =
+    await fetchRuntimeJson<DashboardSummaryResponse>('/api/dashboard')
   return payload.summary
 }
 

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -1,0 +1,158 @@
+import {
+  buildStubServiceLogUrl,
+  fetchDashboardService as fetchStubDashboardService,
+  fetchDashboardSummary as fetchStubDashboardSummary,
+  fetchServices as fetchStubServices,
+  runDashboardAction as runStubDashboardAction,
+  serviceLassoApiBaseUrl,
+} from './stub'
+import type {
+  DashboardAction,
+  DashboardService,
+  DashboardSummary,
+} from './types'
+
+type DashboardSummaryResponse = {
+  summary: DashboardSummary
+}
+
+type DashboardServicesResponse = {
+  services: DashboardService[]
+}
+
+type DashboardServiceDetailResponse = {
+  service: DashboardService
+}
+
+function encodeServiceId(serviceId: string) {
+  return encodeURIComponent(serviceId)
+}
+
+function buildApiUrl(pathname: string) {
+  if (!serviceLassoApiBaseUrl) {
+    throw new Error('Service Lasso API base URL is not configured.')
+  }
+
+  return `${serviceLassoApiBaseUrl}${pathname}`
+}
+
+async function fetchRuntimeJson<T>(pathname: string, init?: RequestInit) {
+  const response = await fetch(buildApiUrl(pathname), init)
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (!response.ok) {
+    throw new Error(`Service Lasso runtime API returned ${response.status}.`)
+  }
+
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new Error('Service Lasso runtime API returned non-JSON content.')
+  }
+
+  return (await response.json()) as T
+}
+
+function hasRuntimeApi() {
+  return Boolean(serviceLassoApiBaseUrl)
+}
+
+async function fetchRuntimeDashboardSummary() {
+  const payload = await fetchRuntimeJson<DashboardSummaryResponse>(
+    '/api/dashboard'
+  )
+  return payload.summary
+}
+
+async function fetchRuntimeServices() {
+  const payload = await fetchRuntimeJson<DashboardServicesResponse>(
+    '/api/dashboard/services'
+  )
+  return payload.services
+}
+
+async function fetchRuntimeDashboardService(serviceId: string) {
+  const payload = await fetchRuntimeJson<DashboardServiceDetailResponse>(
+    `/api/dashboard/services/${encodeServiceId(serviceId)}`
+  )
+  return payload.service ?? null
+}
+
+async function updateRuntimeFavorite(serviceId: string) {
+  const service = await fetchRuntimeDashboardService(serviceId)
+  if (!service) {
+    throw new Error(`Service ${serviceId} was not found by the runtime API.`)
+  }
+
+  await fetchRuntimeJson(`/api/services/${encodeServiceId(serviceId)}/meta`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ favorite: !service.favorite }),
+  })
+
+  return fetchRuntimeDashboardSummary()
+}
+
+async function runRuntimeDashboardAction(action: DashboardAction) {
+  if (action === 'reload-runtime') {
+    await fetchRuntimeJson('/api/runtime/actions/reload', { method: 'POST' })
+    return fetchRuntimeDashboardSummary()
+  }
+
+  if (action === 'start-services') {
+    await fetchRuntimeJson('/api/runtime/actions/startAll', { method: 'POST' })
+    return fetchRuntimeDashboardSummary()
+  }
+
+  return updateRuntimeFavorite(action.serviceId)
+}
+
+export async function fetchDashboardSummary() {
+  if (!hasRuntimeApi()) {
+    return fetchStubDashboardSummary()
+  }
+
+  return fetchRuntimeDashboardSummary()
+}
+
+export async function fetchServices() {
+  if (!hasRuntimeApi()) {
+    return fetchStubServices()
+  }
+
+  return fetchRuntimeServices()
+}
+
+export async function fetchDashboardService(serviceId: string) {
+  if (!hasRuntimeApi()) {
+    return fetchStubDashboardService(serviceId)
+  }
+
+  return fetchRuntimeDashboardService(serviceId)
+}
+
+export function buildServiceLogUrl(
+  serviceId: string,
+  options?: {
+    type?: 'default' | 'access' | 'error'
+  }
+) {
+  if (!hasRuntimeApi()) {
+    return buildStubServiceLogUrl(serviceId, options)
+  }
+
+  const params = new URLSearchParams({
+    service: serviceId,
+    type: options?.type ?? 'default',
+  })
+
+  return buildApiUrl(`/api/logs/read?${params.toString()}`)
+}
+
+export async function runDashboardAction(action: DashboardAction) {
+  if (!hasRuntimeApi()) {
+    return runStubDashboardAction(action)
+  }
+
+  return runRuntimeDashboardAction(action)
+}

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  buildStubServiceLogUrl,
-  favoritesMutationEnabled,
+  buildServiceLogUrl,
   fetchDashboardService,
   fetchDashboardSummary,
   fetchServices,
   runDashboardAction,
-} from './stub'
+} from './client'
+import { favoritesMutationEnabled } from './stub'
 import type { DashboardAction, DashboardService } from './types'
 
 const dashboardQueryKey = ['service-lasso-dashboard']
@@ -38,7 +38,7 @@ export function getServiceLogStubUrl(
     type?: 'default' | 'access' | 'error'
   }
 ) {
-  return buildStubServiceLogUrl(serviceId, options)
+  return buildServiceLogUrl(serviceId, options)
 }
 
 export function useDashboardAction() {


### PR DESCRIPTION
## Summary
- route Service Admin dashboard data through the live Service Lasso runtime API when VITE_SERVICE_LASSO_API_BASE_URL is configured
- keep demo stub data only for no-API local preview and avoid silent fallback from broken API to fake running status
- add runtime-status and log contract tests for Traefik, Service Admin, and Service Broker

## Validation
- npm exec -- vitest run src/lib/service-lasso-dashboard/client.test.ts src/features/logs/provider.runtime.test.ts
- npm run build
- npm test
- npm run test:ui