### PR TITLE
Add Secrets Broker audit events UI

### DIFF
--- a/src/features/secrets-broker/audit-events.ts
+++ b/src/features/secrets-broker/audit-events.ts
@@ -1,0 +1,201 @@
+export type SecretsBrokerAuditEventType =
+  | 'resolve_granted'
+  | 'resolve_denied'
+  | 'external_provider_read'
+  | 'refresh_failure'
+  | 'reconnect_required'
+  | 'session_token_revoked'
+  | 'write_back_denied'
+  | 'secret_rotated'
+
+export type SecretsBrokerAuditOutcome =
+  | 'granted'
+  | 'denied'
+  | 'failure'
+  | 'revoked'
+  | 'success'
+
+export type SecretsBrokerAuditEvent = {
+  id: string
+  timestamp: string
+  type: SecretsBrokerAuditEventType
+  outcome: SecretsBrokerAuditOutcome
+  provider: 'local' | 'openclaw' | 'vault' | 'dagu' | 'onepassword'
+  source: string
+  connection: string
+  serviceOrWorkflow: string
+  actorType: 'service' | 'workflow' | 'operator' | 'cli-session'
+  actorId: string
+  ref: string
+  policyId: string
+  policyDecision: string
+  normalizedReason: string
+}
+
+export type SecretsBrokerAuditFilters = {
+  type?: SecretsBrokerAuditEventType | 'all'
+  outcome?: SecretsBrokerAuditOutcome | 'all'
+  provider?: SecretsBrokerAuditEvent['provider'] | 'all'
+  query?: string
+  since?: string
+  until?: string
+}
+
+export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
+  {
+    id: 'evt-20260507-001',
+    timestamp: '2026-05-07T18:20:00Z',
+    type: 'resolve_granted',
+    outcome: 'granted',
+    provider: 'openclaw',
+    source: '@secretsbroker/openclaw/service-lasso',
+    connection: 'OpenClaw SecretRef adapter',
+    serviceOrWorkflow: '@serviceadmin',
+    actorType: 'service',
+    actorId: '@serviceadmin',
+    ref: 'openclaw/anthropic/api_key',
+    policyId: 'policy/openclaw/service-lasso/read',
+    policyDecision: 'allow: namespace and service identity matched',
+    normalizedReason: 'Resolver granted access to the requested SecretRef.',
+  },
+  {
+    id: 'evt-20260507-002',
+    timestamp: '2026-05-07T18:19:15Z',
+    type: 'resolve_denied',
+    outcome: 'denied',
+    provider: 'local',
+    source: '@secretsbroker/local/default',
+    connection: 'Local encrypted vault',
+    serviceOrWorkflow: 'postgres',
+    actorType: 'service',
+    actorId: 'postgres',
+    ref: 'postgres.ADMIN_PASSWORD',
+    policyId: 'policy/local/default/read',
+    policyDecision: 'deny: service identity missing ref grant',
+    normalizedReason:
+      'Policy denied the read request before any value was resolved.',
+  },
+  {
+    id: 'evt-20260507-003',
+    timestamp: '2026-05-07T18:18:44Z',
+    type: 'refresh_failure',
+    outcome: 'failure',
+    provider: 'vault',
+    source: '@secretsbroker/external/ops',
+    connection: 'Vault kv/service-lasso',
+    serviceOrWorkflow: '@serviceadmin',
+    actorType: 'operator',
+    actorId: 'operator:max',
+    ref: 'telegram.bot_token',
+    policyId: 'policy/external/ops/refresh',
+    policyDecision: 'allow: refresh attempted',
+    normalizedReason:
+      'External provider refresh failed because source authentication is required.',
+  },
+  {
+    id: 'evt-20260507-004',
+    timestamp: '2026-05-07T18:17:12Z',
+    type: 'session_token_revoked',
+    outcome: 'revoked',
+    provider: 'openclaw',
+    source: '@secretsbroker/openclaw/session',
+    connection: 'CLI/session token',
+    serviceOrWorkflow: 'cli:service-lasso',
+    actorType: 'cli-session',
+    actorId: 'session:rotated',
+    ref: 'openclaw/session_token',
+    policyId: 'policy/openclaw/session/lifecycle',
+    policyDecision: 'revoke: token replaced by newer session',
+    normalizedReason: 'Session credential was revoked after rotation.',
+  },
+  {
+    id: 'evt-20260507-005',
+    timestamp: '2026-05-07T18:16:03Z',
+    type: 'external_provider_read',
+    outcome: 'success',
+    provider: 'onepassword',
+    source: '@secretsbroker/external/ops',
+    connection: '1Password ops vault',
+    serviceOrWorkflow: 'dagu:daily-ai-summary',
+    actorType: 'workflow',
+    actorId: 'dagu:daily-ai-summary/run/20260507',
+    ref: 'openclaw/anthropic/api_key',
+    policyId: 'policy/workflows/ai-summary/read',
+    policyDecision: 'allow: workflow run identity matched',
+    normalizedReason:
+      'External provider returned metadata for a successful read.',
+  },
+  {
+    id: 'evt-20260507-006',
+    timestamp: '2026-05-07T18:15:22Z',
+    type: 'write_back_denied',
+    outcome: 'denied',
+    provider: 'local',
+    source: '@secretsbroker/local/default',
+    connection: 'Generated secret write-back',
+    serviceOrWorkflow: '@serviceadmin',
+    actorType: 'service',
+    actorId: '@serviceadmin',
+    ref: '@serviceadmin/SESSION_SECRET',
+    policyId: 'policy/local/default/write-back',
+    policyDecision: 'deny: write-back requires operator audit reason',
+    normalizedReason:
+      'Generated secret write-back was denied before storing a value.',
+  },
+]
+
+export function filterSecretsBrokerAuditEvents(
+  events: SecretsBrokerAuditEvent[],
+  filters: SecretsBrokerAuditFilters
+) {
+  const sinceTime = filters.since ? Date.parse(filters.since) : Number.NaN
+  const untilTime = filters.until ? Date.parse(filters.until) : Number.NaN
+
+  return events.filter((event) => {
+    if (filters.type && filters.type !== 'all' && event.type !== filters.type) {
+      return false
+    }
+    if (
+      filters.outcome &&
+      filters.outcome !== 'all' &&
+      event.outcome !== filters.outcome
+    ) {
+      return false
+    }
+    if (
+      filters.provider &&
+      filters.provider !== 'all' &&
+      event.provider !== filters.provider
+    ) {
+      return false
+    }
+    const query = filters.query?.trim().toLowerCase()
+    if (query) {
+      const searchable = [
+        event.source,
+        event.connection,
+        event.serviceOrWorkflow,
+        event.actorType,
+        event.actorId,
+        event.ref,
+      ]
+        .join(' ')
+        .toLowerCase()
+      if (!searchable.includes(query)) {
+        return false
+      }
+    }
+    const eventTime = Date.parse(event.timestamp)
+    if (!Number.isNaN(sinceTime) && eventTime < sinceTime) {
+      return false
+    }
+    if (!Number.isNaN(untilTime) && eventTime > untilTime) {
+      return false
+    }
+    return true
+  })
+}
+
+export function auditEventTypeLabel(type: SecretsBrokerAuditEventType) {
+  return type.replace(/_/g, ' ')
+}

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -20,12 +20,21 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  auditEventTypeLabel,
+  filterSecretsBrokerAuditEvents,
+  secretsBrokerAuditEvents,
+  type SecretsBrokerAuditEvent,
+  type SecretsBrokerAuditEventType,
+  type SecretsBrokerAuditOutcome,
+} from './audit-events'
 import {
   countDiagnosticsByStatus,
   secretsBrokerDiagnostics,
@@ -152,6 +161,27 @@ const diagnosticStatusVariant: Record<
   fail: 'destructive',
 }
 
