### PR TITLE
ISS-37 add Secrets Broker setup wizard slice

### DIFF
--- a/docs/secrets-broker-setup-wizard.md
+++ b/docs/secrets-broker-setup-wizard.md
@@ -1,0 +1,40 @@
+# Secrets Broker setup wizard
+
+Status: first UI slice for issue #37  
+Scope: Service Admin operator UI only; no live secret resolution or value reveal.
+
+## Purpose
+
+The setup wizard gives operators a safe, guided place to configure and test local and external Secrets Broker sources. It must help with blank installs, existing locked vaults on new machines, external-source authentication, blocked service dependencies, OpenClaw exec adapter checks, and generated secret write-back review.
+
+## First slice
+
+The first implementation is a static/stubbed UI contract that can be wired to live broker APIs later. It must:
+
+- expose local encrypted vault, file source, exec adapter, and external manager setup paths;
+- show safe copyable examples without resolved secret values;
+- provide test-result states for ready, locked, auth required, degraded, policy denied, and write-back review;
+- show affected refs/services before prompting for auth or unlock repair;
+- warn on risky file/exec settings;
+- require explicit confirmation/audit reason for destructive or broad actions in later live flows.
+
+## Security rules
+
+- Never render resolved secret values in setup tests.
+- Mask example values and use `SecretRef`/namespace examples instead of plaintext.
+- Treat raw reveal and bulk operations as separate privileged workflows.
+- Show policy decisions and audit links without logging values.
+- Prefer least-privilege examples for OpenClaw namespaces and file paths.
+
+## Validation expectations
+
+Tests should cover the operator-visible contract rather than live secrets:
+
+- happy path ready state;
+- failed source test/degraded state;
+- risky exec or file configuration warning;
+- cancel/safe no-op behavior;
+- locked vault/new-machine import state;
+- external auth-required state;
+- policy-denied state;
+- no plaintext secret values in rendered examples.

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -3,6 +3,7 @@ import {
   Command,
   GitBranch,
   Globe,
+  KeyRound,
   SlidersHorizontal,
   HardDrive,
   HelpCircle,
@@ -65,6 +66,11 @@ export const sidebarData: SidebarData = {
           title: 'Variables',
           url: '/variables',
           icon: SlidersHorizontal,
+        },
+        {
+          title: 'Secrets Broker',
+          url: '/secrets-broker',
+          icon: KeyRound,
         },
         {
           title: 'Network',

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -1,0 +1,389 @@
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardCheck,
+  FileKey2,
+  KeyRound,
+  LockKeyhole,
+  ShieldCheck,
+  TerminalSquare,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+
+type WizardSource = {
+  id: string
+  title: string
+  kind: string
+  summary: string
+  status: 'ready' | 'locked' | 'auth-required' | 'degraded' | 'policy-denied'
+  affected: string[]
+  safeExample: string
+  warning?: string
+  nextAction: string
+}
+
+const wizardSources: WizardSource[] = [
+  {
+    id: 'local-vault',
+    title: 'Local encrypted vault',
+    kind: 'local/file',
+    summary:
+      'Create or unlock the default local-first Secrets Broker vault without showing resolved values.',
+    status: 'locked',
+    affected: ['@secretsbroker/local/default', 'echo-service:DB_PASSWORD'],
+    safeExample:
+      'SecretRef: secret://local/default/echo-service/DB_PASSWORD (value hidden)',
+    nextAction:
+      'Import portable master key or re-wrap this vault for the current machine.',
+  },
+  {
+    id: 'file-source',
+    title: 'File source',
+    kind: 'file',
+    summary:
+      'Validate a least-privilege file source path and preview affected refs before enabling it.',
+    status: 'degraded',
+    affected: ['@node:NPM_TOKEN', '@serviceadmin:SESSION_SECRET'],
+    safeExample: 'file://C:/service-lasso/secrets/runtime.env#SESSION_SECRET',
+    warning:
+      'Risky broad paths are rejected; keep file grants scoped to the smallest secrets directory.',
+    nextAction: 'Choose a narrower path and test again before saving.',
+  },
+  {
+    id: 'exec-adapter',
+    title: 'OpenClaw exec adapter',
+    kind: 'exec',
+    summary:
+      'Check resolver health, namespace policy, and last result without printing command output values.',
+    status: 'policy-denied',
+    affected: ['openclaw/service-lasso/*', '@serviceadmin:OPENCLAW_TOKEN'],
+    safeExample:
+      'SecretRef: exec://openclaw/service-lasso/SESSION_TOKEN (value hidden)',
+    warning:
+      'Exec adapters must use allowlisted namespaces and must not echo secrets to logs.',
+    nextAction:
+      'Review policy denial, update namespace allowlist, and record an audit reason.',
+  },
+  {
+    id: 'external-manager',
+    title: 'External source auth',
+    kind: 'vault/1password/aws/bitwarden',
+    summary:
+      'Surface expired Vault tokens, locked password managers, or missing cloud credentials before services start.',
+    status: 'auth-required',
+    affected: [
+      'payments-api:STRIPE_KEY',
+      'backup-worker:AWS_SECRET_ACCESS_KEY',
+    ],
+    safeExample:
+      'SecretRef: vault://kv/service-lasso/payments/STRIPE_KEY (value hidden)',
+    nextAction:
+      'Authenticate the external source once, then retry affected refs.',
+  },
+  {
+    id: 'generated-writeback',
+    title: 'Generated secret write-back',
+    kind: 'write-back',
+    summary:
+      'Preview generated secret storage decisions with policy and audit links, never the generated value.',
+    status: 'ready',
+    affected: ['@serviceadmin:SESSION_SECRET'],
+    safeExample:
+      'write-back: local/default/@serviceadmin/SESSION_SECRET (generated value hidden)',
+    nextAction:
+      'Confirm operation, policy decision, and audit reason before writing.',
+  },
+]
+
+const statusCopy: Record<WizardSource['status'], string> = {
+  ready: 'Ready',
+  locked: 'Locked',
+  'auth-required': 'Auth required',
+  degraded: 'Degraded',
+  'policy-denied': 'Policy denied',
+}
+
+const statusVariant: Record<
+  WizardSource['status'],
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  ready: 'default',
+  locked: 'secondary',
+  'auth-required': 'secondary',
+  degraded: 'outline',
+  'policy-denied': 'destructive',
+}
+
+function SourceIcon({ source }: { source: WizardSource }) {
+  if (source.id === 'local-vault') return <LockKeyhole className='size-4' />
+  if (source.id === 'file-source') return <FileKey2 className='size-4' />
+  if (source.id === 'exec-adapter') return <TerminalSquare className='size-4' />
+  if (source.id === 'generated-writeback') {
+    return <ClipboardCheck className='size-4' />
+  }
+  return <KeyRound className='size-4' />
+}
+
+function SourceCard({
+  source,
+  selected,
+  onSelect,
+}: {
+  source: WizardSource
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onSelect}
+      className={`rounded-lg border p-4 text-left transition hover:border-primary ${
+        selected ? 'border-primary bg-muted/60' : 'bg-card'
+      }`}
+    >
+      <div className='mb-3 flex items-start justify-between gap-3'>
+        <div className='flex items-center gap-2 font-medium'>
+          <SourceIcon source={source} />
+          {source.title}
+        </div>
+        <Badge variant={statusVariant[source.status]}>
+          {statusCopy[source.status]}
+        </Badge>
+      </div>
+      <p className='text-sm text-muted-foreground'>{source.summary}</p>
+    </button>
+  )
+}
+
+function SafeExample({ value }: { value: string }) {
+  return (
+    <div className='rounded-md border bg-muted/40 p-3 font-mono text-sm break-all'>
+      {value}
+    </div>
+  )
+}
+
+export function SecretsBrokerSetupWizard() {
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Setup',
+    description:
+      'Guided setup and diagnostics for local and external Secrets Broker sources.',
+  })
+
+  const [selectedId, setSelectedId] = useState(wizardSources[0].id)
+  const selectedSource = useMemo(
+    () =>
+      wizardSources.find((source) => source.id === selectedId) ??
+      wizardSources[0],
+    [selectedId]
+  )
+  const readyCount = wizardSources.filter(
+    (source) => source.status === 'ready'
+  ).length
+  const blockedCount = wizardSources.length - readyCount
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='flex flex-wrap items-end justify-between gap-3'>
+          <div>
+            <h2 className='text-2xl font-bold tracking-tight'>
+              Secrets Broker setup
+            </h2>
+            <p className='text-muted-foreground'>
+              Configure and test local, file, exec, and external secret sources
+              without revealing secret values.
+            </p>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Button variant='outline' size='sm' asChild>
+              <Link to='/variables'>View variables</Link>
+            </Button>
+            <Button variant='outline' size='sm' asChild>
+              <Link to='/dependencies'>Dependency impact</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className='grid gap-4 md:grid-cols-3'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardTitle className='text-base'>Ready sources</CardTitle>
+              <CardDescription>
+                Sources that can be saved or retried safely.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='text-3xl font-bold'>
+              {readyCount}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardTitle className='text-base'>Needs operator action</CardTitle>
+              <CardDescription>
+                Locked, degraded, denied, or auth-required states.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='text-3xl font-bold'>
+              {blockedCount}
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardTitle className='text-base'>Value handling</CardTitle>
+              <CardDescription>
+                No setup test renders resolved plaintext secrets.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Badge variant='secondary'>Values hidden</Badge>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className='grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.9fr)]'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Source setup paths</CardTitle>
+              <CardDescription>
+                Pick a source type to preview the safe setup contract and
+                current stubbed state.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-3'>
+              {wizardSources.map((source) => (
+                <SourceCard
+                  key={source.id}
+                  source={source}
+                  selected={source.id === selectedSource.id}
+                  onSelect={() => setSelectedId(source.id)}
+                />
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <div className='flex items-start justify-between gap-3'>
+                <div>
+                  <CardTitle className='flex items-center gap-2'>
+                    <SourceIcon source={selectedSource} />
+                    {selectedSource.title}
+                  </CardTitle>
+                  <CardDescription>{selectedSource.kind}</CardDescription>
+                </div>
+                <Badge variant={statusVariant[selectedSource.status]}>
+                  {statusCopy[selectedSource.status]}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className='space-y-5'>
+              <section className='space-y-2'>
+                <h3 className='font-medium'>Safe example</h3>
+                <SafeExample value={selectedSource.safeExample} />
+                <p className='text-sm text-muted-foreground'>
+                  Examples intentionally use SecretRef-style identifiers and
+                  hidden generated values only.
+                </p>
+              </section>
+
+              <section className='space-y-2'>
+                <h3 className='font-medium'>Affected refs and services</h3>
+                <div className='flex flex-wrap gap-2'>
+                  {selectedSource.affected.map((item) => (
+                    <Badge key={item} variant='outline'>
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              </section>
+
+              {selectedSource.warning ? (
+                <div className='flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100'>
+                  <AlertTriangle className='mt-0.5 size-4 shrink-0' />
+                  <span>{selectedSource.warning}</span>
+                </div>
+              ) : null}
+
+              <section className='space-y-2'>
+                <h3 className='font-medium'>Next safe action</h3>
+                <p className='text-sm text-muted-foreground'>
+                  {selectedSource.nextAction}
+                </p>
+              </section>
+
+              <div className='rounded-lg border p-3 text-sm'>
+                <div className='mb-2 flex items-center gap-2 font-medium'>
+                  <ShieldCheck className='size-4' /> Security gates
+                </div>
+                <ul className='list-disc space-y-1 pl-5 text-muted-foreground'>
+                  <li>Require preview before destructive or broad changes.</li>
+                  <li>
+                    Require explicit confirmation and an audit reason before
+                    save/write.
+                  </li>
+                  <li>Show policy decisions and audit links without values.</li>
+                </ul>
+              </div>
+
+              <div className='flex flex-wrap gap-2'>
+                <Button type='button'>Test selected source</Button>
+                <Button type='button' variant='outline'>
+                  Cancel setup
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <CheckCircle2 className='size-4' /> Covered setup states
+            </CardTitle>
+            <CardDescription>
+              This first slice makes the states visible before wiring live
+              Secrets Broker APIs.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 text-sm md:grid-cols-2 lg:grid-cols-3'>
+            <div>Blank install: choose local/file/exec/external source.</div>
+            <div>Existing vault on new machine: import or re-wrap.</div>
+            <div>External auth required: show affected refs first.</div>
+            <div>Service dependency blocked: explain source/policy reason.</div>
+            <div>OpenClaw exec adapter: namespace and last check only.</div>
+            <div>
+              Generated secret write-back: policy and audit, value hidden.
+            </div>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -1,0 +1,81 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+describe('Secrets Broker setup wizard', () => {
+  it('shows the safe setup contract without plaintext values', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(
+      await screen.findByRole('heading', { name: /Secrets Broker setup/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Values hidden/i)).toBeVisible()
+    expect(screen.getAllByText(/Local encrypted vault/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/OpenClaw exec adapter/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
+    expect(screen.getByText(/SecretRef:/i)).toBeVisible()
+    expect(screen.getAllByText(/value hidden/i)[0]).toBeVisible()
+    expect(screen.queryByText('supersecret')).not.toBeInTheDocument()
+    expect(screen.queryByText('plaintext secret')).not.toBeInTheDocument()
+  })
+
+  it('covers locked, auth-required, degraded, policy-denied, cancel, and ready states', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getAllByText(/Locked/i)[0]).toBeVisible()
+    expect(screen.getByText(/import portable master key/i)).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: /File source/i }))
+    expect(screen.getAllByText(/Degraded/i)[0]).toBeVisible()
+    expect(screen.getByText(/Risky broad paths are rejected/i)).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /OpenClaw exec adapter/i })
+    )
+    expect(screen.getAllByText(/Policy denied/i)[0]).toBeVisible()
+    expect(screen.getByText(/namespace allowlist/i)).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /External source auth/i })
+    )
+    expect(screen.getAllByText(/Auth required/i)[0]).toBeVisible()
+    expect(screen.getByText(/Authenticate the external source/i)).toBeVisible()
+    expect(screen.getByText(/payments-api:STRIPE_KEY/i)).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /Generated secret write-back/i })
+    )
+    expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Ready/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/Confirm operation, policy decision, and audit reason/i)
+    ).toBeVisible()
+    expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+  })
+
+  it('shows affected refs before unlock or auth prompts', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    const affectedSection = screen.getByText(
+      /Affected refs and services/i
+    ).parentElement
+    expect(affectedSection).toBeTruthy()
+    expect(
+      within(affectedSection!).getByText(/echo-service:DB_PASSWORD/i)
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /External source auth/i })
+    )
+    const updatedSection = screen.getByText(
+      /Affected refs and services/i
+    ).parentElement
+    expect(updatedSection).toBeTruthy()
+    expect(
+      within(updatedSection!).getByText(/backup-worker:AWS_SECRET_ACCESS_KEY/i)
+    ).toBeVisible()
+  })
+})

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as AuthenticatedUsersIndexRouteImport } from './routes/_authentic
 import { Route as AuthenticatedTasksIndexRouteImport } from './routes/_authenticated/tasks/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedServicesIndexRouteImport } from './routes/_authenticated/services/index'
