### PR TITLE
#35 Add secret-safe broker diagnostics

### DIFF
--- a/src/features/secrets-broker/diagnostics.ts
+++ b/src/features/secrets-broker/diagnostics.ts
@@ -1,0 +1,162 @@
+export type SecretsBrokerDiagnosticStatus = 'pass' | 'warning' | 'fail'
+
+export type SecretsBrokerDiagnosticCategory =
+  | 'configuration'
+  | 'permission'
+  | 'provider'
+  | 'auth'
+  | 'runtime'
+
+export type SecretsBrokerDiagnostic = {
+  id: string
+  title: string
+  category: SecretsBrokerDiagnosticCategory
+  status: SecretsBrokerDiagnosticStatus
+  lastCheckedAt: string
+  code: string
+  normalizedMessage: string
+  suggestedFix: string
+  affectedRefs: string[]
+  affectedServices: string[]
+  sourceLabel: string
+  link: {
+    label: string
+    to: '/dependencies' | '/logs' | '/variables' | '/secrets-broker'
+    search?: Record<string, string>
+  }
+}
+
+const secretLikePatterns = [
+  /secret\s*[=:]\s*[^\s,;]+/gi,
+  /password\s*[=:]\s*[^\s,;]+/gi,
+  /token\s*[=:]\s*[^\s,;]+/gi,
+  /api[_-]?key\s*[=:]\s*[^\s,;]+/gi,
+  /AKIA[0-9A-Z]{16}/g,
+  /sk-[A-Za-z0-9_-]{12,}/g,
+]
+
+export function scrubSecretLikeOutput(message: string) {
+  return secretLikePatterns.reduce(
+    (scrubbed, pattern) => scrubbed.replace(pattern, '[redacted]'),
+    message
+  )
+}
+
+const diagnosticFixtures: Array<
+  Omit<SecretsBrokerDiagnostic, 'normalizedMessage'> & {
+    rawMessage: string
+  }
+> = [
+  {
+    id: 'broker-api-reachable',
+    title: 'Broker API reachable',
+    category: 'runtime',
+    status: 'pass',
+    lastCheckedAt: '2026-05-07T18:10:00Z',
+    code: 'broker_api_reachable',
+    rawMessage: 'Broker health endpoint responded with ready state.',
+    suggestedFix:
+      'No action required; retry refs from the affected service if needed.',
+    affectedRefs: [],
+    affectedServices: ['@secretsbroker'],
+    sourceLabel: '@secretsbroker runtime API',
+    link: {
+      label: 'Open broker logs',
+      to: '/logs',
+      search: { service: '@secretsbroker' },
+    },
+  },
+  {
+    id: 'local-store-locked',
+    title: 'Local vault readable',
+    category: 'auth',
+    status: 'fail',
+    lastCheckedAt: '2026-05-07T18:09:30Z',
+    code: 'locked',
+    rawMessage:
+      'Local vault is locked; password=correct-horse-battery-staple was not accepted.',
+    suggestedFix:
+      'Unlock the local store or import/re-wrap the portable master key for this machine.',
+    affectedRefs: ['postgres.ADMIN_PASSWORD'],
+    affectedServices: ['postgres'],
+    sourceLabel: '@secretsbroker/local/default',
+    link: { label: 'Inspect affected refs', to: '/dependencies' },
+  },
+  {
+    id: 'external-source-auth',
+    title: 'External source authentication',
+    category: 'auth',
+    status: 'fail',
+    lastCheckedAt: '2026-05-07T18:08:58Z',
+    code: 'source_auth_required',
+    rawMessage:
+      'Vault token expired while reading telegram.bot_token; token=ghp_examplePlaintextToken.',
+    suggestedFix:
+      'Re-authenticate the external source, then retry only the affected refs.',
+    affectedRefs: ['telegram.bot_token'],
+    affectedServices: ['@serviceadmin'],
+    sourceLabel: '@secretsbroker/external/ops',
+    link: {
+      label: 'Open safe variables',
+      to: '/variables',
+      search: { service: '@serviceadmin' },
+    },
+  },
+  {
+    id: 'exec-adapter-policy',
+    title: 'OpenClaw SecretRef exec adapter',
+    category: 'permission',
+    status: 'fail',
+    lastCheckedAt: '2026-05-07T18:07:44Z',
+    code: 'policy_denied',
+    rawMessage:
+      'Request denied for openclaw/anthropic/api_key; api_key=sk-this-value-must-not-render.',
+    suggestedFix:
+      'Review namespace/action allowlist and record the service or workflow identity in audit before retrying.',
+    affectedRefs: ['openclaw/anthropic/api_key'],
+    affectedServices: ['@serviceadmin'],
+    sourceLabel: 'OpenClaw SecretRef adapter',
+    link: {
+      label: 'Open diagnostics logs',
+      to: '/logs',
+      search: { service: '@serviceadmin' },
+    },
+  },
+  {
+    id: 'workflow-runtime-integration',
+    title: 'Workflow runtime integration',
+    category: 'runtime',
+    status: 'warning',
+    lastCheckedAt: '2026-05-07T18:06:20Z',
+    code: 'runtime_integration_degraded',
+    rawMessage:
+      'Dagu run identity is missing a secretsbroker:read grant for optional refs.',
+    suggestedFix:
+      'Refresh the workflow launch identity or narrow the workflow ref set before the next run.',
+    affectedRefs: ['openclaw/anthropic/api_key'],
+    affectedServices: ['dagu:daily-ai-summary'],
+    sourceLabel: 'Dagu workflow runtime',
+    link: { label: 'Open reference usage', to: '/dependencies' },
+  },
+]
+
+export const secretsBrokerDiagnostics: SecretsBrokerDiagnostic[] =
+  diagnosticFixtures.map(({ rawMessage, ...diagnostic }) => ({
+    ...diagnostic,
+    normalizedMessage: scrubSecretLikeOutput(rawMessage),
+  }))
+
+export function countDiagnosticsByStatus(
+  diagnostics: SecretsBrokerDiagnostic[]
+) {
+  return diagnostics.reduce(
+    (counts, diagnostic) => ({
+      ...counts,
+      [diagnostic.status]: counts[diagnostic.status] + 1,
+    }),
+    { pass: 0, warning: 0, fail: 0 } satisfies Record<
+      SecretsBrokerDiagnosticStatus,
+      number
+    >
+  )
+}

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -26,6 +26,12 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  countDiagnosticsByStatus,
+  secretsBrokerDiagnostics,
+  type SecretsBrokerDiagnostic,
+  type SecretsBrokerDiagnosticStatus,
+} from './diagnostics'
 
 type WizardSource = {
   id: string
@@ -131,6 +137,21 @@ const statusVariant: Record<
   'policy-denied': 'destructive',
 }
 
