### PR TITLE
Add Secrets Broker provider connection detail UI

### DIFF
--- a/src/features/secrets-broker/connection-detail.tsx
+++ b/src/features/secrets-broker/connection-detail.tsx
@@ -1,0 +1,502 @@
+import { Link } from '@tanstack/react-router'
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  KeyRound,
+  Link2,
+  ShieldAlert,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  getSecretsBrokerProviderConnectionDetail,
+  secretsBrokerProviderConnections,
+  type SecretsBrokerProviderConnectionAction,
+  type SecretsBrokerProviderConnectionDetail,
+  type SecretsBrokerProviderConnectionState,
+  type SecretsBrokerSecretMaterialState,
+} from './provider-connections'
+
+const connectionStateCopy: Record<
+  SecretsBrokerProviderConnectionState,
+  string
+> = {
+  healthy: 'Healthy',
+  degraded: 'Degraded',
+  failed: 'Failed',
+  disabled: 'Disabled',
+  missing: 'Missing',
+}
+
+const connectionStateVariant: Record<
+  SecretsBrokerProviderConnectionState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  healthy: 'default',
+  degraded: 'secondary',
+  failed: 'destructive',
+  disabled: 'outline',
+  missing: 'destructive',
+}
+
+const materialStateCopy: Record<SecretsBrokerSecretMaterialState, string> = {
+  present: 'Present',
+  missing: 'Missing',
+  expired: 'Expired',
+  'rotation-due': 'Rotation due',
+  revoked: 'Revoked',
+}
+
+const actionVariant: Record<
+  SecretsBrokerProviderConnectionAction['state'],
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  available: 'secondary',
+  disabled: 'outline',
+  danger: 'destructive',
+}
+
+function StateIcon({ state }: { state: SecretsBrokerProviderConnectionState }) {
+  if (state === 'healthy') return <CheckCircle2 className='size-4' />
+  if (state === 'degraded') return <AlertTriangle className='size-4' />
+  return <XCircle className='size-4' />
+}
+
+function ConnectionDetailMissing({ connectionId }: { connectionId: string }) {
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Connection Missing',
+    description: 'Missing Secrets Broker provider connection detail.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+      <Main id='content' className='space-y-6'>
+        <Card>
+          <CardHeader>
+            <CardTitle>Provider connection not found</CardTitle>
+            <CardDescription>
+              No safe stub data exists for connection id {connectionId}.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant='secondary'>
+              <Link to='/secrets-broker'>Back to Secrets Broker setup</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}
+
+function MetadataGrid({
+  connection,
+}: {
+  connection: SecretsBrokerProviderConnectionDetail
+}) {
+  return (
+    <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'>
+      {connection.metadata.map((item) => (
+        <div key={item.label} className='rounded-lg border p-3'>
+          <div className='text-xs text-muted-foreground'>{item.label}</div>
+          <div className='font-medium'>{item.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ActionButton({
+  action,
+}: {
+  action: SecretsBrokerProviderConnectionAction
+}) {
+  return (
+    <div className='rounded-lg border p-3'>
+      <Button
+        type='button'
+        variant={actionVariant[action.state]}
+        disabled={action.state === 'disabled'}
+        className='w-full justify-start'
+      >
+        {action.label}
+      </Button>
+      {action.confirmationCopy ? (
+        <p className='mt-2 text-xs text-muted-foreground'>
+          Confirmation: {action.confirmationCopy}
+        </p>
+      ) : null}
+      {action.disabledReason ? (
+        <p className='mt-2 text-xs text-muted-foreground'>
+          Disabled: {action.disabledReason}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export function SecretsBrokerProviderConnectionDetailPage({
+  connectionId,
+}: {
+  connectionId: string
+}) {
+  const connection = getSecretsBrokerProviderConnectionDetail(connectionId)
+
+  usePageMetadata({
+    title: connection
+      ? `Service Admin - ${connection.title}`
+      : 'Service Admin - Secrets Broker Connection Missing',
+    description:
+      'Safe Secrets Broker provider connection detail with metadata-only secret material state.',
+  })
+
+  if (!connection)
+    return <ConnectionDetailMissing connectionId={connectionId} />
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <div className='mb-2 flex items-center gap-2 text-sm text-muted-foreground'>
+              <Link to='/secrets-broker' className='hover:underline'>
+                Secrets Broker
+              </Link>
+              <span>/</span>
+              <span>Provider connection detail</span>
+            </div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <KeyRound className='size-5' /> {connection.title}
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Safe metadata, health, material state, usage, and actions for one
+              provider connection. Raw secret values are never rendered or
+              copied.
+            </p>
+          </div>
+          <Badge variant={connectionStateVariant[connection.state]}>
+            <StateIcon state={connection.state} />
+            {connectionStateCopy[connection.state]}
+          </Badge>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <ShieldCheck className='size-4' /> Safe metadata summary
+            </CardTitle>
+            <CardDescription>
+              Provider {connection.provider}, source {connection.source}, ref{' '}
+              {connection.connectionRef}. Values are hidden.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <MetadataGrid connection={connection} />
+          </CardContent>
+        </Card>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <Clock3 className='size-4' /> Status and health
+              </CardTitle>
+              <CardDescription>{connection.health.label}</CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-3 text-sm'>
+              <div className='flex justify-between gap-3 rounded-lg border p-3'>
+                <span className='text-muted-foreground'>Last checked</span>
+                <span className='font-medium'>
+                  {connection.health.checkedAt}
+                </span>
+              </div>
+              {connection.health.failureReason ? (
+                <div className='flex justify-between gap-3 rounded-lg border p-3'>
+                  <span className='text-muted-foreground'>
+                    Last failure reason
+                  </span>
+                  <span className='font-medium'>
+                    {connection.health.failureReason}
+                  </span>
+                </div>
+              ) : null}
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Next action</div>
+                <div className='font-medium'>
+                  {connection.health.nextAction}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <ShieldAlert className='size-4' /> Secret material state
+              </CardTitle>
+              <CardDescription>
+                Presence and lifecycle metadata only; no value material is
+                loaded.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-3 text-sm'>
+              <div className='flex flex-wrap gap-2'>
+                <Badge variant='secondary'>
+                  Presence:{' '}
+                  {materialStateCopy[connection.secretMaterial.presence]}
+                </Badge>
+                <Badge variant='outline'>Raw value: hidden</Badge>
+                <Badge variant='outline'>Copy value: unavailable</Badge>
+              </div>
+              <p>{connection.secretMaterial.safeDescriptor}</p>
+              <div className='grid gap-2 md:grid-cols-2'>
+                {connection.secretMaterial.version ? (
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Key version</div>
+                    <div className='font-medium'>
+                      {connection.secretMaterial.version}
+                    </div>
+                  </div>
+                ) : null}
+                {connection.secretMaterial.updatedAt ? (
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Updated</div>
+                    <div className='font-medium'>
+                      {connection.secretMaterial.updatedAt}
+                    </div>
+                  </div>
+                ) : null}
+                {connection.secretMaterial.expiresAt ? (
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Expiry</div>
+                    <div className='font-medium'>
+                      {connection.secretMaterial.expiresAt}
+                    </div>
+                  </div>
+                ) : null}
+                {connection.secretMaterial.refreshWindow ? (
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>
+                      Refresh timeline
+                    </div>
+                    <div className='font-medium'>
+                      {connection.secretMaterial.refreshWindow}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Scopes and permissions</CardTitle>
+              <CardDescription>
+                Permission decisions are rendered as policy metadata only.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-2'>
+              {connection.scopes.map((scope) => (
+                <div
+                  key={scope.label}
+                  className='flex items-center justify-between gap-3 rounded-lg border p-3 text-sm'
+                >
+                  <span>{scope.label}</span>
+                  <Badge
+                    variant={
+                      scope.decision === 'allowed'
+                        ? 'default'
+                        : scope.decision === 'denied'
+                          ? 'destructive'
+                          : 'secondary'
+                    }
+                  >
+                    {scope.decision}
+                  </Badge>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <Link2 className='size-4' /> Linked services, workflows, and
+                runs
+              </CardTitle>
+              <CardDescription>
+                Consumers that depend on this provider connection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-3 md:grid-cols-3'>
+              <div>
+                <div className='mb-2 text-xs font-medium text-muted-foreground uppercase'>
+                  Services
+                </div>
+                <div className='space-y-1'>
+                  {connection.usage.linkedServices.map((item) => (
+                    <Badge key={item} variant='outline'>
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className='mb-2 text-xs font-medium text-muted-foreground uppercase'>
+                  Workflows
+                </div>
+                <div className='space-y-1'>
+                  {connection.usage.linkedWorkflows.map((item) => (
+                    <Badge key={item} variant='outline'>
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className='mb-2 text-xs font-medium text-muted-foreground uppercase'>
+                  Runs
+                </div>
+                <div className='space-y-1'>
+                  {connection.usage.linkedRuns.map((item) => (
+                    <Badge key={item} variant='outline'>
+                      {item}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+              <div className='grid gap-2 md:col-span-3 md:grid-cols-2'>
+                {connection.usage.lastSuccessfulResolve ? (
+                  <div className='rounded-lg border p-3 text-sm'>
+                    <div className='text-muted-foreground'>
+                      Last successful resolve/use
+                    </div>
+                    <div className='font-medium'>
+                      {connection.usage.lastSuccessfulResolve}
+                    </div>
+                  </div>
+                ) : null}
+                {connection.usage.lastFailure ? (
+                  <div className='rounded-lg border p-3 text-sm'>
+                    <div className='text-muted-foreground'>Last failure</div>
+                    <div className='font-medium'>
+                      {connection.usage.lastFailure}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent audit events</CardTitle>
+            <CardDescription>
+              Safe event metadata for this connection.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-2'>
+            {connection.recentAuditEvents.map((event) => (
+              <div
+                key={event.id}
+                className='grid gap-2 rounded-lg border p-3 text-sm md:grid-cols-[1fr_auto]'
+              >
+                <div>
+                  <div className='font-medium'>{event.type}</div>
+                  <div className='text-muted-foreground'>
+                    {event.at} · {event.actor} · {event.reason}
+                  </div>
+                </div>
+                <Badge
+                  variant={
+                    event.outcome === 'success'
+                      ? 'default'
+                      : event.outcome === 'denied'
+                        ? 'destructive'
+                        : 'secondary'
+                  }
+                >
+                  {event.outcome}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Connection actions</CardTitle>
+            <CardDescription>
+              Dangerous actions include explicit confirmation copy and do not
+              expose raw secret material.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 md:grid-cols-2 xl:grid-cols-3'>
+            {connection.actions.map((action) => (
+              <ActionButton key={action.id} action={action} />
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Available stub detail connections</CardTitle>
+            <CardDescription>
+              API/stub-backed detail records currently available for tests and
+              local preview.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='flex flex-wrap gap-2'>
+            {secretsBrokerProviderConnections.map((item) => (
+              <Button key={item.id} asChild variant='outline' size='sm'>
+                <Link
+                  to='/secrets-broker/$connectionId'
+                  params={{ connectionId: item.id }}
+                >
+                  {item.title}
+                </Link>
+              </Button>
+            ))}
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -41,6 +41,7 @@ import {
   type SecretsBrokerDiagnostic,
   type SecretsBrokerDiagnosticStatus,
 } from './diagnostics'
+import { secretsBrokerProviderConnections } from './provider-connections'
 import {
   countSourceBackendsByState,
   secretsBrokerSourceBackends,
@@ -732,6 +733,45 @@ export function SecretsBrokerSetupWizard() {
                 <SourceBackendCard key={source.id} source={source} />
               ))}
             </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <KeyRound className='size-4' /> Provider connection details
+                </CardTitle>
+                <CardDescription>
+                  Open safe detail records for individual provider connections.
+                  These pages show presence, version, expiry, health, usage, and
+                  action state without raw secret values.
+                </CardDescription>
+              </div>
+              <Badge variant='secondary'>No raw values</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className='grid gap-3 md:grid-cols-3'>
+            {secretsBrokerProviderConnections.map((connection) => (
+              <div key={connection.id} className='rounded-lg border p-3'>
+                <div className='font-medium'>{connection.title}</div>
+                <div className='text-sm text-muted-foreground'>
+                  {connection.provider} · {connection.source}
+                </div>
+                <div className='mt-3 flex items-center justify-between gap-3'>
+                  <Badge variant='outline'>{connection.state}</Badge>
+                  <Button asChild size='sm' variant='secondary'>
+                    <Link
+                      to='/secrets-broker/$connectionId'
+                      params={{ connectionId: connection.id }}
+                    >
+                      View detail
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            ))}
           </CardContent>
         </Card>
 

--- a/src/features/secrets-broker/provider-connections.ts
+++ b/src/features/secrets-broker/provider-connections.ts
@@ -1,0 +1,356 @@
+export type SecretsBrokerProviderConnectionState =
+  | 'healthy'
+  | 'degraded'
+  | 'failed'
+  | 'disabled'
+  | 'missing'
+
+export type SecretsBrokerSecretMaterialState =
+  | 'present'
+  | 'missing'
+  | 'expired'
+  | 'rotation-due'
+  | 'revoked'
+
+export type SecretsBrokerProviderConnectionAction = {
+  id:
+    | 'reconnect'
+    | 'refresh-test-now'
+    | 'replace-rotate-secret-material'
+    | 'clear-revoke-secret-material'
+    | 'disable-enable'
+    | 'delete-connection'
+  label: string
+  state: 'available' | 'disabled' | 'danger'
+  confirmationCopy?: string
+  disabledReason?: string
+}
+
+export type SecretsBrokerProviderConnectionDetail = {
+  id: string
+  title: string
+  provider: string
+  source: string
+  connectionRef: string
+  state: SecretsBrokerProviderConnectionState
+  health: {
+    label: string
+    checkedAt: string
+    nextAction: string
+    failureReason?: string
+  }
+  metadata: Array<{ label: string; value: string }>
+  scopes: Array<{ label: string; decision: 'allowed' | 'denied' | 'review' }>
+  secretMaterial: {
+    presence: SecretsBrokerSecretMaterialState
+    valueAvailable: boolean
+    safeDescriptor: string
+    version?: string
+    updatedAt?: string
+    expiresAt?: string
+    refreshWindow?: string
+  }
+  usage: {
+    lastSuccessfulResolve?: string
+    lastFailure?: string
+    linkedServices: string[]
+    linkedWorkflows: string[]
+    linkedRuns: string[]
+  }
+  recentAuditEvents: Array<{
+    id: string
+    type: string
+    outcome: 'success' | 'failure' | 'denied' | 'revoked'
+    at: string
+    actor: string
+    reason: string
+  }>
+  actions: SecretsBrokerProviderConnectionAction[]
+}
+
+export const secretsBrokerProviderConnections: SecretsBrokerProviderConnectionDetail[] =
+  [
+    {
+      id: 'local-default',
+      title: 'Local default encrypted store',
+      provider: 'local',
+      source: '@secretsbroker/local/default',
+      connectionRef: 'secret://local/default',
+      state: 'healthy',
+      health: {
+        label: 'Ready for resolves',
+        checkedAt: '2026-05-07T19:04:00Z',
+        nextAction: 'No action required; continue monitoring audit events.',
+      },
+      metadata: [
+        { label: 'Mode', value: 'local-first encrypted store' },
+        { label: 'Namespace', value: 'default' },
+        { label: 'Storage', value: 'encrypted metadata index' },
+        { label: 'Values', value: 'hidden / never rendered' },
+      ],
+      scopes: [
+        { label: '@serviceadmin read runtime refs', decision: 'allowed' },
+        { label: 'write generated SESSION_SECRET', decision: 'review' },
+        { label: 'export plaintext values', decision: 'denied' },
+      ],
+      secretMaterial: {
+        presence: 'present',
+        valueAvailable: false,
+        safeDescriptor:
+          'Encrypted payload present; raw value is not loaded in the UI.',
+        version: 'key-v4',
+        updatedAt: '2026-05-07T18:55:00Z',
+        expiresAt: '2026-06-07T18:55:00Z',
+        refreshWindow: 'Rotate during next maintenance window.',
+      },
+      usage: {
+        lastSuccessfulResolve: '2026-05-07T19:01:44Z',
+        linkedServices: ['@serviceadmin', '@secretsbroker', 'postgres'],
+        linkedWorkflows: ['service-start', 'secret-rotation-preview'],
+        linkedRuns: ['run-20260507-190144', 'run-20260507-185500'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-001',
+          type: 'resolve granted',
+          outcome: 'success',
+          at: '2026-05-07T19:01:44Z',
+          actor: 'service:@serviceadmin',
+          reason: 'policy granted metadata-safe resolve',
+        },
+        {
+          id: 'evt-connection-002',
+          type: 'rotation preview',
+          outcome: 'success',
+          at: '2026-05-07T18:55:00Z',
+          actor: 'operator:max',
+          reason: 'version metadata recorded without value access',
+        },
+      ],
+      actions: [
+        {
+          id: 'reconnect',
+          label: 'Reconnect',
+          state: 'disabled',
+          disabledReason: 'Connection is already healthy.',
+        },
+        {
+          id: 'refresh-test-now',
+          label: 'Refresh/test now',
+          state: 'available',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'danger',
+          confirmationCopy:
+            'Rotate local-default material. Existing services may need restart; raw values will remain hidden.',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'danger',
+          confirmationCopy:
+            'Revoke local-default material. Dependent resolves will fail until replacement material is present.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Disable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete local-default connection metadata. This does not print or export secret values.',
+        },
+      ],
+    },
+    {
+      id: 'vault-ops',
+      title: 'Vault ops connection',
+      provider: 'vault',
+      source: '@secretsbroker/external/ops',
+      connectionRef: 'vault://kv/service-lasso',
+      state: 'degraded',
+      health: {
+        label: 'Authentication required',
+        checkedAt: '2026-05-07T18:58:12Z',
+        nextAction:
+          'Reconnect the Vault CLI session, then refresh/test this connection.',
+        failureReason: 'source_auth_required',
+      },
+      metadata: [
+        { label: 'Mount', value: 'kv/service-lasso' },
+        { label: 'Auth mode', value: 'operator session token required' },
+        { label: 'Values', value: 'hidden / never requested' },
+      ],
+      scopes: [
+        { label: 'payments-api read STRIPE_KEY ref', decision: 'review' },
+        { label: 'backup-worker read AWS refs', decision: 'review' },
+        { label: 'list all Vault mounts', decision: 'denied' },
+      ],
+      secretMaterial: {
+        presence: 'expired',
+        valueAvailable: false,
+        safeDescriptor:
+          'Credential handle exists, but the operator session is expired.',
+        version: 'vault-metadata-v2',
+        updatedAt: '2026-05-07T17:30:00Z',
+        expiresAt: '2026-05-07T18:30:00Z',
+        refreshWindow: 'Reconnect before starting dependent services.',
+      },
+      usage: {
+        lastSuccessfulResolve: '2026-05-07T18:12:20Z',
+        lastFailure: '2026-05-07T18:58:12Z — source_auth_required',
+        linkedServices: ['payments-api', 'backup-worker'],
+        linkedWorkflows: ['deploy-payments-api'],
+        linkedRuns: ['run-20260507-185812'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-003',
+          type: 'refresh failure',
+          outcome: 'failure',
+          at: '2026-05-07T18:58:12Z',
+          actor: 'operator:max',
+          reason: 'source_auth_required',
+        },
+        {
+          id: 'evt-connection-004',
+          type: 'resolve denied',
+          outcome: 'denied',
+          at: '2026-05-07T18:57:34Z',
+          actor: 'service:payments-api',
+          reason: 'auth expired before resolve',
+        },
+      ],
+      actions: [
+        { id: 'reconnect', label: 'Reconnect', state: 'available' },
+        {
+          id: 'refresh-test-now',
+          label: 'Refresh/test now',
+          state: 'available',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'disabled',
+          disabledReason: 'Reconnect before rotating external material.',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'danger',
+          confirmationCopy:
+            'Revoke the Vault ops credential handle. Dependent services will lose access until reconnected.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Disable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete the Vault ops connection metadata. This removes metadata only and never displays secret values.',
+        },
+      ],
+    },
+    {
+      id: 'aws-backup-worker',
+      title: 'AWS backup worker connection',
+      provider: 'aws-secrets-manager',
+      source: '@secretsbroker/external/aws',
+      connectionRef: 'aws-secrets-manager://service-lasso/backup-worker',
+      state: 'missing',
+      health: {
+        label: 'Missing credentials',
+        checkedAt: '2026-05-07T18:45:00Z',
+        nextAction:
+          'Add a scoped AWS profile or disable this connection until configured.',
+        failureReason: 'credential_handle_missing',
+      },
+      metadata: [
+        { label: 'Region', value: 'ap-southeast-2' },
+        { label: 'Profile', value: 'service-lasso' },
+        { label: 'Values', value: 'hidden / unavailable' },
+      ],
+      scopes: [
+        { label: 'backup-worker read backup refs', decision: 'review' },
+        { label: 'delete AWS secret versions', decision: 'denied' },
+      ],
+      secretMaterial: {
+        presence: 'missing',
+        valueAvailable: false,
+        safeDescriptor:
+          'No credential handle is configured for this provider connection.',
+      },
+      usage: {
+        lastFailure: '2026-05-07T18:45:00Z — credential_handle_missing',
+        linkedServices: ['backup-worker'],
+        linkedWorkflows: ['nightly-backup'],
+        linkedRuns: ['run-20260507-184500'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-005',
+          type: 'test failure',
+          outcome: 'failure',
+          at: '2026-05-07T18:45:00Z',
+          actor: 'operator:max',
+          reason: 'credential_handle_missing',
+        },
+      ],
+      actions: [
+        { id: 'reconnect', label: 'Reconnect', state: 'available' },
+        {
+          id: 'refresh-test-now',
+          label: 'Refresh/test now',
+          state: 'disabled',
+          disabledReason: 'Credential handle is missing.',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'available',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'disabled',
+          disabledReason: 'No material is present.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Enable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete the AWS backup worker connection metadata. No secret values will be shown or copied.',
+        },
+      ],
+    },
+  ]
+
+export function getSecretsBrokerProviderConnectionDetail(id: string) {
+  return secretsBrokerProviderConnections.find(
+    (connection) => connection.id === id
+  )
+}
+
+export function providerConnectionHasSecretValue(
+  connection: SecretsBrokerProviderConnectionDetail
+) {
+  const joined = JSON.stringify(connection)
+  return /hunter2|correct-horse|plain\s*text\s*secret|supersecret|sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|AKIA[0-9A-Z]{16}|password\s*=|token\s*=/i.test(
+    joined
+  )
+}

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -8,6 +8,10 @@ import {
 } from './audit-events'
 import { secretsBrokerDiagnostics, scrubSecretLikeOutput } from './diagnostics'
 import {
+  providerConnectionHasSecretValue,
+  secretsBrokerProviderConnections,
+} from './provider-connections'
+import {
   secretsBrokerSourceBackends,
   sourceBackendHasSecretValue,
 } from './source-backends'
@@ -108,6 +112,92 @@ describe('Secrets Broker setup wizard', () => {
     expect(secretsBrokerSourceBackends.some(sourceBackendHasSecretValue)).toBe(
       false
     )
+  })
+
+  it('links to provider connection detail records from the setup surface', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getByText(/Provider connection details/i)).toBeVisible()
+    expect(screen.getByText(/Local default encrypted store/i)).toBeVisible()
+    expect(screen.getByText(/Vault ops connection/i)).toBeVisible()
+    expect(screen.getByText(/AWS backup worker connection/i)).toBeVisible()
+    expect(
+      screen.getAllByRole('link', { name: /View detail/i })[0]
+    ).toHaveAttribute('href', '/secrets-broker/local-default')
+  })
+
+  it('renders safe provider connection detail without raw secret values', async () => {
+    await renderRoute('/secrets-broker/local-default')
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Local default encrypted store/i,
+      })
+    ).toBeVisible()
+    expect(screen.getByText(/Safe metadata summary/i)).toBeVisible()
+    expect(screen.getByText(/Status and health/i)).toBeVisible()
+    expect(screen.getByText(/Secret material state/i)).toBeVisible()
+    expect(screen.getByText(/Presence: Present/i)).toBeVisible()
+    expect(screen.getByText(/Raw value: hidden/i)).toBeVisible()
+    expect(screen.getByText(/Copy value: unavailable/i)).toBeVisible()
+    expect(screen.getByText(/Key version/i)).toBeVisible()
+    expect(screen.getByText(/Expiry/i)).toBeVisible()
+    expect(screen.getByText(/Last successful resolve\/use/i)).toBeVisible()
+    expect(screen.getByText(/Recent audit events/i)).toBeVisible()
+    expect(screen.getByText(/Connection actions/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Replace\/rotate secret material/i })
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Existing services may need restart/i)
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Delete connection/i })
+    ).toBeVisible()
+    expect(screen.queryByText(/supersecret/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/ghp_examplePlaintextToken/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/sk-this-value-must-not-render/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Copy secret/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('explains degraded and missing provider connection next actions', async () => {
+    const degraded = await renderRoute('/secrets-broker/vault-ops')
+
+    expect(screen.getByText(/Authentication required/i)).toBeVisible()
+    expect(screen.getAllByText(/source_auth_required/i)[0]).toBeVisible()
+    expect(screen.getByText(/Reconnect the Vault CLI session/i)).toBeVisible()
+    expect(screen.getByRole('button', { name: /Reconnect/i })).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Replace\/rotate secret material/i })
+    ).toBeDisabled()
+    expect(
+      screen.getByText(/Reconnect before rotating external material/i)
+    ).toBeVisible()
+
+    degraded.unmount()
+    await renderRoute('/secrets-broker/aws-backup-worker')
+    expect(screen.getByText(/Missing credentials/i)).toBeVisible()
+    expect(screen.getAllByText(/credential_handle_missing/i)[0]).toBeVisible()
+    expect(screen.getByText(/Add a scoped AWS profile/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Clear\/revoke secret material/i })
+    ).toBeDisabled()
+    expect(screen.getByText(/No material is present/i)).toBeVisible()
+  })
+
+  it('keeps provider connection detail fixtures free of secret values', () => {
+    expect(
+      secretsBrokerProviderConnections.some(providerConnectionHasSecretValue)
+    ).toBe(false)
   })
 
   it('covers audit event types, filtering, and safe detail rendering', async () => {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as AuthenticatedSettingsDisplayRouteImport } from './routes/_auth
 import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_authenticated/settings/appearance'
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
 import { Route as AuthenticatedServicesServiceIdRouteImport } from './routes/_authenticated/services.$serviceId'
+import { Route as AuthenticatedSecretsBrokerConnectionIdRouteImport } from './routes/_authenticated/secrets-broker.$connectionId'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
 const ClerkRouteRoute = ClerkRouteRouteImport.update({
@@ -252,6 +253,12 @@ const AuthenticatedServicesServiceIdRoute =
     path: '/services/$serviceId',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedSecretsBrokerConnectionIdRoute =
+  AuthenticatedSecretsBrokerConnectionIdRouteImport.update({
+    id: '/secrets-broker/$connectionId',
+    path: '/secrets-broker/$connectionId',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedErrorsErrorRoute =
   AuthenticatedErrorsErrorRouteImport.update({
     id: '/errors/$error',
@@ -274,6 +281,7 @@ export interface FileRoutesByFullPath {
   '/500': typeof errors500Route
   '/503': typeof errors503Route
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -311,6 +319,7 @@ export interface FileRoutesByTo {
   '/503': typeof errors503Route
   '/': typeof AuthenticatedIndexRoute
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -353,6 +362,7 @@ export interface FileRoutesById {
   '/(errors)/503': typeof errors503Route
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/_authenticated/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/_authenticated/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/_authenticated/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -393,6 +403,7 @@ export interface FileRouteTypes {
     | '/500'
     | '/503'
     | '/errors/$error'
+    | '/secrets-broker/$connectionId'
     | '/services/$serviceId'
     | '/settings/account'
     | '/settings/appearance'
@@ -430,6 +441,7 @@ export interface FileRouteTypes {
     | '/503'
     | '/'
     | '/errors/$error'
+    | '/secrets-broker/$connectionId'
     | '/services/$serviceId'
     | '/settings/account'
     | '/settings/appearance'
@@ -471,6 +483,7 @@ export interface FileRouteTypes {
     | '/(errors)/503'
     | '/_authenticated/'
     | '/_authenticated/errors/$error'
+    | '/_authenticated/secrets-broker/$connectionId'
     | '/_authenticated/services/$serviceId'
     | '/_authenticated/settings/account'
     | '/_authenticated/settings/appearance'
@@ -778,6 +791,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedServicesServiceIdRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/$connectionId': {
+      id: '/_authenticated/secrets-broker/$connectionId'
+      path: '/secrets-broker/$connectionId'
+      fullPath: '/secrets-broker/$connectionId'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerConnectionIdRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/errors/$error': {
       id: '/_authenticated/errors/$error'
       path: '/errors/$error'
@@ -815,6 +835,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedErrorsErrorRoute: typeof AuthenticatedErrorsErrorRoute
+  AuthenticatedSecretsBrokerConnectionIdRoute: typeof AuthenticatedSecretsBrokerConnectionIdRoute
   AuthenticatedServicesServiceIdRoute: typeof AuthenticatedServicesServiceIdRoute
   AuthenticatedAppsIndexRoute: typeof AuthenticatedAppsIndexRoute
   AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
@@ -835,6 +856,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
   AuthenticatedErrorsErrorRoute: AuthenticatedErrorsErrorRoute,
+  AuthenticatedSecretsBrokerConnectionIdRoute:
+    AuthenticatedSecretsBrokerConnectionIdRoute,
   AuthenticatedServicesServiceIdRoute: AuthenticatedServicesServiceIdRoute,
   AuthenticatedAppsIndexRoute: AuthenticatedAppsIndexRoute,
   AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,

--- a/src/routes/_authenticated/secrets-broker.$connectionId.tsx
+++ b/src/routes/_authenticated/secrets-broker.$connectionId.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretsBrokerProviderConnectionDetailPage } from '@/features/secrets-broker/connection-detail'
+
+export const Route = createFileRoute(
+  '/_authenticated/secrets-broker/$connectionId'
+)({
+  component: ProviderConnectionDetailRoute,
+})
+
+function ProviderConnectionDetailRoute() {
+  const { connectionId } = Route.useParams()
+
+  return (
+    <SecretsBrokerProviderConnectionDetailPage connectionId={connectionId} />
+  )
+}


### PR DESCRIPTION
Closes #32

## Summary
- Added safe provider connection detail stub data for healthy, degraded, and missing Secrets Broker provider connections.
- Added a `/secrets-broker/$connectionId` detail route with metadata, health, permissions, secret material presence/state, version/expiry timeline, usage links, audit events, and action states.
- Linked the setup page to available provider connection detail records.
- Extended tests for safe masking/no-reveal behavior, dangerous/disabled action states, degraded/missing next actions, and fixture-level secret-value guards.

## Validation
- `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 13 passed
- `npm run test` — 64 passed
- `npm run format:check` — passed
- `npm run lint` — passed with existing warnings only in installed/logs/network/runtime/variables files
- `npm run build` — passed

## Secret-safety notes
- Detail pages show presence/state/version/expiry/validation metadata only.
- Raw secret values are never rendered, copied, or represented in fixture data.
- Dangerous actions include confirmation copy that explicitly preserves no-value rendering.
