### PR TITLE
Add services page lifecycle controls

### DIFF
--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -1,9 +1,17 @@
 /* eslint-disable react-refresh/only-export-components */
 import { Link } from '@tanstack/react-router'
 import { type ColumnDef } from '@tanstack/react-table'
-import { ExternalLink, Search, Star } from 'lucide-react'
+import {
+  ExternalLink,
+  Play,
+  RotateCcw,
+  Search,
+  Square,
+  Star,
+} from 'lucide-react'
 import {
   useFavoriteFeatureState,
+  useDashboardAction,
   useToggleFavorite,
 } from '@/lib/service-lasso-dashboard/hooks'
 import { type DashboardService } from '@/lib/service-lasso-dashboard/types'
@@ -54,6 +62,69 @@ function FavoriteCell({ service }: { service: DashboardService }) {
         className={`size-4 ${service.favorite ? 'fill-amber-500 text-amber-500' : 'text-muted-foreground'}`}
       />
     </button>
+  )
+}
+
+function ServiceLifecycleControls({ service }: { service: DashboardService }) {
+  const actionMutation = useDashboardAction()
+  const disabled = actionMutation.isPending
+
+  const runAction = (action: 'start' | 'stop' | 'restart') => {
+    actionMutation.mutate({
+      kind: 'service-lifecycle',
+      serviceId: service.id,
+      action,
+    })
+  }
+
+  return (
+    <div className='flex items-center gap-1'>
+      <Button
+        type='button'
+        size='icon'
+        variant='outline'
+        className='size-8'
+        aria-label={`Start ${service.name}`}
+        title={`Start ${service.name}`}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation()
+          runAction('start')
+        }}
+      >
+        <Play className='size-3.5' />
+      </Button>
+      <Button
+        type='button'
+        size='icon'
+        variant='outline'
+        className='size-8'
+        aria-label={`Stop ${service.name}`}
+        title={`Stop ${service.name}`}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation()
+          runAction('stop')
+        }}
+      >
+        <Square className='size-3.5' />
+      </Button>
+      <Button
+        type='button'
+        size='icon'
+        variant='outline'
+        className='size-8'
+        aria-label={`Restart ${service.name}`}
+        title={`Restart ${service.name}`}
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation()
+          runAction('restart')
+        }}
+      >
+        <RotateCcw className='size-3.5' />
+      </Button>
+    </div>
   )
 }
 
@@ -146,6 +217,13 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
       )
     },
     enableSorting: false,
