### PR TITLE
Add Secrets Broker secret sources and backends UI

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -41,6 +41,12 @@ import {
   type SecretsBrokerDiagnostic,
   type SecretsBrokerDiagnosticStatus,
 } from './diagnostics'
+import {
+  countSourceBackendsByState,
+  secretsBrokerSourceBackends,
+  type SecretsBrokerSourceBackend,
+  type SecretsBrokerSourceState,
+} from './source-backends'
 
 type WizardSource = {
   id: string
@@ -172,6 +178,44 @@ const auditOutcomeVariant: Record<
   revoked: 'outline',
 }
 
+const sourceStateCopy: Record<SecretsBrokerSourceState, string> = {
+  configured: 'Configured',
+  'not-configured': 'Not configured',
+  reachable: 'Reachable',
+  failing: 'Failing',
+  untested: 'Untested',
+}
+
+const sourceStateVariant: Record<
+  SecretsBrokerSourceState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  configured: 'secondary',
+  'not-configured': 'outline',
+  reachable: 'default',
+  failing: 'destructive',
+  untested: 'outline',
+}
+
+const warningVariant: Record<
+  SecretsBrokerSourceBackend['warnings'][number]['severity'],
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  info: 'outline',
+  warning: 'secondary',
+  critical: 'destructive',
+}
+
+const sourceActionCopy: Record<
+  SecretsBrokerSourceBackend['supportedActions'][number],
+  string
+> = {
+  'test-source': 'Test source',
+  'view-diagnostics': 'View diagnostics',
+  'edit-configuration': 'Edit configuration',
+  'view-examples': 'View examples',
+}
+
 const auditTypes = Array.from(
   new Set(secretsBrokerAuditEvents.map((event) => event.type))
 )