+const auditOutcomeVariant: Record<
+  SecretsBrokerAuditOutcome,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  granted: 'default',
+  success: 'default',
+  denied: 'destructive',
+  failure: 'secondary',
+  revoked: 'outline',
+}
+
+const auditTypes = Array.from(
+  new Set(secretsBrokerAuditEvents.map((event) => event.type))
+)
+const auditOutcomes = Array.from(
+  new Set(secretsBrokerAuditEvents.map((event) => event.outcome))
+)
+const auditProviders = Array.from(
+  new Set(secretsBrokerAuditEvents.map((event) => event.provider))
+)
+
 function SourceIcon({ source }: { source: WizardSource }) {
   if (source.id === 'local-vault') return <LockKeyhole className='size-4' />
   if (source.id === 'file-source') return <FileKey2 className='size-4' />
@@ -198,6 +228,95 @@ function SafeExample({ value }: { value: string }) {
     <div className='rounded-md border bg-muted/40 p-3 font-mono text-sm break-all'>
       {value}
     </div>
+  )
+}
+
+function AuditEventDetail({ event }: { event: SecretsBrokerAuditEvent }) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <div>
+            <CardTitle className='text-base'>Event detail</CardTitle>
+            <CardDescription>{event.id}</CardDescription>
+          </div>
+          <Badge variant={auditOutcomeVariant[event.outcome]}>
+            {event.outcome}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className='space-y-4 text-sm'>
+        <div className='grid gap-3 md:grid-cols-2'>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Event
+            </div>
+            <div>{auditEventTypeLabel(event.type)}</div>
+          </div>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Timestamp
+            </div>
+            <div>{event.timestamp}</div>
+          </div>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Provider/source
+            </div>
+            <div>
+              {event.provider} · {event.source}
+            </div>
+          </div>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Connection
+            </div>
+            <div>{event.connection}</div>
+          </div>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Actor
+            </div>
+            <div>
+              {event.actorType}: {event.actorId}
+            </div>
+          </div>
+          <div>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Service/workflow/run
+            </div>
+            <div>{event.serviceOrWorkflow}</div>
+          </div>
+        </div>
+        <div className='rounded-md bg-muted/40 p-2'>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            SecretRef identifier
+          </div>
+          <div className='font-mono break-all'>{event.ref}</div>
+        </div>
+        <div className='rounded-md bg-muted/40 p-2'>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Policy decision
+          </div>
+          <div>{event.policyId}</div>
+          <div className='text-muted-foreground'>{event.policyDecision}</div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Normalized reason
+          </div>
+          <p className='text-muted-foreground'>{event.normalizedReason}</p>
+        </div>
+        <div className='flex gap-3 rounded-lg border p-3'>
+          <ShieldCheck className='mt-0.5 size-4 shrink-0' />
+          <div>
+            Event details use safe identifiers, policy metadata, and normalized
+            reasons only. Resolved secret values are not stored in this fixture
+            or rendered by this panel.
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -279,6 +398,21 @@ export function SecretsBrokerSetupWizard() {
   })
 
   const [selectedId, setSelectedId] = useState(wizardSources[0].id)
