### PR TITLE
ISS-25 Add real Service Lasso dev server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,9 @@ jobs:
         run: |
           bash ./scripts/test.sh
           bash ./scripts/package.sh
+
+      - name: Run packaged Service Lasso dev server smoke
+        shell: bash
+        env:
+          SERVICEADMIN_ARTIFACT_PATH: dist/@serviceadmin-linux.tar.gz
+        run: npm run test:dev-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
         shell: bash
         run: bash ./scripts/package.sh
 
+      - name: Run packaged Service Lasso dev server smoke
+        shell: bash
+        env:
+          SERVICEADMIN_ARTIFACT_PATH: ${{ matrix.artifact }}
+        run: npm run test:dev-server
+
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@eslint/js": "^10.0.1",
         "@faker-js/faker": "^10.4.0",
         "@playwright/test": "^1.59.1",
+        "@service-lasso/service-lasso": "2026.5.2-92235c2",
         "@tanstack/eslint-plugin-query": "^5.95.2",
         "@tanstack/react-query-devtools": "^5.95.2",
         "@tanstack/react-router-devtools": "^1.166.11",
@@ -1543,6 +1544,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3860,6 +3874,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@service-lasso/service-lasso": {
+      "version": "2026.5.2-92235c2",
+      "resolved": "https://registry.npmjs.org/@service-lasso/service-lasso/-/service-lasso-2026.5.2-92235c2.tgz",
+      "integrity": "sha512-MiVAQQ/5+ZWlx+cFpCth7F6cd/E8+zTAae2zZ32YfMTHaV0ohmDkhwxMUHfBszFIHDKDeVpgMsudaHisuk6dqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "tar": "^7.5.2"
+      },
+      "bin": {
+        "service-lasso": "cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5723,6 +5754,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -6397,6 +6438,16 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ci-info": {
@@ -10316,6 +10367,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -12101,6 +12175,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/throttleit": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:unit": "vitest run",
     "test:ui": "playwright test",
     "test:logs:unit": "vitest run src/features/logs/provider.stub.test.ts src/features/logs/provider.runtime.test.ts",
-    "test:logs:e2e": "start-server-and-test \"vite --host 127.0.0.1 --port 4175 --strictPort\" http://127.0.0.1:4175 \"cypress run --config baseUrl=http://127.0.0.1:4175 --spec cypress/e2e/logs/logs-page.cy.js\""
+    "test:logs:e2e": "start-server-and-test \"vite --host 127.0.0.1 --port 4175 --strictPort\" http://127.0.0.1:4175 \"cypress run --config baseUrl=http://127.0.0.1:4175 --spec cypress/e2e/logs/logs-page.cy.js\"",
+    "dev:server": "node scripts/dev-server.mjs",
+    "test:dev-server": "node scripts/dev-server.mjs --verify"
   },
   "dependencies": {
     "@clerk/react": "^6.5.0",
@@ -71,6 +73,7 @@
     "@eslint/js": "^10.0.1",
     "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.59.1",
+    "@service-lasso/service-lasso": "2026.5.2-92235c2",
     "@tanstack/eslint-plugin-query": "^5.95.2",
     "@tanstack/react-query-devtools": "^5.95.2",
     "@tanstack/react-router-devtools": "^1.166.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@service-lasso/service-lasso':
+        specifier: 2026.5.2-92235c2
+        version: 2026.5.2-92235c2
       '@tanstack/eslint-plugin-query':
         specifier: ^5.95.2
         version: 5.95.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
@@ -907,6 +910,10 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -1821,6 +1828,11 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@service-lasso/service-lasso@2026.5.2-92235c2':
+    resolution: {integrity: sha512-MiVAQQ/5+ZWlx+cFpCth7F6cd/E8+zTAae2zZ32YfMTHaV0ohmDkhwxMUHfBszFIHDKDeVpgMsudaHisuk6dqA==}
+    engines: {node: '>=22'}
+    hasBin: true
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -2422,6 +2434,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -2610,6 +2626,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -3726,6 +3746,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
@@ -4297,6 +4325,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   throttleit@1.0.1:
     resolution: {integrity: sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==}
 
@@ -4668,6 +4700,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -5296,6 +5332,10 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -6071,6 +6111,11 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
+  '@service-lasso/service-lasso@2026.5.2-92235c2':
+    dependencies:
+      adm-zip: 0.5.17
+      tar: 7.5.13
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6670,6 +6715,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6853,6 +6900,8 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -8225,6 +8274,12 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mitt@3.0.1: {}
 
   ms@2.1.3: {}
@@ -8805,6 +8860,14 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   throttleit@1.0.1: {}
 
   tiny-invariant@1.3.3: {}
@@ -9117,6 +9180,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { createReadStream } from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
+
+const __filename = fileURLToPath(import.meta.url)
+const repoRoot = path.resolve(path.dirname(__filename), '..')
+
+const args = new Set(process.argv.slice(2))
+const verifyMode = args.has('--verify')
+const keepRoot = args.has('--keep') || process.env.SERVICEADMIN_DEV_SERVER_KEEP === 'true'
+const serviceAdminArtifactPath = process.env.SERVICEADMIN_ARTIFACT_PATH
+  ? path.resolve(process.env.SERVICEADMIN_ARTIFACT_PATH)
+  : null
+
+const serviceLassoCliPath = fileURLToPath(await import.meta.resolve('@service-lasso/service-lasso/cli'))
+
+function log(message) {
+  console.log(`[serviceadmin dev:server] ${message}`)
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function reserveLoopbackPort() {
+  return await new Promise((resolve, reject) => {
+    const server = http.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : null
+      server.close(() => {
+        if (!port) {
+          reject(new Error('Failed to reserve loopback port.'))
+          return
+        }
+        resolve(port)
+      })
+    })
+  })
+}
+
+async function startLocalArtifactServer(filePath) {
+  const fileStat = await stat(filePath)
+  if (!fileStat.isFile()) {
+    throw new Error(`SERVICEADMIN_ARTIFACT_PATH must point at a packaged artifact file: ${filePath}`)
+  }
+
+  const assetName = path.basename(filePath)
+  const archiveType = assetName.endsWith('.zip') ? 'zip' : 'tar.gz'
+  const port = await reserveLoopbackPort()
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url || '/', `http://127.0.0.1:${port}`)
+    if (url.pathname !== `/${assetName}`) {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      response.end('Not Found')
+      return
+    }
+
+    response.writeHead(200, {
+      'Content-Length': String(fileStat.size),
+      'Content-Type': 'application/octet-stream',
+    })
+    createReadStream(filePath).pipe(response)
+  })
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', resolve)
+  })
+
+  return {
+    server,
+    assetName,
+    archiveType,
+    assetUrl: `http://127.0.0.1:${port}/${assetName}`,
+  }
+}
+
+async function closeServer(server) {
+  if (!server) {
+    return
+  }
+
+  await new Promise((resolve) => server.close(resolve))
+}
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init)
+  const text = await response.text()
+  let body = null
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      body = text
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}: ${typeof body === 'string' ? body : JSON.stringify(body)}`)
+  }
+
+  return body
+}
+
+async function waitForJson(url, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs
+  let lastError = null
+
+  while (Date.now() < deadline) {
+    try {
+      return await fetchJson(url)
+    } catch (error) {
+      lastError = error
+      await sleep(500)
+    }
+  }
+
+  throw new Error(`Timed out waiting for ${url}: ${lastError instanceof Error ? lastError.message : String(lastError)}`)
+}
+
+async function waitForOk(url, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs
+  let lastStatus = null
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      lastStatus = response.status
+      if (response.ok) {
+        return response
+      }
+    } catch {}
+    await sleep(500)
+  }
+
+  throw new Error(`Timed out waiting for ${url}; last status: ${lastStatus ?? 'unreachable'}`)
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function serviceManifestPath(servicesRoot, serviceId) {
+  return path.join(servicesRoot, serviceId, 'service.json')
+}
+
+async function writeNodeProvider(servicesRoot) {
+  await writeJson(serviceManifestPath(servicesRoot, '@node'), {
+    id: '@node',
+    name: 'Node Runtime',
+    description: 'Release-backed Node.js runtime provider for the Service Admin dev server.',
+    version: 'v24.15.0',
+    role: 'provider',
+    enabled: true,
+    executable: 'node',
+    args: ['--version'],
+    globalenv: {
+      NODE: '${SERVICE_ARTIFACT_COMMAND}',
+      NODE_HOME: '${SERVICE_ARTIFACT_ROOT}',
+    },
+    artifact: {
+      kind: 'archive',
+      source: {
+        type: 'github-release',
+        repo: 'service-lasso/lasso-node',
+        channel: 'latest',
+      },
+      platforms: {
+        win32: {
+          assetName: 'lasso-node-v24.15.0-win32.zip',
+          archiveType: 'zip',
+          command: '.\\node.exe',
+          args: ['--version'],
+        },
+        linux: {
+          assetName: 'lasso-node-v24.15.0-linux.tar.gz',
+          archiveType: 'tar.gz',
+          command: './bin/node',
+          args: ['--version'],
+        },
+        darwin: {
+          assetName: 'lasso-node-v24.15.0-darwin.tar.gz',
+          archiveType: 'tar.gz',
+          command: './bin/node',
+          args: ['--version'],
+        },
+      },
+    },
+  })
+}
+
+async function writeTraefikService(servicesRoot, ports) {
+  await writeJson(serviceManifestPath(servicesRoot, '@traefik'), {
+    id: '@traefik',
+    name: 'Traefik Router',
+    description: 'Release-backed Traefik router for the Service Admin dev server.',
+    version: 'dev-latest',
+    enabled: true,
+    ports: {
+      web: ports.traefikWeb,
+      admin: ports.traefikAdmin,
+    },
+    env: {
+      TRAEFIK_DASHBOARD_URL: 'http://127.0.0.1:${ADMIN_PORT}/dashboard/',
+      TRAEFIK_PING_URL: 'http://127.0.0.1:${ADMIN_PORT}/ping',
+    },
+    urls: [
+      {
+        label: 'dashboard',
+        url: 'http://127.0.0.1:${ADMIN_PORT}/dashboard/',
+        kind: 'local',
+      },
+      {
+        label: 'ping',
+        url: 'http://127.0.0.1:${ADMIN_PORT}/ping',
+        kind: 'local',
+      },
+    ],
+    artifact: {
+      kind: 'archive',
+      source: {
+        type: 'github-release',
+        repo: 'service-lasso/lasso-traefik',
+        channel: 'latest',
+      },
+      platforms: {
+        win32: {
+          assetName: 'lasso-traefik-win32.zip',
+          archiveType: 'zip',
+          command: '.\\traefik.exe',
+          args: ['--configFile=./runtime/traefik.yml'],
+        },
+        linux: {
+          assetName: 'lasso-traefik-linux.tar.gz',
+          archiveType: 'tar.gz',
+          command: './traefik',
+          args: ['--configFile=./runtime/traefik.yml'],
+        },
+        darwin: {
+          assetName: 'lasso-traefik-darwin.tar.gz',
+          archiveType: 'tar.gz',
+          command: './traefik',
+          args: ['--configFile=./runtime/traefik.yml'],
+        },
+      },
+    },
+    install: {
+      files: [
+        {
+          path: './runtime/dynamic.yml',
+          content: 'http:\n  routers: {}\n  services: {}\n',
+        },
+      ],
+    },
+    config: {
+      files: [
+        {
+          path: './runtime/traefik.yml',
+          content: `entryPoints:\n  web:\n    address: "127.0.0.1:${ports.traefikWeb}"\n  traefik:\n    address: "127.0.0.1:${ports.traefikAdmin}"\napi:\n  dashboard: true\nping:\n  entryPoint: traefik\nproviders:\n  file:\n    filename: "./runtime/dynamic.yml"\n    watch: true\nlog:\n  level: INFO\n`,
+        },
+      ],
+    },
+    healthcheck: {
+      type: 'http',
+      url: 'http://127.0.0.1:${ADMIN_PORT}/ping',
+      expected_status: 200,
+      retries: 80,
+      interval: 250,
+    },
+  })
+}
+
+function buildServiceAdminArtifact(serviceAdminArtifact) {
+  const platforms = {
+    win32: {
+      assetName: '@serviceadmin-win32.zip',
+      archiveType: 'zip',
+      command: 'node',
+      args: ['runtime/server.js'],
+    },
+    linux: {
+      assetName: '@serviceadmin-linux.tar.gz',
+      archiveType: 'tar.gz',
+      command: 'node',
+      args: ['runtime/server.js'],
+    },
+    darwin: {
+      assetName: '@serviceadmin-darwin.tar.gz',
+      archiveType: 'tar.gz',
+      command: 'node',
+      args: ['runtime/server.js'],
+    },
+  }
+
+  if (serviceAdminArtifact) {
+    platforms[process.platform] = {
+      ...platforms[process.platform],
+      assetName: serviceAdminArtifact.assetName,
+      archiveType: serviceAdminArtifact.archiveType,
+      assetUrl: serviceAdminArtifact.assetUrl,
+    }
+  }
+
+  return {
+    kind: 'archive',
+    source: {
+      type: 'github-release',
+      repo: 'service-lasso/lasso-serviceadmin',
+      channel: 'latest',
+    },
+    platforms,
+  }
+}
+
+async function writeServiceAdmin(servicesRoot, ports, serviceAdminArtifact = null) {
+  await writeJson(serviceManifestPath(servicesRoot, '@serviceadmin'), {
+    id: '@serviceadmin',
+    name: 'Service Admin UI',
+    description: 'Published Service Admin UI release started by Service Lasso dev:server.',
+    enabled: true,
+    version: 'dev-latest',
+    depend_on: ['@node', '@traefik'],
+    ports: {
+      ui: ports.serviceAdmin,
+    },
+    env: {
+      SERVICE_HOST: '127.0.0.1',
+      SERVICE_PORT: '${UI_PORT}',
+    },
+    urls: [
+      {
+        label: 'ui',
+        url: 'http://127.0.0.1:${UI_PORT}/',
+        kind: 'local',
+      },
+    ],
+    artifact: buildServiceAdminArtifact(serviceAdminArtifact),
+    healthcheck: {
+      type: 'http',
+      url: 'http://127.0.0.1:${UI_PORT}/',
+      expected_status: 200,
+      retries: 80,
+      interval: 250,
+    },
+  })
+}
+
+async function prepareRuntimeRoots(serviceAdminArtifact = null) {
+  const defaultRoot = verifyMode
+    ? await import('node:fs/promises').then(({ mkdtemp }) => mkdtemp(path.join(os.tmpdir(), 'serviceadmin-dev-server-')))
+    : path.join(repoRoot, '.tmp', 'dev-server')
+  const root = path.resolve(process.env.SERVICEADMIN_DEV_SERVER_ROOT || defaultRoot)
+
+  if (!keepRoot) {
+    await rm(root, { recursive: true, force: true })
+  }
+
+  const servicesRoot = path.join(root, 'services')
+  const workspaceRoot = path.join(root, 'workspace')
+  await mkdir(servicesRoot, { recursive: true })
+  await mkdir(workspaceRoot, { recursive: true })
+
+  const ports = {
+    api: Number(process.env.SERVICE_LASSO_PORT || (await reserveLoopbackPort())),
+    traefikWeb: Number(process.env.SERVICEADMIN_TRAEFIK_WEB_PORT || (await reserveLoopbackPort())),
+    traefikAdmin: Number(process.env.SERVICEADMIN_TRAEFIK_ADMIN_PORT || (await reserveLoopbackPort())),
+    serviceAdmin: Number(process.env.SERVICEADMIN_UI_PORT || (await reserveLoopbackPort())),
+  }
+
+  await writeNodeProvider(servicesRoot)
+  await writeTraefikService(servicesRoot, ports)
+  await writeServiceAdmin(servicesRoot, ports, serviceAdminArtifact)
+
+  return { root, servicesRoot, workspaceRoot, ports }
+}
+
+function startServiceLasso({ servicesRoot, workspaceRoot, ports }) {
+  const child = spawn(
+    process.execPath,
+    [
+      serviceLassoCliPath,
+      'serve',
+      '--services-root',
+      servicesRoot,
+      '--workspace-root',
+      workspaceRoot,
+      '--port',
+      String(ports.api),
+    ],
+    {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  child.stdout.on('data', (chunk) => process.stdout.write(chunk))
+  child.stderr.on('data', (chunk) => process.stderr.write(chunk))
+  return child
+}
+
+async function stopRuntime(apiBaseUrl, child) {
+  try {
+    await fetchJson(`${apiBaseUrl}/api/runtime/actions/stopAll`, { method: 'POST' })
+  } catch {}
+
+  if (child && child.exitCode === null && child.signalCode === null) {
+    child.kill('SIGTERM')
+    await Promise.race([
+      new Promise((resolve) => child.once('close', resolve)),
+      sleep(5_000).then(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL')
+        }
+      }),
+    ])
+  }
+}
+
+async function lifecycle(apiBaseUrl, serviceId, action) {
+  return await fetchJson(`${apiBaseUrl}/api/services/${encodeURIComponent(serviceId)}/${action}`, {
+    method: 'POST',
+  })
+}
+
+async function bootstrapServices(apiBaseUrl) {
+  for (const serviceId of ['@node', '@traefik', '@serviceadmin']) {
+    log(`install ${serviceId}`)
+    await lifecycle(apiBaseUrl, serviceId, 'install')
+    log(`config ${serviceId}`)
+    await lifecycle(apiBaseUrl, serviceId, 'config')
+    if (serviceId !== '@node') {
+      log(`start ${serviceId}`)
+      await lifecycle(apiBaseUrl, serviceId, 'start')
+    }
+  }
+}
+
+async function readService(apiBaseUrl, serviceId) {
+  const body = await waitForJson(`${apiBaseUrl}/api/services/${encodeURIComponent(serviceId)}`)
+  return body.service
+}
+
+async function verifyRuntime(apiBaseUrl, ports) {
+  const health = await waitForJson(`${apiBaseUrl}/api/health`)
+  assert(health.status === 'ok', 'Service Lasso API did not report healthy status.')
+
+  const servicesPayload = await waitForJson(`${apiBaseUrl}/api/services`)
+  const serviceIds = servicesPayload.services.map((service) => service.id).sort()
+  assert(
+    JSON.stringify(serviceIds) === JSON.stringify(['@node', '@serviceadmin', '@traefik']),
+    `Unexpected dev server services: ${JSON.stringify(serviceIds)}`,
+  )
+
+  const node = await readService(apiBaseUrl, '@node')
+  assert(node.lifecycle?.installed === true, '@node was not installed.')
+  assert(node.lifecycle?.configured === true, '@node was not configured.')
+  assert(node.lifecycle?.running === false, '@node should be a provider, not a managed daemon.')
+
+  const traefik = await readService(apiBaseUrl, '@traefik')
+  assert(traefik.lifecycle?.running === true, '@traefik was not running.')
+  assert(traefik.health?.healthy === true, '@traefik was not healthy.')
+  await waitForOk(`http://127.0.0.1:${ports.traefikAdmin}/ping`)
+
+  const serviceadmin = await readService(apiBaseUrl, '@serviceadmin')
+  assert(serviceadmin.lifecycle?.running === true, '@serviceadmin was not running.')
+  assert(serviceadmin.health?.healthy === true, '@serviceadmin was not healthy.')
+  const response = await waitForOk(`http://127.0.0.1:${ports.serviceAdmin}/`)
+  assert((response.headers.get('content-type') || '').includes('text/html'), '@serviceadmin did not serve HTML.')
+}
+
+let child = null
+let apiBaseUrl = null
+let tempRoot = null
+let artifactServer = null
+
+try {
+  const serviceAdminArtifact = serviceAdminArtifactPath ? await startLocalArtifactServer(serviceAdminArtifactPath) : null
+  artifactServer = serviceAdminArtifact?.server ?? null
+  if (serviceAdminArtifactPath) {
+    log(`Service Admin artifact: ${serviceAdminArtifactPath}`)
+  }
+  const runtime = await prepareRuntimeRoots(serviceAdminArtifact)
+  tempRoot = runtime.root
+  apiBaseUrl = `http://127.0.0.1:${runtime.ports.api}`
+  child = startServiceLasso(runtime)
+
+  await waitForJson(`${apiBaseUrl}/api/health`)
+  await bootstrapServices(apiBaseUrl)
+  await verifyRuntime(apiBaseUrl, runtime.ports)
+
+  log('real Service Lasso dev server is running')
+  log(`API: ${apiBaseUrl}`)
+  log(`Service Admin: http://127.0.0.1:${runtime.ports.serviceAdmin}/`)
+  log(`Traefik dashboard: http://127.0.0.1:${runtime.ports.traefikAdmin}/dashboard/`)
+
+  if (verifyMode) {
+    log('verification passed')
+    await stopRuntime(apiBaseUrl, child)
+    child = null
+    await closeServer(artifactServer)
+    if (!keepRoot && tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+    process.exit(0)
+  }
+
+  const shutdown = async () => {
+    log('stopping Service Lasso dev server')
+    await stopRuntime(apiBaseUrl, child)
+    await closeServer(artifactServer)
+    process.exit(0)
+  }
+  process.once('SIGINT', shutdown)
+  process.once('SIGTERM', shutdown)
+  await new Promise((resolve) => child.once('close', resolve))
+  await closeServer(artifactServer)
+} catch (error) {
+  console.error(error instanceof Error ? error.stack || error.message : error)
+  if (apiBaseUrl || child) {
+    await stopRuntime(apiBaseUrl, child)
+  }
+  await closeServer(artifactServer)
+  if (verifyMode && !keepRoot && tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- add \dev:server\ / \	est:dev-server\ runner that boots a real Service Lasso runtime API
- provision isolated dev runtime manifests for \@node\, \@traefik\, and \@serviceadmin\
- start/verify \@serviceadmin\ as a Service Lasso service from archive artifacts, including current-build local artifacts via \SERVICEADMIN_ARTIFACT_PATH\
- run packaged artifact dev-server smoke in CI and release matrix after packaging

Closes #25.

## Local validation
- \
pm run lint\ passed with existing warnings only
- \
pm run test:unit\ passed: 7 files / 48 tests
- \
pm run build\ passed
- \.\\scripts\\package.ps1\ created \dist/@serviceadmin-win32.zip\
- \SERVICEADMIN_ARTIFACT_PATH=dist/@serviceadmin-win32.zip npm run test:dev-server\ passed
- \
pm run test:dev-server\ passed against latest release artifact
- \
pm run format:check\ passed