+  },
+  {
+    id: 'controls',
+    header: 'Controls',
+    cell: ({ row }) => <ServiceLifecycleControls service={row.original} />,
+    enableSorting: false,
+    enableHiding: false,
   },
   {
     id: 'open',

--- a/src/features/services/index.tsx
+++ b/src/features/services/index.tsx
@@ -1,6 +1,11 @@
 import { getRouteApi } from '@tanstack/react-router'
+import { Play, RotateCcw, Square } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
-import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import {
+  useDashboardAction,
+  useServices,
+} from '@/lib/service-lasso-dashboard/hooks'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ConfigDrawer } from '@/components/config-drawer'
@@ -36,8 +41,10 @@ export function Services() {
   const search = route.useSearch()
   const navigate = route.useNavigate()
   const servicesQuery = useServices()
+  const actionMutation = useDashboardAction()
 
   const services = servicesQuery.data ?? []
+  const actionsDisabled = actionMutation.isPending || services.length === 0
 
   return (
     <>
@@ -58,6 +65,37 @@ export function Services() {
               Manage Service Lasso services, inspect runtime state, and open the
               detail view from the table below.
             </p>
+          </div>
+          <div className='flex flex-wrap items-center gap-2'>
+            <Button
+              type='button'
+              size='sm'
+              disabled={actionsDisabled}
+              onClick={() => actionMutation.mutate('start-services')}
+            >
+              <Play className='size-3.5' />
+              Start all
+            </Button>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              disabled={actionsDisabled}
+              onClick={() => actionMutation.mutate('stop-services')}
+            >
+              <Square className='size-3.5' />
+              Stop all
+            </Button>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              disabled={actionsDisabled}
+              onClick={() => actionMutation.mutate('restart-services')}
+            >
+              <RotateCcw className='size-3.5' />
+              Restart all
+            </Button>
           </div>
         </div>
 

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -224,4 +224,119 @@ describe('service lasso dashboard runtime client', () => {
     expect(runtimeSummary.servicesRunning).toBe(3)
     expect(runtimeSummary.problemServices).toEqual([])
   })
+
+  it('runs stop-all and restart-all through runtime orchestration endpoints', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const runningServices = [
+      service('@traefik', 'Traefik', 'running'),
+      service('@serviceadmin', 'Service Admin', 'running'),
+      service('service-broker', 'Service Broker', 'running'),
+    ]
+    const stoppedServices = runningServices.map((item) => ({
+      ...item,
+      status: 'stopped' as const,
+      runtimeHealth: {
+        ...item.runtimeHealth,
+        state: 'stopped' as const,
+        health: 'critical' as const,
+      },
+    }))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'stopAll',
+          ok: true,
+          results: [],
+          skipped: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ summary: summary(stoppedServices) })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'stopAll',
+          ok: true,
+          results: [],
+          skipped: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'startAll',
+          ok: true,
+          results: [],
+          skipped: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ summary: summary(runningServices) })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { runDashboardAction } = await import('./client')
+
+    const stoppedSummary = await runDashboardAction('stop-services')
+    const restartedSummary = await runDashboardAction('restart-services')
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://runtime.test/api/runtime/actions/stopAll',
+      { method: 'POST' }
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://runtime.test/api/runtime/actions/stopAll',
+      { method: 'POST' }
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      'http://runtime.test/api/runtime/actions/startAll',
+      { method: 'POST' }
+    )
+    expect(stoppedSummary.servicesStopped).toBe(3)
+    expect(restartedSummary.servicesRunning).toBe(3)
+  })
+
+  it('runs per-service lifecycle actions through service runtime endpoints', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const services = [
+      service('@traefik', 'Traefik', 'running'),
+      service('@serviceadmin', 'Service Admin', 'running'),
+      service('service-broker', 'Service Broker', 'running'),
+    ]
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'restart',
+          serviceId: '@traefik',
+          ok: true,
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ summary: summary(services) }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { runDashboardAction } = await import('./client')
+
+    const runtimeSummary = await runDashboardAction({
+      kind: 'service-lifecycle',
+      serviceId: '@traefik',
+      action: 'restart',
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://runtime.test/api/services/%40traefik/restart',
+      { method: 'POST' }
+    )
+    expect(runtimeSummary.servicesRunning).toBe(3)
+  })
 })

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -103,6 +103,25 @@ async function runRuntimeDashboardAction(action: DashboardAction) {
     return fetchRuntimeDashboardSummary()
   }
 
+  if (action === 'stop-services') {
+    await fetchRuntimeJson('/api/runtime/actions/stopAll', { method: 'POST' })
+    return fetchRuntimeDashboardSummary()
+  }
+
+  if (action === 'restart-services') {
+    await fetchRuntimeJson('/api/runtime/actions/stopAll', { method: 'POST' })
+    await fetchRuntimeJson('/api/runtime/actions/startAll', { method: 'POST' })
+    return fetchRuntimeDashboardSummary()
+  }
+
+  if (action.kind === 'service-lifecycle') {
+    await fetchRuntimeJson(
+      `/api/services/${encodeServiceId(action.serviceId)}/${action.action}`,
+      { method: 'POST' }
+    )
+    return fetchRuntimeDashboardSummary()
+  }
+
   return updateRuntimeFavorite(action.serviceId)
 }
 

--- a/src/lib/service-lasso-dashboard/stub.test.ts
+++ b/src/lib/service-lasso-dashboard/stub.test.ts
@@ -63,6 +63,44 @@ describe('service lasso dashboard stub', () => {
     ])
   })
 
