### PR TITLE
ISS-47 remove dev-server smoke from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,3 @@ jobs:
         run: |
           bash ./scripts/test.sh
           bash ./scripts/package.sh
-
-      - name: Run packaged Service Lasso dev server smoke
-        shell: bash
-        env:
-          SERVICEADMIN_ARTIFACT_PATH: dist/@serviceadmin-linux.tar.gz
-        run: npm run test:dev-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,6 @@ jobs:
         shell: bash
         run: bash ./scripts/package.sh
 
-      - name: Run packaged Service Lasso dev server smoke
-        shell: bash
-        env:
-          SERVICEADMIN_ARTIFACT_PATH: ${{ matrix.artifact }}
-        run: npm run test:dev-server
-
       - name: Upload packaged artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- removes `npm run test:dev-server` from Continuous Integration
- removes the packaged dev-server smoke from the Release workflow too, so GitHub Actions no longer runs it automatically
- keeps `npm run test:dev-server` available for local/manual validation only

## Validation
- `npm run format:check` ✅
- `rg "test:dev-server|SERVICEADMIN_ARTIFACT_PATH|dev server smoke" .github/workflows` ✅ no workflow references
- `git diff --check` ✅

Fixes #47