+  const [auditTypeFilter, setAuditTypeFilter] = useState<
+    SecretsBrokerAuditEventType | 'all'
+  >('all')
+  const [auditOutcomeFilter, setAuditOutcomeFilter] = useState<
+    SecretsBrokerAuditOutcome | 'all'
+  >('all')
+  const [auditProviderFilter, setAuditProviderFilter] = useState<
+    SecretsBrokerAuditEvent['provider'] | 'all'
+  >('all')
+  const [auditQueryFilter, setAuditQueryFilter] = useState('')
+  const [auditSinceFilter, setAuditSinceFilter] = useState('')
+  const [auditUntilFilter, setAuditUntilFilter] = useState('')
+  const [selectedAuditEventId, setSelectedAuditEventId] = useState(
+    secretsBrokerAuditEvents[0].id
+  )
   const selectedSource = useMemo(
     () =>
       wizardSources.find((source) => source.id === selectedId) ??
@@ -290,6 +424,29 @@ export function SecretsBrokerSetupWizard() {
   ).length
   const blockedCount = wizardSources.length - readyCount
   const diagnosticCounts = countDiagnosticsByStatus(secretsBrokerDiagnostics)
+  const filteredAuditEvents = useMemo(
+    () =>
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        type: auditTypeFilter,
+        outcome: auditOutcomeFilter,
+        provider: auditProviderFilter,
+        query: auditQueryFilter,
+        since: auditSinceFilter,
+        until: auditUntilFilter,
+      }),
+    [
+      auditOutcomeFilter,
+      auditProviderFilter,
+      auditQueryFilter,
+      auditSinceFilter,
+      auditTypeFilter,
+      auditUntilFilter,
+    ]
+  )
+  const selectedAuditEvent =
+    filteredAuditEvents.find((event) => event.id === selectedAuditEventId) ??
+    filteredAuditEvents[0] ??
+    secretsBrokerAuditEvents[0]
 
   return (
     <>
@@ -358,6 +515,191 @@ export function SecretsBrokerSetupWizard() {
             </CardContent>
           </Card>
         </div>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <ClipboardCheck className='size-4' /> Audit and events
+                </CardTitle>
+                <CardDescription>
+                  Inspect Secrets Broker operations by type, outcome, provider,
+                  source/backend, connection, service/workflow/run, actor, and
+                  timestamp without exposing secret values.
+                </CardDescription>
+              </div>
+              <Badge variant='secondary'>Values never rendered</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-6'>
+              <div>
+                <label
+                  htmlFor='secret-audit-type'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Event type
+                </label>
+                <select
+                  id='secret-audit-type'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={auditTypeFilter}
+                  onChange={(event) =>
+                    setAuditTypeFilter(
+                      event.target.value as SecretsBrokerAuditEventType | 'all'
+                    )
+                  }
+                >
+                  <option value='all'>all</option>
+                  {auditTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {auditEventTypeLabel(type)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor='secret-audit-outcome'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Outcome
+                </label>
+                <select
+                  id='secret-audit-outcome'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={auditOutcomeFilter}
+                  onChange={(event) =>
+                    setAuditOutcomeFilter(
+                      event.target.value as SecretsBrokerAuditOutcome | 'all'
+                    )
+                  }
+                >
+                  <option value='all'>all</option>
+                  {auditOutcomes.map((outcome) => (
+                    <option key={outcome} value={outcome}>
+                      {outcome}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor='secret-audit-provider'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Provider
+                </label>
+                <select
+                  id='secret-audit-provider'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={auditProviderFilter}
+                  onChange={(event) =>
+                    setAuditProviderFilter(
+                      event.target.value as
+                        | SecretsBrokerAuditEvent['provider']
+                        | 'all'
+                    )
+                  }
+                >
+                  <option value='all'>all</option>
+                  {auditProviders.map((provider) => (
+                    <option key={provider} value={provider}>
+                      {provider}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor='secret-audit-query'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Source / actor
+                </label>
+                <Input
+                  id='secret-audit-query'
+                  value={auditQueryFilter}
+                  onChange={(event) => setAuditQueryFilter(event.target.value)}
+                  placeholder='source, connection, target, actor'
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor='secret-audit-since'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Since
+                </label>
+                <Input
+                  id='secret-audit-since'
+                  type='datetime-local'
+                  value={auditSinceFilter}
+                  onChange={(event) => setAuditSinceFilter(event.target.value)}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor='secret-audit-until'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Until
+                </label>
+                <Input
+                  id='secret-audit-until'
+                  type='datetime-local'
+                  value={auditUntilFilter}
+                  onChange={(event) => setAuditUntilFilter(event.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className='grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]'>
+              <div className='space-y-2'>
+                {filteredAuditEvents.length ? (
+                  filteredAuditEvents.map((event) => (
+                    <button
+                      key={event.id}
+                      type='button'
+                      className={`w-full rounded-lg border p-3 text-left text-sm transition hover:border-primary ${
+                        selectedAuditEvent.id === event.id
+                          ? 'border-primary bg-muted/60'
+                          : 'bg-card'
+                      }`}
+                      onClick={() => setSelectedAuditEventId(event.id)}
+                    >
+                      <div className='mb-2 flex flex-wrap items-start justify-between gap-2'>
+                        <div>
+                          <div className='font-medium'>
+                            {auditEventTypeLabel(event.type)}
+                          </div>
+                          <div className='text-xs text-muted-foreground'>
+                            {event.timestamp} · {event.provider} ·{' '}
+                            {event.source}
+                          </div>
+                        </div>
+                        <Badge variant={auditOutcomeVariant[event.outcome]}>
+                          {event.outcome}
+                        </Badge>
+                      </div>
+                      <div className='grid gap-2 text-xs text-muted-foreground md:grid-cols-3'>
+                        <span>ref: {event.ref}</span>
+                        <span>actor: {event.actorId}</span>
+                        <span>target: {event.serviceOrWorkflow}</span>
+                      </div>
+                    </button>
+                  ))
+                ) : (
+                  <div className='rounded-lg border border-dashed p-3 text-sm text-muted-foreground'>
+                    No audit events match the current filters.
+                  </div>
+                )}
+              </div>
+              <AuditEventDetail event={selectedAuditEvent} />
+            </div>
+          </CardContent>
+        </Card>
 
         <Card>
           <CardHeader>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -2,6 +2,10 @@ import { renderRoute } from '@/test/render-route'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
+import {
+  filterSecretsBrokerAuditEvents,
+  secretsBrokerAuditEvents,
+} from './audit-events'
 import { secretsBrokerDiagnostics, scrubSecretLikeOutput } from './diagnostics'
 
 describe('Secrets Broker setup wizard', () => {
@@ -17,6 +21,8 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
     expect(screen.getByText(/SecretRef:/i)).toBeVisible()
     expect(screen.getAllByText(/value hidden/i)[0]).toBeVisible()
+    expect(screen.getByText(/Audit and events/i)).toBeVisible()
+    expect(screen.getByText(/Values never rendered/i)).toBeVisible()
     expect(screen.getByText(/Diagnostics and troubleshooting/i)).toBeVisible()
     expect(screen.getByText(/Raw output scrubbed/i)).toBeVisible()
     expect(screen.queryByText('supersecret')).not.toBeInTheDocument()
@@ -58,6 +64,79 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Confirm operation, policy decision, and audit reason/i)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+  })
+
+  it('covers audit event types, filtering, and safe detail rendering', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getAllByText(/resolve granted/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/resolve denied/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/refresh failure/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/session token revoked/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Event detail/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/policy\/openclaw\/service-lasso\/read/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Resolver granted access/i)).toBeVisible()
+
+    await user.selectOptions(screen.getByLabelText(/Outcome/i), 'denied')
+    expect(screen.getAllByText(/resolve denied/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/write back denied/i)[0]).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: /session token revoked/i })
+    ).not.toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText(/Provider/i), 'local')
+    expect(screen.getAllByText(/resolve denied/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/write back denied/i)[0]).toBeVisible()
+
+    await user.type(screen.getByLabelText(/Source \/ actor/i), '@serviceadmin')
+    expect(screen.getAllByText(/write back denied/i)[0]).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: /resolve denied/i })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/ghp_examplePlaintextToken/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/sk-this-value-must-not-render/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('plaintext secret')).not.toBeInTheDocument()
+  })
+
+  it('filters audit events by type outcome provider and time range', () => {
+    expect(
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        type: 'resolve_denied',
+        outcome: 'denied',
+        provider: 'local',
+        query: 'postgres',
+      }).map((event) => event.id)
+    ).toEqual(['evt-20260507-002'])
+
+    expect(
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        outcome: 'revoked',
+      })[0]
+    ).toMatchObject({ type: 'session_token_revoked' })
+
+    const rangedEvents = filterSecretsBrokerAuditEvents(
+      secretsBrokerAuditEvents,
+      {
+        since: '2026-05-07T18:16:00Z',
+        until: '2026-05-07T18:19:00Z',
+      }
+    )
+    expect(rangedEvents.map((event) => event.id)).toEqual([
+      'evt-20260507-003',
+      'evt-20260507-004',
+      'evt-20260507-005',
+    ])
   })
 
   it('covers diagnostic failure categories and suggested fixes without raw secret output', async () => {


### PR DESCRIPTION
## Summary
- Add a secret-safe Secrets Broker audit/events model with fixture events for granted, denied, failure, revoked, and success outcomes.
- Add an Audit and events panel to the Secrets Broker setup page with filters for event type, outcome, provider, source/connection/service/actor text, and since/until time range.
- Add a safe event detail panel that renders only identifiers, policy metadata, normalized reasons, and timestamps; no resolved/plaintext secret values are stored or rendered.
- Extend tests for audit filtering, granted/denied/failure/revoked coverage, and no-value rendering.

## Validation
- `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 7 passed
- `npm run test` — 9 files / 58 tests passed
- `npm run format:check` — passed
- `npm run lint` — passed with existing warnings in installed/logs/network/runtime/variables
- `npm run build` — passed

Closes #34