@@ -227,6 +271,124 @@ function SafeExample({ value }: { value: string }) {
   return (
     <div className='rounded-md border bg-muted/40 p-3 font-mono text-sm break-all'>
       {value}
+    </div>
+  )
+}
+
+function SourceBackendCard({ source }: { source: SecretsBrokerSourceBackend }) {
+  return (
+    <div className='rounded-lg border p-4 text-sm'>
+      <div className='mb-3 flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <div className='flex items-center gap-2 font-medium'>
+            <FileKey2 className='size-4' />
+            {source.title}
+          </div>
+          <div className='text-xs text-muted-foreground'>
+            {source.type} · {source.provider} · {source.mode}
+          </div>
+        </div>
+        <Badge variant={sourceStateVariant[source.state]}>
+          {sourceStateCopy[source.state]}
+        </Badge>
+      </div>
+      <p className='text-muted-foreground'>{source.summary}</p>
+
+      <div className='mt-3 grid gap-3 md:grid-cols-2'>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Source/backend
+          </div>
+          <div>{source.source}</div>
+          <div className='text-xs text-muted-foreground'>
+            {source.connection}
+          </div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Last test result
+          </div>
+          <div>
+            {source.testResult.outcome} · {source.testResult.checkedAt}
+          </div>
+          <div className='text-xs text-muted-foreground'>
+            Last check: {source.lastCheckedAt}
+          </div>
+        </div>
+      </div>
+
+      <div className='mt-3 rounded-md bg-muted/40 p-2'>
+        <div className='text-xs font-medium text-muted-foreground uppercase'>
+          Test metadata only
+        </div>
+        <div className='mt-1 flex flex-wrap gap-1'>
+          {source.testResult.metadata.map((item) => (
+            <Badge key={item} variant='outline'>
+              {item}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className='mt-3 grid gap-3 md:grid-cols-2'>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Example refs
+          </div>
+          <div className='mt-1 space-y-1'>
+            {source.exampleRefs.map((ref) => (
+              <div key={ref} className='font-mono text-xs break-all'>
+                {ref}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Example config
+          </div>
+          <div className='mt-1 space-y-1'>
+            {source.exampleConfig.map((line) => (
+              <div key={line} className='font-mono text-xs break-all'>
+                {line}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {source.warnings.length ? (
+        <div className='mt-3 space-y-2'>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Security warnings
+          </div>
+          {source.warnings.map((warning) => (
+            <div key={warning.code} className='rounded-md border p-2'>
+              <div className='mb-1 flex flex-wrap items-center gap-2'>
+                <Badge variant={warningVariant[warning.severity]}>
+                  {warning.title}
+                </Badge>
+                <span className='font-mono text-xs text-muted-foreground'>
+                  {warning.code}
+                </span>
+              </div>
+              <div className='text-muted-foreground'>{warning.description}</div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className='mt-3 rounded-md border border-dashed p-2 text-xs text-muted-foreground'>
+          No source security warnings.
+        </div>
+      )}
+
+      <div className='mt-3 flex flex-wrap gap-2'>
+        {source.supportedActions.map((action) => (
+          <Button key={action} type='button' variant='outline' size='sm'>
+            {sourceActionCopy[action]}
+          </Button>
+        ))}
+      </div>
     </div>
   )
 }
@@ -424,6 +586,11 @@ export function SecretsBrokerSetupWizard() {
   ).length
   const blockedCount = wizardSources.length - readyCount
   const diagnosticCounts = countDiagnosticsByStatus(secretsBrokerDiagnostics)
+  const sourceCounts = countSourceBackendsByState(secretsBrokerSourceBackends)
+  const sourceWarningCount = secretsBrokerSourceBackends.reduce(
+    (count, source) => count + source.warnings.length,
+    0
+  )
   const filteredAuditEvents = useMemo(
     () =>
       filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
@@ -515,6 +682,58 @@ export function SecretsBrokerSetupWizard() {
             </CardContent>
           </Card>
         </div>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <FileKey2 className='size-4' /> Secret Sources / Backends
+                </CardTitle>
+                <CardDescription>
+                  Inspect local and external Secrets Broker sources, source test
+                  results, safe example refs/config, and security warnings
+                  without displaying returned secret values.
+                </CardDescription>
+              </div>
+              <Badge variant='secondary'>Metadata only</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-4'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Reachable</div>
+                <div className='text-2xl font-bold'>
+                  {sourceCounts.reachable}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Configured</div>
+                <div className='text-2xl font-bold'>
+                  {sourceCounts.configured}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>
+                  Failing/untested
+                </div>
+                <div className='text-2xl font-bold'>
+                  {sourceCounts.failing + sourceCounts.untested}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Warnings</div>
+                <div className='text-2xl font-bold'>{sourceWarningCount}</div>
+              </div>
+            </div>
+
+            <div className='grid gap-4 lg:grid-cols-2'>
+              {secretsBrokerSourceBackends.map((source) => (
+                <SourceBackendCard key={source.id} source={source} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
 
         <Card>
           <CardHeader>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -7,6 +7,10 @@ import {
   secretsBrokerAuditEvents,
 } from './audit-events'
 import { secretsBrokerDiagnostics, scrubSecretLikeOutput } from './diagnostics'
+import {
+  secretsBrokerSourceBackends,
+  sourceBackendHasSecretValue,
+} from './source-backends'
 
 describe('Secrets Broker setup wizard', () => {
   it('shows the safe setup contract without plaintext values', async () => {
@@ -64,6 +68,46 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Confirm operation, policy decision, and audit reason/i)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+  })
+
+  it('renders secret sources and backends with warning states and metadata-only test results', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getByText(/Secret Sources \/ Backends/i)).toBeVisible()
+    expect(screen.getAllByText(/Metadata only/i)[0]).toBeVisible()
+    expect(screen.getByText(/Environment provider/i)).toBeVisible()
+    expect(screen.getByText(/File provider/i)).toBeVisible()
+    expect(screen.getByText(/Exec provider/i)).toBeVisible()
+    expect(screen.getByText(/HashiCorp Vault CLI/i)).toBeVisible()
+    expect(screen.getAllByText(/AWS Secrets Manager CLI/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/1Password CLI/i)[0]).toBeVisible()
+    expect(screen.getByText(/Bitwarden \/ BWS CLI/i)).toBeVisible()
+    expect(
+      screen.getByText(/Docker\/Kubernetes mounted secrets/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Broad env allowlist/i)).toBeVisible()
+    expect(screen.getByText(/Insecure path override/i)).toBeVisible()
+    expect(screen.getByText(/Untrusted command path/i)).toBeVisible()
+    expect(screen.getByText(/Missing timeout\/output limits/i)).toBeVisible()
+    expect(
+      screen.getAllByRole('button', { name: /Test source/i })[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByRole('button', { name: /View diagnostics/i })[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByRole('button', { name: /Edit configuration/i })[0]
+    ).toBeVisible()
+    expect(screen.getByText(/3 keys matched allowlist/i)).toBeVisible()
+    expect(screen.getByText(/path policy denied/i)).toBeVisible()
+    expect(screen.getByText(/command not executed/i)).toBeVisible()
+    expect(screen.getAllByText(/value=hidden/i)[0]).toBeVisible()
+  })
+
+  it('keeps source backend fixtures free of secret values', () => {
+    expect(secretsBrokerSourceBackends.some(sourceBackendHasSecretValue)).toBe(
+      false
+    )
   })
 
   it('covers audit event types, filtering, and safe detail rendering', async () => {

--- a/src/features/secrets-broker/source-backends.ts
+++ b/src/features/secrets-broker/source-backends.ts
@@ -1,0 +1,395 @@
+export type SecretsBrokerSourceType =
+  | 'local'
+  | 'env'
+  | 'file'
+  | 'exec'
+  | 'vault-cli'
+  | 'aws-secrets-manager-cli'
+  | 'onepassword-cli'
+  | 'bitwarden-bws-cli'
+  | 'mounted-secrets'
+
+export type SecretsBrokerSourceState =
+  | 'configured'
+  | 'not-configured'
+  | 'reachable'
+  | 'failing'
+  | 'untested'
+
+export type SecretsBrokerSourceWarning = {
+  code:
+    | 'broad_env_allowlist'
+    | 'symlink_command_allowed'
+    | 'insecure_path_override'
+    | 'untrusted_command_path'
+    | 'missing_timeout_output_limits'
+    | 'auth_required'
+  title: string
+  severity: 'info' | 'warning' | 'critical'
+  description: string
+}
+
+export type SecretsBrokerSourceTestResult = {
+  outcome: 'success' | 'failure' | 'not-run'
+  checkedAt: string
+  metadata: string[]
+}
+
+export type SecretsBrokerSourceBackend = {
+  id: string
+  title: string
+  type: SecretsBrokerSourceType
+  provider: string
+  source: string
+  connection: string
+  state: SecretsBrokerSourceState
+  mode: string
+  lastCheckedAt: string
+  summary: string
+  warnings: SecretsBrokerSourceWarning[]
+  testResult: SecretsBrokerSourceTestResult
+  exampleRefs: string[]
+  exampleConfig: string[]
+  supportedActions: Array<
+    'test-source' | 'view-diagnostics' | 'edit-configuration' | 'view-examples'
+  >
+}
+
+export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
+  {
+    id: 'local-encrypted-store',
+    title: 'Local encrypted store',
+    type: 'local',
+    provider: 'local',
+    source: '@secretsbroker/local/default',
+    connection: 'Local encrypted vault',
+    state: 'reachable',
+    mode: 'local-first encrypted store',
+    lastCheckedAt: '2026-05-07T18:32:00Z',
+    summary:
+      'Default local-first encrypted Secrets Broker source for Service Lasso runtime refs.',
+    warnings: [],
+    testResult: {
+      outcome: 'success',
+      checkedAt: '2026-05-07T18:32:00Z',
+      metadata: ['vault unlocked', '4 refs addressable', 'policy checked'],
+    },
+    exampleRefs: [
+      'secret://local/default/@serviceadmin/SESSION_SECRET',
+      'secret://local/default/postgres/ADMIN_PASSWORD',
+    ],
+    exampleConfig: ['source=local', 'namespace=default', 'value=hidden'],
+    supportedActions: [
+      'test-source',
+      'view-diagnostics',
+      'edit-configuration',
+      'view-examples',
+    ],
+  },
+  {
+    id: 'env-provider',
+    title: 'Environment provider',
+    type: 'env',
+    provider: 'env',
+    source: '@secretsbroker/env/service-lasso',
+    connection: 'Process environment',
+    state: 'configured',
+    mode: 'read-only allowlist',
+    lastCheckedAt: '2026-05-07T18:31:15Z',
+    summary:
+      'Reads only explicitly allowlisted environment keys and reports metadata without values.',
+    warnings: [
+      {
+        code: 'broad_env_allowlist',
+        title: 'Broad env allowlist',
+        severity: 'warning',
+        description:
+          'Allowlist includes a wildcard-like prefix; narrow it before enabling production reads.',
+      },
+    ],
+    testResult: {
+      outcome: 'success',
+      checkedAt: '2026-05-07T18:31:15Z',
+      metadata: [
+        '3 keys matched allowlist',
+        'values redacted',
+        'readonly mode',
+      ],
+    },
+    exampleRefs: ['env://service-lasso/OPENCLAW_TOKEN'],
+    exampleConfig: ['allow=SERVICE_LASSO_*', 'deny=*_PASSWORD', 'value=hidden'],
+    supportedActions: ['test-source', 'view-diagnostics', 'edit-configuration'],
+  },
+  {
+    id: 'file-provider',
+    title: 'File provider',
+    type: 'file',
+    provider: 'file',
+    source: '@secretsbroker/file/runtime',
+    connection: 'Scoped runtime env file',
+    state: 'failing',
+    mode: 'read-only file path',
+    lastCheckedAt: '2026-05-07T18:30:40Z',
+    summary:
+      'Reads refs from a scoped secrets file path after sandbox and symlink checks pass.',
+    warnings: [
+      {
+        code: 'insecure_path_override',
+        title: 'Insecure path override',
+        severity: 'critical',
+        description:
+          'Configured override escapes the approved service-lasso secrets directory.',
+      },
+    ],
+    testResult: {
+      outcome: 'failure',
+      checkedAt: '2026-05-07T18:30:40Z',
+      metadata: [
+        'path policy denied',
+        '0 values read',
+        'sandbox escape blocked',
+      ],
+    },
+    exampleRefs: ['file://C:/service-lasso/secrets/runtime.env#SESSION_SECRET'],
+    exampleConfig: [
+      'path=C:/service-lasso/secrets/runtime.env',
+      'followSymlinks=false',
+      'value=hidden',
+    ],
+    supportedActions: [
+      'test-source',
+      'view-diagnostics',
+      'edit-configuration',
+      'view-examples',
+    ],
+  },
+  {
+    id: 'exec-provider',
+    title: 'Exec provider',
+    type: 'exec',
+    provider: 'exec',
+    source: '@secretsbroker/exec/openclaw',
+    connection: 'OpenClaw SecretRef adapter',
+    state: 'failing',
+    mode: 'allowlisted command',
+    lastCheckedAt: '2026-05-07T18:30:05Z',
+    summary:
+      'Runs an allowlisted resolver command with bounded timeout and scrubbed output metadata.',
+    warnings: [
+      {
+        code: 'untrusted_command_path',
+        title: 'Untrusted command path',
+        severity: 'critical',
+        description:
+          'Resolver command path is outside the trusted Service Lasso tool directory.',
+      },
+      {
+        code: 'missing_timeout_output_limits',
+        title: 'Missing timeout/output limits',
+        severity: 'warning',
+        description:
+          'Source tests must define timeout and output byte limits before execution.',
+      },
+    ],
+    testResult: {
+      outcome: 'failure',
+      checkedAt: '2026-05-07T18:30:05Z',
+      metadata: [
+        'command not executed',
+        'policy denied',
+        'output scrubber ready',
+      ],
+    },
+    exampleRefs: ['exec://openclaw/service-lasso/SESSION_TOKEN'],
+    exampleConfig: [
+      'command=openclaw secrets resolve',
+      'timeoutMs=5000',
+      'maxOutputBytes=2048',
+      'value=hidden',
+    ],
+    supportedActions: ['test-source', 'view-diagnostics', 'edit-configuration'],
+  },
+  {
+    id: 'vault-cli',
+    title: 'HashiCorp Vault CLI',
+    type: 'vault-cli',
+    provider: 'vault',
+    source: '@secretsbroker/external/ops',
+    connection: 'Vault kv/service-lasso',
+    state: 'failing',
+    mode: 'external cli read',
+    lastCheckedAt: '2026-05-07T18:29:40Z',
+    summary:
+      'External Vault-backed source for ops-managed refs; authentication status is shown without token values.',
+    warnings: [
+      {
+        code: 'auth_required',
+        title: 'Authentication required',
+        severity: 'warning',
+        description:
+          'Vault CLI token is expired or missing; authenticate before testing refs.',
+      },
+    ],
+    testResult: {
+      outcome: 'failure',
+      checkedAt: '2026-05-07T18:29:40Z',
+      metadata: [
+        'auth required',
+        'provider reachable unknown',
+        'values not requested',
+      ],
+    },
+    exampleRefs: ['vault://kv/service-lasso/payments/STRIPE_KEY'],
+    exampleConfig: [
+      'mount=kv/service-lasso',
+      'auth=operator-required',
+      'value=hidden',
+    ],
+    supportedActions: ['test-source', 'view-diagnostics', 'edit-configuration'],
+  },
+  {
+    id: 'aws-secrets-manager-cli',
+    title: 'AWS Secrets Manager CLI',
+    type: 'aws-secrets-manager-cli',
+    provider: 'aws',
+    source: '@secretsbroker/external/aws',
+    connection: 'AWS Secrets Manager CLI',
+    state: 'untested',
+    mode: 'external cli metadata probe',
+    lastCheckedAt: 'never',
+    summary:
+      'Cloud source definition for AWS-managed refs; tests should fetch metadata only.',
+    warnings: [],
+    testResult: {
+      outcome: 'not-run',
+      checkedAt: 'never',
+      metadata: ['not tested', 'metadata-only probe pending'],
+    },
+    exampleRefs: ['aws-secrets-manager://service-lasso/backup-worker'],
+    exampleConfig: [
+      'region=ap-southeast-2',
+      'profile=service-lasso',
+      'value=hidden',
+    ],
+    supportedActions: ['test-source', 'view-diagnostics', 'edit-configuration'],
+  },
+  {
+    id: 'onepassword-cli',
+    title: '1Password CLI',
+    type: 'onepassword-cli',
+    provider: 'onepassword',
+    source: '@secretsbroker/external/1password',
+    connection: '1Password ops vault',
+    state: 'configured',
+    mode: 'external cli metadata probe',
+    lastCheckedAt: '2026-05-07T18:28:30Z',
+    summary:
+      'Password-manager source for operator-managed service refs with item metadata only.',
+    warnings: [],
+    testResult: {
+      outcome: 'success',
+      checkedAt: '2026-05-07T18:28:30Z',
+      metadata: [
+        'vault reachable',
+        '2 item handles matched',
+        'values redacted',
+      ],
+    },
+    exampleRefs: ['op://Service Lasso/OpenClaw/anthropic api key'],
+    exampleConfig: ['vault=Service Lasso', 'field=credential', 'value=hidden'],
+    supportedActions: ['test-source', 'view-diagnostics', 'view-examples'],
+  },
+  {
+    id: 'bitwarden-bws-cli',
+    title: 'Bitwarden / BWS CLI',
+    type: 'bitwarden-bws-cli',
+    provider: 'bitwarden',
+    source: '@secretsbroker/external/bws',
+    connection: 'Bitwarden Secrets Manager',
+    state: 'not-configured',
+    mode: 'external cli metadata probe',
+    lastCheckedAt: 'never',
+    summary:
+      'Optional external BWS source placeholder for future Service Lasso refs.',
+    warnings: [],
+    testResult: {
+      outcome: 'not-run',
+      checkedAt: 'never',
+      metadata: ['not configured', 'no values requested'],
+    },
+    exampleRefs: ['bws://service-lasso/project/openclaw-api-key'],
+    exampleConfig: [
+      'project=service-lasso',
+      'auth=operator-required',
+      'value=hidden',
+    ],
+    supportedActions: ['edit-configuration', 'view-examples'],
+  },
+  {
+    id: 'mounted-secrets',
+    title: 'Docker/Kubernetes mounted secrets',
+    type: 'mounted-secrets',
+    provider: 'mounted-file',
+    source: '@secretsbroker/mounted/run-secrets',
+    connection: '/run/secrets/*',
+    state: 'configured',
+    mode: 'read-only mounted path',
+    lastCheckedAt: '2026-05-07T18:27:20Z',
+    summary:
+      'Container-orchestrator mounted secret files exposed as refs with path scope checks.',
+    warnings: [
+      {
+        code: 'symlink_command_allowed',
+        title: 'Symlink traversal blocked',
+        severity: 'info',
+        description:
+          'Symlink targets are rejected unless explicitly allowed by the source policy.',
+      },
+    ],
+    testResult: {
+      outcome: 'success',
+      checkedAt: '2026-05-07T18:27:20Z',
+      metadata: ['path exists', 'symlink check passed', 'values redacted'],
+    },
+    exampleRefs: ['mounted://run-secrets/postgres-password'],
+    exampleConfig: [
+      'root=/run/secrets',
+      'followSymlinks=false',
+      'value=hidden',
+    ],
+    supportedActions: ['test-source', 'view-diagnostics', 'edit-configuration'],
+  },
+]
+
+export function countSourceBackendsByState(
+  sources: SecretsBrokerSourceBackend[]
+) {
+  return sources.reduce<Record<SecretsBrokerSourceState, number>>(
+    (counts, source) => {
+      counts[source.state] += 1
+      return counts
+    },
+    {
+      configured: 0,
+      'not-configured': 0,
+      reachable: 0,
+      failing: 0,
+      untested: 0,
+    }
+  )
+}
+
+export function sourceBackendHasSecretValue(
+  source: SecretsBrokerSourceBackend
+) {
+  const joined = [
+    source.summary,
+    ...source.testResult.metadata,
+    ...source.exampleRefs,
+    ...source.exampleConfig,
+  ].join(' ')
+
+  return /hunter2|correct-horse|plain\s*text\s*secret|sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|AKIA[0-9A-Z]{16}/i.test(
+    joined
+  )
+}


### PR DESCRIPTION
Closes #33

## Summary
- Added a secret-safe Secrets Broker source/backend fixture model for local, env, file, exec, Vault, AWS Secrets Manager, 1Password, Bitwarden/BWS, and mounted-secret sources.
- Added a Secret Sources / Backends section to the Secrets Broker page with source state, warning severity, safe example refs/config, supported actions, and source-test metadata only.
- Extended Secrets Broker tests for env/file/exec examples, warning states, source-test metadata, and fixture-level no-secret-value checks.

## Validation
- `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 9 passed
- `npm run test` — 60 passed
- `npm run format:check` — passed
- `npm run lint` — passed with existing warnings only in installed/logs/network/runtime/variables files
- `npm run build` — passed

## Secret-safety notes
- Source test results render success/failure/not-run and metadata only.
- Example configs use `value=hidden` placeholders.
- Added fixture guard for common secret-token patterns; no plaintext/resolved secret values are rendered.