+import { Route as AuthenticatedSecretsBrokerIndexRouteImport } from './routes/_authenticated/secrets-broker/index'
 import { Route as AuthenticatedRuntimeIndexRouteImport } from './routes/_authenticated/runtime/index'
 import { Route as AuthenticatedNetworkIndexRouteImport } from './routes/_authenticated/network/index'
 import { Route as AuthenticatedLogsIndexRouteImport } from './routes/_authenticated/logs/index'
@@ -152,6 +153,12 @@ const AuthenticatedServicesIndexRoute =
   AuthenticatedServicesIndexRouteImport.update({
     id: '/services/',
     path: '/services/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedSecretsBrokerIndexRoute =
+  AuthenticatedSecretsBrokerIndexRouteImport.update({
+    id: '/secrets-broker/',
+    path: '/secrets-broker/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedRuntimeIndexRoute =
@@ -283,6 +290,7 @@ export interface FileRoutesByFullPath {
   '/logs/': typeof AuthenticatedLogsIndexRoute
   '/network/': typeof AuthenticatedNetworkIndexRoute
   '/runtime/': typeof AuthenticatedRuntimeIndexRoute
+  '/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/services/': typeof AuthenticatedServicesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/tasks/': typeof AuthenticatedTasksIndexRoute
@@ -319,6 +327,7 @@ export interface FileRoutesByTo {
   '/logs': typeof AuthenticatedLogsIndexRoute
   '/network': typeof AuthenticatedNetworkIndexRoute
   '/runtime': typeof AuthenticatedRuntimeIndexRoute
+  '/secrets-broker': typeof AuthenticatedSecretsBrokerIndexRoute
   '/services': typeof AuthenticatedServicesIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/tasks': typeof AuthenticatedTasksIndexRoute
@@ -360,6 +369,7 @@ export interface FileRoutesById {
   '/_authenticated/logs/': typeof AuthenticatedLogsIndexRoute
   '/_authenticated/network/': typeof AuthenticatedNetworkIndexRoute
   '/_authenticated/runtime/': typeof AuthenticatedRuntimeIndexRoute
+  '/_authenticated/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/_authenticated/services/': typeof AuthenticatedServicesIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/_authenticated/tasks/': typeof AuthenticatedTasksIndexRoute
@@ -399,6 +409,7 @@ export interface FileRouteTypes {
     | '/logs/'
     | '/network/'
     | '/runtime/'
+    | '/secrets-broker/'
     | '/services/'
     | '/settings/'
     | '/tasks/'
@@ -435,6 +446,7 @@ export interface FileRouteTypes {
     | '/logs'
     | '/network'
     | '/runtime'
+    | '/secrets-broker'
     | '/services'
     | '/settings'
     | '/tasks'
@@ -475,6 +487,7 @@ export interface FileRouteTypes {
     | '/_authenticated/logs/'
     | '/_authenticated/network/'
     | '/_authenticated/runtime/'
+    | '/_authenticated/secrets-broker/'
     | '/_authenticated/services/'
     | '/_authenticated/settings/'
     | '/_authenticated/tasks/'
@@ -646,6 +659,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedServicesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/': {
+      id: '/_authenticated/secrets-broker/'
+      path: '/secrets-broker'
+      fullPath: '/secrets-broker/'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/runtime/': {
       id: '/_authenticated/runtime/'
       path: '/runtime'
@@ -804,6 +824,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedLogsIndexRoute: typeof AuthenticatedLogsIndexRoute
   AuthenticatedNetworkIndexRoute: typeof AuthenticatedNetworkIndexRoute
   AuthenticatedRuntimeIndexRoute: typeof AuthenticatedRuntimeIndexRoute
+  AuthenticatedSecretsBrokerIndexRoute: typeof AuthenticatedSecretsBrokerIndexRoute
   AuthenticatedServicesIndexRoute: typeof AuthenticatedServicesIndexRoute
   AuthenticatedTasksIndexRoute: typeof AuthenticatedTasksIndexRoute
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute
@@ -823,6 +844,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedLogsIndexRoute: AuthenticatedLogsIndexRoute,
   AuthenticatedNetworkIndexRoute: AuthenticatedNetworkIndexRoute,
   AuthenticatedRuntimeIndexRoute: AuthenticatedRuntimeIndexRoute,
+  AuthenticatedSecretsBrokerIndexRoute: AuthenticatedSecretsBrokerIndexRoute,
   AuthenticatedServicesIndexRoute: AuthenticatedServicesIndexRoute,
   AuthenticatedTasksIndexRoute: AuthenticatedTasksIndexRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,

--- a/src/routes/_authenticated/secrets-broker/index.tsx
+++ b/src/routes/_authenticated/secrets-broker/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretsBrokerSetupWizard } from '@/features/secrets-broker'
+
+export const Route = createFileRoute('/_authenticated/secrets-broker/')({
+  component: SecretsBrokerSetupWizard,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -49,6 +49,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Variables',
   },
   {
+    path: '/secrets-broker',
+    heading: /^Secrets Broker setup$/i,
+    title: 'Service Admin - Secrets Broker Setup',
+  },
+  {
     path: '/network',
     heading: /^Network$/i,
     title: 'Service Admin - Network',


### PR DESCRIPTION
## Summary
- adds a spec-first Secrets Broker setup wizard contract in `docs/secrets-broker-setup-wizard.md`
- adds `/secrets-broker` Service Admin route and sidebar navigation
- implements a safe first UI slice covering local vault, file source, OpenClaw exec adapter, external auth, and generated write-back states
- keeps all examples SecretRef/value-hidden only; no resolved plaintext values are rendered
- adds tests for happy/safe contract, locked/new-machine, degraded/risky config, policy denial, external auth-required, cancel, affected refs, and no-plaintext rendering

## Validation
- `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx src/test/app-screens.test.tsx`
- `npm run format:check`
- `npm run lint` (passes with existing warnings in installed/logs/network/runtime/variables)
- `npm run build` (passes with existing Vite chunk-size/esbuild warnings)
- `git diff --check`

Closes #37.