### PR TITLE
Style and wire lifecycle actions

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -32,7 +32,11 @@ import {
   buildServiceNodeStyle,
   getServiceNodeImage,
 } from '@/lib/service-graph'
-import { useDashboardService } from '@/lib/service-lasso-dashboard/hooks'
+import { lifecycleActionButtonClass } from '@/lib/service-lasso-dashboard/action-styles'
+import {
+  useDashboardAction,
+  useDashboardService,
+} from '@/lib/service-lasso-dashboard/hooks'
 import { serviceLassoApiBaseUrl } from '@/lib/service-lasso-dashboard/stub'
 import type {
   DashboardService,
@@ -636,7 +640,14 @@ function EnvironmentTable({
   )
 }
 
-function renderActionButton(action: ServiceAction, service: DashboardService) {
+function ServiceActionButton({
+  action,
+  service,
+}: {
+  action: ServiceAction
+  service: DashboardService
+}) {
+  const actionMutation = useDashboardAction()
   const key = action.id
 
   if (action.kind === 'open_logs') {
@@ -670,6 +681,33 @@ function renderActionButton(action: ServiceAction, service: DashboardService) {
         <a href={adminTarget ?? '#'} target='_blank' rel='noreferrer'>
           {action.label}
         </a>
+      </Button>
+    )
+  }
+
+  if (
+    action.kind === 'start' ||
+    action.kind === 'stop' ||
+    action.kind === 'restart'
+  ) {
+    const lifecycleAction = action.kind
+
+    return (
+      <Button
+        key={key}
+        variant='outline'
+        size='sm'
+        disabled={actionMutation.isPending}
+        className={lifecycleActionButtonClass(lifecycleAction)}
+        onClick={() =>
+          actionMutation.mutate({
+            kind: 'service-lifecycle',
+            serviceId: service.id,
+            action: lifecycleAction,
+          })
+        }
+      >
+        {action.label}
       </Button>
     )
   }
@@ -930,9 +968,13 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           </CardTitle>
                         </CardHeader>
                         <CardContent className='flex flex-wrap gap-2'>
-                          {service.actions.map((action) =>
-                            renderActionButton(action, service)
-                          )}
+                          {service.actions.map((action) => (
+                            <ServiceActionButton
+                              key={action.id}
+                              action={action}
+                              service={service}
+                            />
+                          ))}
                         </CardContent>
                       </Card>
                     </div>

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -9,6 +9,7 @@ import {
   Square,
   Star,
 } from 'lucide-react'
+import { lifecycleActionButtonClass } from '@/lib/service-lasso-dashboard/action-styles'
 import {
   useFavoriteFeatureState,
   useDashboardAction,
@@ -83,7 +84,7 @@ function ServiceLifecycleControls({ service }: { service: DashboardService }) {
         type='button'
         size='icon'
         variant='outline'
-        className='size-8'
+        className={lifecycleActionButtonClass('start', 'size-8')}
         aria-label={`Start ${service.name}`}
         title={`Start ${service.name}`}
         disabled={disabled}
@@ -98,7 +99,7 @@ function ServiceLifecycleControls({ service }: { service: DashboardService }) {
         type='button'
         size='icon'
         variant='outline'
-        className='size-8'
+        className={lifecycleActionButtonClass('stop', 'size-8')}
         aria-label={`Stop ${service.name}`}
         title={`Stop ${service.name}`}
         disabled={disabled}
@@ -113,7 +114,7 @@ function ServiceLifecycleControls({ service }: { service: DashboardService }) {
         type='button'
         size='icon'
         variant='outline'
-        className='size-8'
+        className={lifecycleActionButtonClass('restart', 'size-8')}
         aria-label={`Restart ${service.name}`}
         title={`Restart ${service.name}`}
         disabled={disabled}

--- a/src/features/services/index.tsx
+++ b/src/features/services/index.tsx
@@ -1,6 +1,7 @@
 import { getRouteApi } from '@tanstack/react-router'
 import { Play, RotateCcw, Square } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
+import { lifecycleActionButtonClass } from '@/lib/service-lasso-dashboard/action-styles'
 import {
   useDashboardAction,
   useServices,
@@ -70,6 +71,8 @@ export function Services() {
             <Button
               type='button'
               size='sm'
+              variant='outline'
+              className={lifecycleActionButtonClass('start')}
               disabled={actionsDisabled}
               onClick={() => actionMutation.mutate('start-services')}
             >
@@ -80,6 +83,7 @@ export function Services() {
               type='button'
               size='sm'
               variant='outline'
+              className={lifecycleActionButtonClass('stop')}
               disabled={actionsDisabled}
               onClick={() => actionMutation.mutate('stop-services')}
             >
@@ -90,6 +94,7 @@ export function Services() {
               type='button'
               size='sm'
               variant='outline'
+              className={lifecycleActionButtonClass('restart')}
               disabled={actionsDisabled}
               onClick={() => actionMutation.mutate('restart-services')}
             >

--- a/src/lib/service-lasso-dashboard/action-styles.ts
+++ b/src/lib/service-lasso-dashboard/action-styles.ts
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils'
+import type { ServiceAction } from './types'
+
+type LifecycleActionKind = Extract<
+  ServiceAction['kind'],
+  'start' | 'stop' | 'restart'
+>
+
+export function getLifecycleActionHoverClass(kind: LifecycleActionKind) {
+  if (kind === 'start') {
+    return 'hover:border-emerald-600 hover:bg-emerald-600 hover:text-white focus-visible:border-emerald-600 focus-visible:ring-emerald-600/30'
+  }
+
+  return 'hover:border-red-600 hover:bg-red-600 hover:text-white focus-visible:border-red-600 focus-visible:ring-red-600/30'
+}
+
+export function lifecycleActionButtonClass(
+  kind: LifecycleActionKind,
+  className?: string
+) {
+  return cn(getLifecycleActionHoverClass(kind), className)
+}

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -26,20 +26,38 @@ test('services table filters and opens service detail', async ({ page }) => {
     page.getByRole('button', { name: 'Start all', exact: true })
   ).toBeEnabled()
   await expect(
+    page.getByRole('button', { name: 'Start all', exact: true })
+  ).toHaveClass(/hover:bg-emerald-600/)
+  await expect(
     page.getByRole('button', { name: 'Stop all', exact: true })
   ).toBeEnabled()
+  await expect(
+    page.getByRole('button', { name: 'Stop all', exact: true })
+  ).toHaveClass(/hover:bg-red-600/)
   await expect(
     page.getByRole('button', { name: 'Restart all', exact: true })
   ).toBeEnabled()
   await expect(
+    page.getByRole('button', { name: 'Restart all', exact: true })
+  ).toHaveClass(/hover:bg-red-600/)
+  await expect(
     page.getByRole('button', { name: 'Start Traefik', exact: true })
   ).toBeEnabled()
+  await expect(
+    page.getByRole('button', { name: 'Start Traefik', exact: true })
+  ).toHaveClass(/hover:bg-emerald-600/)
   await expect(
     page.getByRole('button', { name: 'Stop Traefik', exact: true })
   ).toBeEnabled()
   await expect(
+    page.getByRole('button', { name: 'Stop Traefik', exact: true })
+  ).toHaveClass(/hover:bg-red-600/)
+  await expect(
     page.getByRole('button', { name: 'Restart Traefik', exact: true })
   ).toBeEnabled()
+  await expect(
+    page.getByRole('button', { name: 'Restart Traefik', exact: true })
+  ).toHaveClass(/hover:bg-red-600/)
 
   await page
     .getByPlaceholder(
@@ -85,6 +103,18 @@ test('services table filters and opens service detail', async ({ page }) => {
   await expect(
     page.getByText('Operator dashboard for Service Lasso')
   ).toBeVisible()
+  await expect(
+    page.getByRole('button', { name: 'Start service', exact: true })
+  ).toBeEnabled()
+  await expect(
+    page.getByRole('button', { name: 'Start service', exact: true })
+  ).toHaveClass(/hover:bg-emerald-600/)
+  await expect(
+    page.getByRole('button', { name: 'Stop service', exact: true })
+  ).toBeEnabled()
+  await expect(
+    page.getByRole('button', { name: 'Stop service', exact: true })
+  ).toHaveClass(/hover:bg-red-600/)
   await page.getByRole('tab', { name: /variables/i }).click()
   await expect(page.getByText('VITE_SERVICE_LASSO_API_BASE_URL')).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- make start controls hover green and stop/restart controls hover red on the Services page
- wire service-detail start/stop/restart actions through the same Service Lasso runtime lifecycle mutation
- add UI coverage for hover classes and enabled detail actions

## Notes
- Service Admin only shows live running state when VITE_SERVICE_LASSO_API_BASE_URL points at the runtime API; otherwise it is demo stub data.
- Secrets Broker currently exists as a Service Admin fixture service manifest, not as part of Service Lasso core.

## Validation
- npm run test:ui
- npm run format:check
- npm test
- npm run lint
- npm run build