### PR TITLE
#36 Add safe SecretRef usage view

### DIFF
--- a/src/features/dependencies/index.tsx
+++ b/src/features/dependencies/index.tsx
@@ -11,10 +11,12 @@ import {
   ArrowDown,
   ArrowRight,
   GitBranch,
+  KeyRound,
   Link2,
   Network,
   Save,
   Search,
+  ShieldCheck,
   Star,
   Undo2,
   Workflow,
@@ -57,6 +59,12 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search as GlobalSearch } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  buildSecretRefUsageRows,
+  groupSecretRefUsageByRef,
+  groupSecretRefUsageByService,
+  type SecretRefOutcome,
+} from './secret-ref-usage'
 
 const route = getRouteApi('/_authenticated/dependencies/')
 
@@ -109,6 +117,24 @@ function StatusBadge({ status }: { status: DashboardService['status'] }) {
   return <Badge variant='outline'>Stopped</Badge>
 }
 
+function SecretRefOutcomeBadge({ outcome }: { outcome: SecretRefOutcome }) {
+  if (outcome === 'resolved') {
+    return (
+      <Badge className='bg-emerald-600 hover:bg-emerald-600'>Resolved</Badge>
+    )
+  }
+
+  if (outcome === 'denied') {
+    return <Badge variant='destructive'>Denied</Badge>
+  }
+
+  if (outcome === 'missing') {
+    return <Badge variant='secondary'>Missing</Badge>
+  }
+
+  return <Badge variant='outline'>Unresolved</Badge>
+}
+
 function DependenciesLoading() {
   return (
     <div className='space-y-4'>
@@ -155,6 +181,29 @@ export function Dependencies() {
   const favoriteFeature = useFavoriteFeatureState()
 
   const services = useMemo(() => servicesQuery.data ?? [], [servicesQuery.data])
+
+  const secretRefUsageRows = useMemo(
+    () => buildSecretRefUsageRows(services),
+    [services]
+  )
+
+  const secretRefUsageByService = useMemo(
+    () => groupSecretRefUsageByService(secretRefUsageRows),
+    [secretRefUsageRows]
+  )
+
+  const secretRefUsageByRef = useMemo(
+    () => groupSecretRefUsageByRef(secretRefUsageRows),
+    [secretRefUsageRows]
+  )
+
+  const blockedSecretRefRows = useMemo(
+    () =>
+      secretRefUsageRows.filter(
+        (row) => row.outcome === 'denied' || row.outcome === 'missing'
+      ),
+    [secretRefUsageRows]
+  )
 
   const availableCategories = useMemo(
     () => Array.from(new Set(services.map((service) => getCategory(service)))),
@@ -578,6 +627,215 @@ export function Dependencies() {
                 </CardContent>
               </Card>
             </div>
+
+            <Card>
+              <CardHeader>
+                <div className='flex flex-wrap items-start justify-between gap-3'>
+                  <div>
+                    <CardTitle className='flex items-center gap-2'>
+                      <KeyRound className='size-4' /> Secrets Broker reference
+                      usage
+                    </CardTitle>
+                    <CardDescription>
+                      Safe metadata only: ref names, import direction, source,
+                      provider connection, last outcome, and affected services.
+                    </CardDescription>
+                  </div>
+                  <Badge variant='secondary'>Values hidden</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className='space-y-5'>
+                <div className='grid gap-3 md:grid-cols-4'>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-2xl font-bold'>
+                      {secretRefUsageRows.length}
+                    </div>
+                    <p className='text-xs text-muted-foreground'>
+                      tracked broker refs
+                    </p>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-2xl font-bold'>
+                      {secretRefUsageByService.length}
+                    </div>
+                    <p className='text-xs text-muted-foreground'>
+                      consuming services/workflows
+                    </p>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-2xl font-bold'>
+                      {secretRefUsageByRef.length}
+                    </div>
+                    <p className='text-xs text-muted-foreground'>
+                      ref-centric groups
+                    </p>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-2xl font-bold'>
+                      {blockedSecretRefRows.length}
+                    </div>
+                    <p className='text-xs text-muted-foreground'>
+                      missing or denied refs
+                    </p>
+                  </div>
+                </div>
+
+                <div className='grid gap-4 lg:grid-cols-2'>
+                  <div className='space-y-3'>
+                    <div className='flex items-center gap-2 text-sm font-medium'>
+                      <Workflow className='size-4' /> By service/workflow
+                    </div>
+                    {secretRefUsageByService.length ? (
+                      secretRefUsageByService.map((group) => (
+                        <div
+                          key={group.serviceId}
+                          className='rounded-lg border p-3'
+                        >
+                          <div className='mb-2 flex flex-wrap items-center justify-between gap-2'>
+                            <div>
+                              <div className='font-medium'>
+                                {group.serviceName}
+                              </div>
+                              <div className='text-xs text-muted-foreground'>
+                                {group.serviceId}
+                              </div>
+                            </div>
+                            <Badge variant='outline'>
+                              {group.refs.length} imports
+                            </Badge>
+                          </div>
+                          <div className='space-y-2'>
+                            {group.refs.map((row) => (
+                              <div
+                                key={row.id}
+                                className='rounded-md bg-muted/40 p-2 text-sm'
+                              >
+                                <div className='mb-1 flex flex-wrap items-center gap-2'>
+                                  <span className='font-mono break-all'>
+                                    {row.ref}
+                                  </span>
+                                  <SecretRefOutcomeBadge
+                                    outcome={row.outcome}
+                                  />
+                                  {row.legacyGlobalEnv ? (
+                                    <Badge variant='secondary'>
+                                      globalenv legacy
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                                <div className='text-xs text-muted-foreground'>
+                                  {row.direction} from {row.source} via{' '}
+                                  {row.providerConnection}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className='rounded-lg border border-dashed p-3 text-sm text-muted-foreground'>
+                        No Secrets Broker refs are recorded for the current
+                        services yet.
+                      </div>
+                    )}
+                  </div>
+
+                  <div className='space-y-3'>
+                    <div className='flex items-center gap-2 text-sm font-medium'>
+                      <KeyRound className='size-4' /> By broker namespace/ref
+                    </div>
+                    {secretRefUsageByRef.length ? (
+                      secretRefUsageByRef.map((group) => (
+                        <div key={group.ref} className='rounded-lg border p-3'>
+                          <div className='mb-2 flex flex-wrap items-center justify-between gap-2'>
+                            <div>
+                              <div className='font-mono text-sm break-all'>
+                                {group.ref}
+                              </div>
+                              <div className='text-xs text-muted-foreground'>
+                                namespace: {group.namespace}
+                              </div>
+                            </div>
+                            <Badge variant='outline'>
+                              {group.services.length} consumers
+                            </Badge>
+                          </div>
+                          <div className='space-y-2'>
+                            {group.services.map((row) => (
+                              <div
+                                key={row.id}
+                                className='rounded-md bg-muted/40 p-2 text-sm'
+                              >
+                                <div className='mb-1 flex flex-wrap items-center gap-2'>
+                                  <Button
+                                    variant='link'
+                                    size='sm'
+                                    className='h-auto p-0'
+                                    asChild
+                                  >
+                                    <Link
+                                      to='/services/$serviceId'
+                                      params={{ serviceId: row.serviceId }}
+                                    >
+                                      {row.serviceName}
+                                    </Link>
+                                  </Button>
+                                  <SecretRefOutcomeBadge
+                                    outcome={row.outcome}
+                                  />
+                                </div>
+                                <div className='text-xs text-muted-foreground'>
+                                  last resolved:{' '}
+                                  {row.lastResolvedAt ?? 'not successful yet'}
+                                </div>
+                                {row.outcome === 'denied' ||
+                                row.outcome === 'missing' ? (
+                                  <div className='mt-2 flex flex-wrap gap-2'>
+                                    <Button variant='outline' size='sm' asChild>
+                                      <Link
+                                        to='/logs'
+                                        search={{ service: row.serviceId }}
+                                      >
+                                        Open diagnostics/logs
+                                      </Link>
+                                    </Button>
+                                    <Button variant='outline' size='sm' asChild>
+                                      <Link
+                                        to='/variables'
+                                        search={{ service: row.serviceId }}
+                                      >
+                                        Inspect safe variables
+                                      </Link>
+                                    </Button>
+                                  </div>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className='rounded-lg border border-dashed p-3 text-sm text-muted-foreground'>
+                        No broker namespace/ref metadata is available yet.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className='flex gap-3 rounded-lg border p-3 text-sm'>
+                  <ShieldCheck className='mt-0.5 size-4 shrink-0' />
+                  <div>
+                    <div className='font-medium'>No secret values rendered</div>
+                    <p className='text-muted-foreground'>
+                      This view intentionally shows only SecretRef identifiers,
+                      provider/source names, outcomes, and navigation links.
+                      Resolved plaintext never appears in table cells, badges,
+                      tooltips, or links.
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
 
             <Card>
               <CardHeader>

--- a/src/features/dependencies/secret-ref-usage.test.tsx
+++ b/src/features/dependencies/secret-ref-usage.test.tsx
@@ -1,0 +1,86 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  buildSecretRefUsageRows,
+  groupSecretRefUsageByRef,
+  groupSecretRefUsageByService,
+} from './secret-ref-usage'
+
+describe('Secrets Broker reference usage view', () => {
+  it('renders service-centric and ref-centric usage without secret values', async () => {
+    await renderRoute('/dependencies')
+
+    expect(
+      await screen.findByText(/Secrets Broker reference usage/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Values hidden/i)).toBeVisible()
+    expect(screen.getByText(/By service\/workflow/i)).toBeVisible()
+    expect(screen.getByText(/By broker namespace\/ref/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/openclaw\/anthropic\/api_key/i)[0]
+    ).toBeVisible()
+    expect(screen.getAllByText(/postgres\.ADMIN_PASSWORD/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/telegram\.bot_token/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Denied/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Missing/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Open diagnostics\/logs/i)[0]).toBeVisible()
+    expect(screen.queryByText(/supersecret/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/plaintext secret/i)).not.toBeInTheDocument()
+  })
+
+  it('groups the same safe metadata by service and by ref', () => {
+    const rows = buildSecretRefUsageRows([
+      {
+        id: '@serviceadmin',
+        name: 'Service Admin UI',
+        status: 'running',
+        favorite: false,
+        note: '',
+        links: [],
+        installed: true,
+        role: 'Operator dashboard',
+        runtimeHealth: {
+          state: 'running',
+          health: 'healthy',
+          uptime: '1m',
+          lastCheckAt: '2026-05-07T17:40:00Z',
+          summary: 'ok',
+        },
+        endpoints: [],
+        metadata: {
+          serviceType: 'ui-admin',
+          runtime: 'node',
+          version: 'test',
+          build: 'test',
+        },
+        dependencies: [],
+        dependents: [],
+        environmentVariables: [
+          {
+            key: 'OPENCLAW_ANTHROPIC_API_KEY',
+            value: 'secret://openclaw/anthropic/api_key',
+            scope: 'service',
+            secret: true,
+            source: '@secretsbroker/openclaw/service-lasso',
+          },
+        ],
+        recentLogs: [],
+        actions: [],
+      },
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      ref: 'openclaw/anthropic/api_key',
+      serviceId: '@serviceadmin',
+      outcome: 'resolved',
+    })
+    expect(groupSecretRefUsageByService(rows)[0].serviceName).toBe(
+      'Service Admin UI'
+    )
+    expect(groupSecretRefUsageByRef(rows)[0].namespace).toBe(
+      'openclaw/anthropic'
+    )
+  })
+})

--- a/src/features/dependencies/secret-ref-usage.ts
+++ b/src/features/dependencies/secret-ref-usage.ts
@@ -1,0 +1,129 @@
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+
+export type SecretRefOutcome = 'resolved' | 'missing' | 'denied' | 'unresolved'
+
+export type SecretRefUsageRow = {
+  id: string
+  ref: string
+  namespace: string
+  serviceId: string
+  serviceName: string
+  direction: 'imports' | 'exports'
+  providerConnection: string
+  source: string
+  lastResolvedAt: string | null
+  outcome: SecretRefOutcome
+  legacyGlobalEnv: boolean
+}
+
+const knownSecretRefMetadata: Record<
+  string,
+  Pick<
+    SecretRefUsageRow,
+    'providerConnection' | 'source' | 'lastResolvedAt' | 'outcome'
+  >
+> = {
+  'openclaw/anthropic/api_key': {
+    providerConnection: 'OpenClaw SecretRef adapter',
+    source: '@secretsbroker/openclaw/service-lasso',
+    lastResolvedAt: '2026-05-07T17:40:00Z',
+    outcome: 'resolved',
+  },
+  'postgres.ADMIN_PASSWORD': {
+    providerConnection: 'Local encrypted vault',
+    source: '@secretsbroker/local/default',
+    lastResolvedAt: null,
+    outcome: 'denied',
+  },
+  'telegram.bot_token': {
+    providerConnection: 'External token store',
+    source: '@secretsbroker/external/ops',
+    lastResolvedAt: null,
+    outcome: 'missing',
+  },
+  '@serviceadmin/SESSION_SECRET': {
+    providerConnection: 'Generated secret write-back',
+    source: '@secretsbroker/local/default',
+    lastResolvedAt: '2026-05-07T16:58:00Z',
+    outcome: 'resolved',
+  },
+}
+
+function normalizeSecretRef(value: string) {
+  return value
+    .replace(/^secret:\/\//, '')
+    .replace(/^secretsbroker:\/\//, '')
+    .replace(/^exec:\/\//, '')
+    .replace(/^vault:\/\//, '')
+}
+
+function isSecretRefLike(value: string, source?: string) {
+  return (
+    /^(secret|secretsbroker|exec|vault):\/\//i.test(value) ||
+    /@secretsbroker|Secrets Broker|SecretRef/i.test(source ?? '')
+  )
+}
+
+function namespaceFor(ref: string) {
+  if (ref.includes('/')) return ref.split('/').slice(0, -1).join('/')
+  if (ref.includes('.')) return ref.split('.').slice(0, -1).join('.')
+  return 'default'
+}
+
+export function buildSecretRefUsageRows(
+  services: DashboardService[]
+): SecretRefUsageRow[] {
+  return services
+    .flatMap((service) =>
+      service.environmentVariables
+        .filter((variable) => isSecretRefLike(variable.value, variable.source))
+        .map((variable) => {
+          const ref = normalizeSecretRef(variable.value)
+          const known = knownSecretRefMetadata[ref]
+
+          return {
+            id: `${service.id}:${variable.key}:${ref}`,
+            ref,
+            namespace: namespaceFor(ref),
+            serviceId: service.id,
+            serviceName: service.name,
+            direction: 'imports' as const,
+            providerConnection:
+              known?.providerConnection ?? 'Secrets Broker provider',
+            source: known?.source ?? variable.source ?? '@secretsbroker',
+            lastResolvedAt: known?.lastResolvedAt ?? null,
+            outcome: known?.outcome ?? 'unresolved',
+            legacyGlobalEnv: variable.source?.toLowerCase() === 'globalenv',
+          }
+        })
+    )
+    .sort((a, b) => a.ref.localeCompare(b.ref))
+}
+
+export function groupSecretRefUsageByService(rows: SecretRefUsageRow[]) {
+  const map = new Map<string, SecretRefUsageRow[]>()
+
+  rows.forEach((row) => {
+    map.set(row.serviceId, [...(map.get(row.serviceId) ?? []), row])
+  })
+
+  return Array.from(map.entries()).map(([serviceId, refs]) => ({
+    serviceId,
+    serviceName: refs[0]?.serviceName ?? serviceId,
+    refs,
+  }))
+}
+
+export function groupSecretRefUsageByRef(rows: SecretRefUsageRow[]) {
+  const map = new Map<string, SecretRefUsageRow[]>()
+
+  rows.forEach((row) => {
+    map.set(row.ref, [...(map.get(row.ref) ?? []), row])
+  })
+
+  return Array.from(map.entries()).map(([ref, services]) => ({
+    ref,
+    namespace: services[0]?.namespace ?? 'default',
+    services,
+  }))
+}

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -266,6 +266,20 @@ const defaultServices: DashboardService[] = [
         source: '.env.local',
       },
       {
+        key: 'SESSION_SECRET',
+        value: 'secret://@serviceadmin/SESSION_SECRET',
+        scope: 'service',
+        secret: true,
+        source: '@secretsbroker/local/default',
+      },
+      {
+        key: 'OPENCLAW_ANTHROPIC_API_KEY',
+        value: 'secret://openclaw/anthropic/api_key',
+        scope: 'service',
+        secret: true,
+        source: '@secretsbroker/openclaw/service-lasso',
+      },
+      {
         key: 'SERVICE_LASSO_ROOT',
         value: 'C:\\service-lasso',
         scope: 'global',
@@ -360,6 +374,13 @@ const defaultServices: DashboardService[] = [
         source: 'zitadel.env',
       },
       {
+        key: 'POSTGRES_ADMIN_PASSWORD',
+        value: 'secret://postgres.ADMIN_PASSWORD',
+        scope: 'service',
+        secret: true,
+        source: '@secretsbroker/local/default',
+      },
+      {
         key: 'SERVICE_LASSO_ROOT',
         value: 'C:\\service-lasso',
         scope: 'global',
@@ -442,6 +463,13 @@ const defaultServices: DashboardService[] = [
         value: 'C:\\service-lasso\\dagu',
         scope: 'service',
         source: 'service.json',
+      },
+      {
+        key: 'TELEGRAM_BOT_TOKEN',
+        value: 'secret://telegram.bot_token',
+        scope: 'service',
+        secret: true,
+        source: '@secretsbroker/external/ops',
       },
       {
         key: 'SERVICE_LASSO_ROOT',


### PR DESCRIPTION
## Summary
- adds a safe metadata-only Secrets Broker reference usage panel to Dependencies
- groups SecretRef usage by consuming service/workflow and by broker namespace/ref
- surfaces resolved/missing/denied/unresolved outcomes plus diagnostics/logs and safe-variable links for blocked refs
- adds stub SecretRef metadata and regression coverage that plaintext values are not rendered

Closes #36

## Validation
- `npm run test -- src/features/dependencies/secret-ref-usage.test.tsx src/features/secrets-broker/secrets-broker-setup.test.tsx` — 5 passed
- `npm run test` — 54 passed
- `npm run lint` — passed with existing warnings only (TanStack Table/react-hooks warnings in installed/network/runtime/variables/logs)
- `npm run build` — passed

## Safety
- UI displays safe metadata only: ref identifiers, source/provider labels, timestamps, outcomes, and navigation links.
- No resolved/plaintext secret values are included in stub data or rendered cells/badges/links.