+  it('stops and restarts services from dashboard actions', async () => {
+    const { fetchDashboardService, runDashboardAction } = await loadStub()
+
+    const stoppedSummary = await runDashboardAction('stop-services')
+
+    expect(stoppedSummary.servicesStopped).toBe(5)
+    expect((await fetchDashboardService('traefik'))?.status).toBe('stopped')
+
+    const restartedSummary = await runDashboardAction('restart-services')
+
+    expect(restartedSummary.servicesRunning).toBe(5)
+    expect((await fetchDashboardService('traefik'))?.status).toBe('running')
+  })
+
+  it('runs per-service lifecycle actions from services table controls', async () => {
+    const { fetchDashboardService, runDashboardAction } = await loadStub()
+
+    await runDashboardAction({
+      kind: 'service-lifecycle',
+      serviceId: '@serviceadmin',
+      action: 'stop',
+    })
+
+    expect((await fetchDashboardService('@serviceadmin'))?.status).toBe(
+      'stopped'
+    )
+
+    await runDashboardAction({
+      kind: 'service-lifecycle',
+      serviceId: '@serviceadmin',
+      action: 'restart',
+    })
+
+    expect((await fetchDashboardService('@serviceadmin'))?.status).toBe(
+      'running'
+    )
+  })
+
   it('toggles favorite state and returns cloned service data', async () => {
     const { fetchDashboardService, fetchServices, runDashboardAction } =
       await loadStub()

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -770,6 +770,91 @@ export async function runDashboardAction(action: DashboardAction) {
 
       return service
     })
+  } else if (action === 'stop-services') {
+    services = services.map((service) => ({
+      ...service,
+      status: 'stopped',
+      note: 'Service was stopped from the dashboard action.',
+      runtimeHealth: {
+        ...service.runtimeHealth,
+        state: 'stopped',
+        health: 'critical',
+        uptime: '0m',
+        lastCheckAt: new Date().toISOString(),
+        summary: 'Service was stopped from the dashboard action.',
+      },
+      recentLogs: [
+        {
+          timestamp: new Date().toISOString(),
+          level: 'info' as const,
+          source: 'supervisor' as const,
+          message: 'Service stopped from dashboard bulk action.',
+        },
+        ...service.recentLogs,
+      ].slice(0, 5),
+    }))
+  } else if (action === 'restart-services') {
+    services = services.map((service) => ({
+      ...service,
+      status: 'running',
+      note: 'Service was restarted from the dashboard action.',
+      runtimeHealth: {
+        ...service.runtimeHealth,
+        state: 'running',
+        health: 'healthy',
+        uptime: '0m',
+        lastCheckAt: new Date().toISOString(),
+        lastRestartAt: new Date().toISOString(),
+        summary: 'Service was restarted from the dashboard action.',
+      },
+      recentLogs: [
+        {
+          timestamp: new Date().toISOString(),
+          level: 'info' as const,
+          source: 'supervisor' as const,
+          message: 'Service restarted from dashboard bulk action.',
+        },
+        ...service.recentLogs,
+      ].slice(0, 5),
+    }))
+  } else if (action.kind === 'service-lifecycle') {
+    services = services.map((service) => {
+      if (service.id !== action.serviceId) return service
+
+      const nextStatus = action.action === 'stop' ? 'stopped' : 'running'
+      const actionLabel = {
+        restart: 'restarted',
+        start: 'started',
+        stop: 'stopped',
+      }[action.action]
+
+      return {
+        ...service,
+        status: nextStatus,
+        note: `Service was ${actionLabel} from the services table.`,
+        runtimeHealth: {
+          ...service.runtimeHealth,
+          state: nextStatus,
+          health: nextStatus === 'running' ? 'healthy' : 'critical',
+          uptime: nextStatus === 'running' ? '0m' : '0m',
+          lastCheckAt: new Date().toISOString(),
+          lastRestartAt:
+            action.action === 'stop'
+              ? service.runtimeHealth.lastRestartAt
+              : new Date().toISOString(),
+          summary: `Service was ${actionLabel} from the services table.`,
+        },
+        recentLogs: [
+          {
+            timestamp: new Date().toISOString(),
+            level: 'info' as const,
+            source: 'supervisor' as const,
+            message: `Service ${action.action} requested from services table.`,
+          },
+          ...service.recentLogs,
+        ].slice(0, 5),
+      }
+    })
   } else {
     const service = services.find((item) => item.id === action.serviceId)
     const nextFavorite = service ? !service.favorite : true

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -119,4 +119,11 @@ export type DashboardSummary = {
 export type DashboardAction =
   | 'reload-runtime'
   | 'start-services'
+  | 'stop-services'
+  | 'restart-services'
   | { kind: 'toggle-favorite'; serviceId: string }
+  | {
+      kind: 'service-lifecycle'
+      serviceId: string
+      action: 'start' | 'stop' | 'restart'
+    }

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -22,6 +22,25 @@ test('services table filters and opens service detail', async ({ page }) => {
   await page.goto('/services')
 
   await expect(page.getByRole('heading', { name: 'Services' })).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Start all', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Stop all', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Restart all', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Start Traefik', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Stop Traefik', exact: true })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Restart Traefik', exact: true })
+  ).toBeVisible()
+
   await page
     .getByPlaceholder(
       'Search services and open details from the matching row...'


### PR DESCRIPTION
## Summary
- add per-service start, stop, and restart buttons to the Services table
- add Start all, Stop all, and Restart all controls beside the Services page title
- wire actions to live Service Lasso runtime endpoints with stub behavior for local preview

## Validation
- npm exec -- vitest run src/lib/service-lasso-dashboard/client.test.ts src/lib/service-lasso-dashboard/stub.test.ts
- npm run test:ui
- npm run lint
- npm run format:check
- npm run build
- npm test