### PR TITLE
ISS-45 explain dev-server dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,16 @@ See `docs/reference/MIGRATION-REPORT.md` for the stricter migration rules.
 Install dependencies:
 
 ```bash
-npm install
+npm ci --legacy-peer-deps
 ```
+
+For editable local installs, use:
+
+```bash
+npm install --legacy-peer-deps
+```
+
+`npm run test:dev-server` requires the `@service-lasso/service-lasso` devDependency from `node_modules`; run one of the install commands above after a fresh clone or pull.
 
 Start the Vite dev server:
 

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -17,7 +17,34 @@ const serviceAdminArtifactPath = process.env.SERVICEADMIN_ARTIFACT_PATH
   ? path.resolve(process.env.SERVICEADMIN_ARTIFACT_PATH)
   : null
 
-const serviceLassoCliPath = fileURLToPath(await import.meta.resolve('@service-lasso/service-lasso/cli'))
+async function resolveServiceLassoCliPath() {
+  try {
+    return fileURLToPath(await import.meta.resolve('@service-lasso/service-lasso/cli'))
+  } catch (error) {
+    if (error?.code !== 'ERR_MODULE_NOT_FOUND') {
+      throw error
+    }
+
+    const message = [
+      'Service Admin dev-server smoke requires the @service-lasso/service-lasso devDependency to be installed.',
+      '',
+      `Repo: ${repoRoot}`,
+      '',
+      'Install dependencies first, then rerun the smoke test:',
+      '',
+      '  npm ci --legacy-peer-deps',
+      '  npm run test:dev-server',
+      '',
+      'For an editable local dependency install, use:',
+      '',
+      '  npm install --legacy-peer-deps',
+    ].join('\n')
+
+    throw new Error(message, { cause: error })
+  }
+}
+
+const serviceLassoCliPath = await resolveServiceLassoCliPath()
 
 function log(message) {
   console.log(`[serviceadmin dev:server] ${message}`)


### PR DESCRIPTION
## Summary
- wraps `@service-lasso/service-lasso/cli` resolution with a Service Admin-specific setup error
- tells local users to run `npm ci --legacy-peer-deps` or `npm install --legacy-peer-deps` when `test:dev-server` dependencies are missing
- documents the local install requirement in README

## Validation
- `npm run format:check` ✅
- `npm run lint` ✅ (0 errors; existing warnings only)
- missing-dependency simulation ✅ produced friendly setup message and non-zero exit
- `npm run test:dev-server` ✅ after restoring dependency

Fixes #45