+const diagnosticStatusCopy: Record<SecretsBrokerDiagnosticStatus, string> = {
+  pass: 'Passing',
+  warning: 'Warning',
+  fail: 'Failing',
+}
+
+const diagnosticStatusVariant: Record<
+  SecretsBrokerDiagnosticStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  pass: 'default',
+  warning: 'secondary',
+  fail: 'destructive',
+}
+
 function SourceIcon({ source }: { source: WizardSource }) {
   if (source.id === 'local-vault') return <LockKeyhole className='size-4' />
   if (source.id === 'file-source') return <FileKey2 className='size-4' />
@@ -180,6 +201,76 @@ function SafeExample({ value }: { value: string }) {
   )
 }
 
+function DiagnosticCard({
+  diagnostic,
+}: {
+  diagnostic: SecretsBrokerDiagnostic
+}) {
+  return (
+    <div className='rounded-lg border p-3 text-sm'>
+      <div className='mb-2 flex flex-wrap items-start justify-between gap-2'>
+        <div>
+          <div className='font-medium'>{diagnostic.title}</div>
+          <div className='text-xs text-muted-foreground'>
+            {diagnostic.category} · {diagnostic.code} · last checked{' '}
+            {diagnostic.lastCheckedAt}
+          </div>
+        </div>
+        <Badge variant={diagnosticStatusVariant[diagnostic.status]}>
+          {diagnosticStatusCopy[diagnostic.status]}
+        </Badge>
+      </div>
+      <p className='text-muted-foreground'>{diagnostic.normalizedMessage}</p>
+      <div className='mt-3 grid gap-2 md:grid-cols-2'>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Affected refs
+          </div>
+          <div className='mt-1 flex flex-wrap gap-1'>
+            {diagnostic.affectedRefs.length ? (
+              diagnostic.affectedRefs.map((ref) => (
+                <Badge key={ref} variant='outline'>
+                  {ref}
+                </Badge>
+              ))
+            ) : (
+              <span className='text-xs text-muted-foreground'>none</span>
+            )}
+          </div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Affected services/workflows
+          </div>
+          <div className='mt-1 flex flex-wrap gap-1'>
+            {diagnostic.affectedServices.map((service) => (
+              <Badge key={service} variant='outline'>
+                {service}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className='mt-3 rounded-md bg-muted/40 p-2'>
+        <div className='text-xs font-medium text-muted-foreground uppercase'>
+          Suggested fix
+        </div>
+        <div>{diagnostic.suggestedFix}</div>
+      </div>
+      <div className='mt-3 flex flex-wrap items-center justify-between gap-2'>
+        <span className='text-xs text-muted-foreground'>
+          Source: {diagnostic.sourceLabel}
+        </span>
+        <Button variant='outline' size='sm' asChild>
+          <Link to={diagnostic.link.to} search={diagnostic.link.search}>
+            {diagnostic.link.label}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 export function SecretsBrokerSetupWizard() {
   usePageMetadata({
     title: 'Service Admin - Secrets Broker Setup',
@@ -198,6 +289,7 @@ export function SecretsBrokerSetupWizard() {
     (source) => source.status === 'ready'
   ).length
   const blockedCount = wizardSources.length - readyCount
+  const diagnosticCounts = countDiagnosticsByStatus(secretsBrokerDiagnostics)
 
   return (
     <>
@@ -266,6 +358,63 @@ export function SecretsBrokerSetupWizard() {
             </CardContent>
           </Card>
         </div>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <AlertTriangle className='size-4' /> Diagnostics and
+                  troubleshooting
+                </CardTitle>
+                <CardDescription>
+                  Normalized, secret-safe checks for broker lifecycle, provider,
+                  auth, policy, and workflow runtime failures.
+                </CardDescription>
+              </div>
+              <Badge variant='secondary'>Raw output scrubbed</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-3'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-2xl font-bold'>
+                  {diagnosticCounts.pass}
+                </div>
+                <p className='text-xs text-muted-foreground'>passing checks</p>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-2xl font-bold'>
+                  {diagnosticCounts.warning}
+                </div>
+                <p className='text-xs text-muted-foreground'>degraded checks</p>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-2xl font-bold'>
+                  {diagnosticCounts.fail}
+                </div>
+                <p className='text-xs text-muted-foreground'>failed checks</p>
+              </div>
+            </div>
+            <div className='grid gap-3 lg:grid-cols-2'>
+              {secretsBrokerDiagnostics.map((diagnostic) => (
+                <DiagnosticCard key={diagnostic.id} diagnostic={diagnostic} />
+              ))}
+            </div>
+            <div className='flex gap-3 rounded-lg border p-3 text-sm'>
+              <ShieldCheck className='mt-0.5 size-4 shrink-0' />
+              <div>
+                <div className='font-medium'>Secret-safe diagnostics only</div>
+                <p className='text-muted-foreground'>
+                  Checks show normalized codes, source labels, affected refs,
+                  affected services or workflows, and suggested fixes. Raw
+                  command stdout/stderr and resolved secret values are never
+                  rendered.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         <div className='grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.9fr)]'>
           <Card>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -2,6 +2,7 @@ import { renderRoute } from '@/test/render-route'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
+import { secretsBrokerDiagnostics, scrubSecretLikeOutput } from './diagnostics'
 
 describe('Secrets Broker setup wizard', () => {
   it('shows the safe setup contract without plaintext values', async () => {
@@ -16,6 +17,8 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
     expect(screen.getByText(/SecretRef:/i)).toBeVisible()
     expect(screen.getAllByText(/value hidden/i)[0]).toBeVisible()
+    expect(screen.getByText(/Diagnostics and troubleshooting/i)).toBeVisible()
+    expect(screen.getByText(/Raw output scrubbed/i)).toBeVisible()
     expect(screen.queryByText('supersecret')).not.toBeInTheDocument()
     expect(screen.queryByText('plaintext secret')).not.toBeInTheDocument()
   })
@@ -41,7 +44,9 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByRole('button', { name: /External source auth/i })
     )
     expect(screen.getAllByText(/Auth required/i)[0]).toBeVisible()
-    expect(screen.getByText(/Authenticate the external source/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/Authenticate the external source/i)[0]
+    ).toBeVisible()
     expect(screen.getByText(/payments-api:STRIPE_KEY/i)).toBeVisible()
 
     await user.click(
@@ -53,6 +58,56 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Confirm operation, policy decision, and audit reason/i)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+  })
+
+  it('covers diagnostic failure categories and suggested fixes without raw secret output', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getByText(/Broker API reachable/i)).toBeVisible()
+    expect(screen.getByText(/Local vault readable/i)).toBeVisible()
+    expect(screen.getByText(/External source authentication/i)).toBeVisible()
+    expect(screen.getByText(/OpenClaw SecretRef exec adapter/i)).toBeVisible()
+    expect(screen.getByText(/Workflow runtime integration/i)).toBeVisible()
+    expect(screen.getAllByText(/locked/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/source_auth_required/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/policy_denied/i)[0]).toBeVisible()
+    expect(screen.getByText(/runtime_integration_degraded/i)).toBeVisible()
+    expect(screen.getByText(/Unlock the local store/i)).toBeVisible()
+    expect(
+      screen.getByText(/Re-authenticate the external source/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Review namespace\/action allowlist/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Refresh the workflow launch identity/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/Open diagnostics logs/i)[0]).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/ghp_examplePlaintextToken/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/sk-this-value-must-not-render/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('scrubs secret-like diagnostic output before rendering', () => {
+    expect(
+      scrubSecretLikeOutput(
+        'password=hunter2 token=ghp_secretValue api_key=sk-exampleSecret123456 AKIAABCDEFGHIJKLMNOP'
+      )
+    ).toBe('[redacted] [redacted] [redacted] [redacted]')
+    expect(
+      secretsBrokerDiagnostics.every(
+        (diagnostic) =>
+          !/hunter2|correct-horse|ghp_example|sk-this-value/i.test(
+            diagnostic.normalizedMessage
+          )
+      )
+    ).toBe(true)
   })
 
   it('shows affected refs before unlock or auth prompts', async () => {


### PR DESCRIPTION
## Summary
- adds a secret-safe diagnostics/troubleshooting panel to the Secrets Broker setup page
- distinguishes broker runtime, locked store, external source auth, policy denial, and workflow runtime degradation states
- shows normalized error codes/messages, affected refs/services, suggested fixes, and links to safe diagnostics/reference/variable surfaces
- adds scrubbing helper/tests so secret-like command output is redacted before rendering

Closes #35

## Validation
- `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 5 passed
- `npm run test` — 56 passed
- `npm run lint` — passed with existing warnings only (TanStack Table/react-hooks warnings in installed/network/runtime/variables/logs)
- `npm run build` — passed

## Safety
- Diagnostics render normalized messages only; raw command output is scrubbed.
- Tests assert password/token/api key-like values do not appear in the UI or diagnostic messages.
