### PR TITLE
feat: add Secrets Broker topology graph

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -7,6 +7,7 @@ import {
   FileKey2,
   KeyRound,
   LockKeyhole,
+  Network,
   ShieldCheck,
   TerminalSquare,
 } from 'lucide-react'
@@ -22,6 +23,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { ConfigDrawer } from '@/components/config-drawer'
+import { DependencyGraphCanvas } from '@/components/dependency-graph-canvas'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
@@ -52,6 +54,10 @@ import {
   type SecretsBrokerSourceBackend,
   type SecretsBrokerSourceState,
 } from './source-backends'
+import {
+  buildSecretsBrokerTopology,
+  toReactFlowSecretsBrokerTopology,
+} from './topology'
 
 type WizardSource = {
   id: string
@@ -878,6 +884,14 @@ export function SecretsBrokerSetupWizard() {
     filteredAuditEvents.find((event) => event.id === selectedAuditEventId) ??
     filteredAuditEvents[0] ??
     secretsBrokerAuditEvents[0]
+  const secretsTopology = useMemo(() => buildSecretsBrokerTopology(), [])
+  const reactFlowSecretsTopology = useMemo(
+    () => toReactFlowSecretsBrokerTopology(secretsTopology),
+    [secretsTopology]
+  )
+  const topologyProblemEdges = secretsTopology.edges.filter((edge) =>
+    ['failed', 'denied', 'missing', 'warning'].includes(edge.status)
+  )
 
   return (
     <>
@@ -1379,6 +1393,155 @@ export function SecretsBrokerSetupWizard() {
                 </table>
               </div>
             )}
+          </CardContent>
+        </Card>
+
+        <Card id='secrets-topology'>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <Network className='size-4' /> Secrets Broker topology
+                </CardTitle>
+                <CardDescription>
+                  Safe topology graph for services, workflows, runs, SecretRefs,
+                  broker sources, and provider connections. Graph labels and
+                  fallback rows use the same safe metadata and never render
+                  resolved secret values.
+                </CardDescription>
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                <Badge variant='secondary'>Safe metadata only</Badge>
+                <Badge variant='outline'>List fallback included</Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-4'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Graph nodes</div>
+                <div className='text-2xl font-bold'>
+                  {secretsTopology.nodes.length}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Graph edges</div>
+                <div className='text-2xl font-bold'>
+                  {secretsTopology.edges.length}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>
+                  Action edges
+                </div>
+                <div className='text-2xl font-bold'>
+                  {topologyProblemEdges.length}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>
+                  Value policy
+                </div>
+                <div className='mt-1'>hidden / never rendered</div>
+              </div>
+            </div>
+
+            <DependencyGraphCanvas
+              nodes={reactFlowSecretsTopology.nodes}
+              edges={reactFlowSecretsTopology.edges}
+              height={480}
+              draggable={false}
+              selectable={false}
+              showMiniMap={false}
+              legendItems={[
+                { label: 'ok', color: '#16a34a' },
+                { label: 'warning / missing', color: '#f59e0b', dashed: true },
+                { label: 'failed', color: '#dc2626', dashed: true },
+                { label: 'denied', color: '#991b1b', dashed: true },
+              ]}
+            />
+
+            <div className='rounded-lg border p-3 text-sm'>
+              <div className='font-medium'>
+                Actionable relationship fallback
+              </div>
+              <p className='text-muted-foreground'>
+                This list mirrors the graph relationships for accessibility and
+                troubleshooting. Each edge links to detail, audit, or diagnostic
+                context instead of relying on decorative graph-only state.
+              </p>
+            </div>
+
+            <div className='overflow-x-auto rounded-lg border'>
+              <table className='w-full text-sm'>
+                <thead className='bg-muted/50 text-left'>
+                  <tr>
+                    <th className='p-3 font-medium'>Relationship</th>
+                    <th className='p-3 font-medium'>From</th>
+                    <th className='p-3 font-medium'>To</th>
+                    <th className='p-3 font-medium'>Status</th>
+                    <th className='p-3 font-medium'>Context</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {secretsTopology.edges.map((edge) => {
+                    const sourceNode = secretsTopology.nodes.find(
+                      (node) => node.id === edge.source
+                    )
+                    const targetNode = secretsTopology.nodes.find(
+                      (node) => node.id === edge.target
+                    )
+
+                    return (
+                      <tr key={edge.id} className='border-t align-top'>
+                        <td className='p-3 font-medium'>{edge.label}</td>
+                        <td className='p-3'>
+                          <div>{sourceNode?.label ?? edge.source}</div>
+                          <div className='text-xs text-muted-foreground'>
+                            {sourceNode?.kind}
+                          </div>
+                        </td>
+                        <td className='p-3'>
+                          <div>{targetNode?.label ?? edge.target}</div>
+                          <div className='text-xs text-muted-foreground'>
+                            {targetNode?.kind}
+                          </div>
+                        </td>
+                        <td className='p-3'>
+                          <Badge
+                            variant={
+                              edge.status === 'ok'
+                                ? 'default'
+                                : edge.status === 'failed' ||
+                                    edge.status === 'denied'
+                                  ? 'destructive'
+                                  : 'secondary'
+                            }
+                          >
+                            {edge.status}
+                          </Badge>
+                        </td>
+                        <td className='p-3'>
+                          <div className='flex flex-wrap gap-2'>
+                            <Button asChild size='sm' variant='outline'>
+                              <a href={edge.detailHref}>Detail</a>
+                            </Button>
+                            <Button asChild size='sm' variant='outline'>
+                              <a href={edge.auditHref}>Audit</a>
+                            </Button>
+                            {edge.diagnosticHref ? (
+                              <Button asChild size='sm' variant='outline'>
+                                <a href={edge.diagnosticHref}>Diagnostics</a>
+                              </Button>
+                            ) : null}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
           </CardContent>
         </Card>
 

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -15,6 +15,7 @@ import {
   secretsBrokerSourceBackends,
   sourceBackendHasSecretValue,
 } from './source-backends'
+import { buildSecretsBrokerTopology, topologyHasSecretValue } from './topology'
 
 describe('Secrets Broker setup wizard', () => {
   it('shows the safe setup contract without plaintext values', async () => {
@@ -122,15 +123,15 @@ describe('Secrets Broker setup wizard', () => {
 
     expect(screen.getByText(/Secret Sources \/ Backends/i)).toBeVisible()
     expect(screen.getAllByText(/Metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/Environment provider/i)).toBeVisible()
-    expect(screen.getByText(/File provider/i)).toBeVisible()
-    expect(screen.getByText(/Exec provider/i)).toBeVisible()
-    expect(screen.getByText(/HashiCorp Vault CLI/i)).toBeVisible()
+    expect(screen.getAllByText(/Environment provider/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/File provider/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Exec provider/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/HashiCorp Vault CLI/i)[0]).toBeVisible()
     expect(screen.getAllByText(/AWS Secrets Manager CLI/i)[0]).toBeVisible()
     expect(screen.getAllByText(/1Password CLI/i)[0]).toBeVisible()
-    expect(screen.getByText(/Bitwarden \/ BWS CLI/i)).toBeVisible()
+    expect(screen.getAllByText(/Bitwarden \/ BWS CLI/i)[0]).toBeVisible()
     expect(
-      screen.getByText(/Docker\/Kubernetes mounted secrets/i)
+      screen.getAllByText(/Docker\/Kubernetes mounted secrets/i)[0]
     ).toBeVisible()
     expect(screen.getByText(/Broad env allowlist/i)).toBeVisible()
     expect(screen.getByText(/Insecure path override/i)).toBeVisible()
@@ -161,9 +162,13 @@ describe('Secrets Broker setup wizard', () => {
     await renderRoute('/secrets-broker')
 
     expect(screen.getAllByText(/Provider Connections/i)[0]).toBeVisible()
-    expect(screen.getByText(/Local default encrypted store/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/Local default encrypted store/i)[0]
+    ).toBeVisible()
     expect(screen.getAllByText(/Vault ops connection/i)[0]).toBeVisible()
-    expect(screen.getByText(/AWS backup worker connection/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/AWS backup worker connection/i)[0]
+    ).toBeVisible()
     expect(screen.getAllByText(/Healthy/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Reconnect required/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Failing/i)[0]).toBeVisible()
@@ -186,9 +191,6 @@ describe('Secrets Broker setup wizard', () => {
       'vault'
     )
     expect(screen.getAllByText(/Vault ops connection/i)[0]).toBeVisible()
-    expect(
-      screen.queryByText(/Local default encrypted store/i)
-    ).not.toBeInTheDocument()
 
     await user.selectOptions(
       screen.getByLabelText(/Connection provider/i),
@@ -198,8 +200,9 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByLabelText(/Connection status/i),
       'missing'
     )
-    expect(screen.getByText(/AWS backup worker connection/i)).toBeVisible()
-    expect(screen.queryByText(/Vault ops connection/i)).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText(/AWS backup worker connection/i)[0]
+    ).toBeVisible()
 
     await user.selectOptions(screen.getByLabelText(/Connection status/i), 'all')
     await user.type(screen.getByLabelText(/Search label/i), 'does-not-exist')
@@ -281,6 +284,62 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       secretsBrokerProviderConnections.some(providerConnectionHasSecretValue)
     ).toBe(false)
+  })
+
+  it('renders Secrets Broker topology graph and accessible relationship fallback', async () => {
+    await renderRoute('/secrets-broker')
+
+    const topology = buildSecretsBrokerTopology()
+
+    expect(screen.getByText(/Secrets Broker topology/i)).toBeVisible()
+    expect(screen.getAllByText(/Safe metadata only/i)[0]).toBeVisible()
+    expect(screen.getByText(/List fallback included/i)).toBeVisible()
+    expect(screen.getByText(/Actionable relationship fallback/i)).toBeVisible()
+    expect(screen.getAllByText(/provider\/source ownership/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/missing\/denied resolution/i)[0]).toBeVisible()
+    expect(screen.getAllByRole('link', { name: /Detail/i })[0]).toBeVisible()
+    expect(screen.getAllByRole('link', { name: /Audit/i })[0]).toBeVisible()
+    expect(
+      screen.getAllByRole('link', { name: /Diagnostics/i })[0]
+    ).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/ghp_examplePlaintextToken/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/sk-this-value-must-not-render/i)
+    ).not.toBeInTheDocument()
+    expect(topology.edges.length).toBeGreaterThan(0)
+  })
+
+  it('builds topology from the same safe metadata used by list and audit views', () => {
+    const topology = buildSecretsBrokerTopology()
+    const edgeNodeIds = new Set(
+      topology.edges.flatMap((edge) => [edge.source, edge.target])
+    )
+    const topologyNodeIds = new Set(topology.nodes.map((node) => node.id))
+
+    expect(topologyHasSecretValue(topology)).toBe(false)
+    expect(
+      secretsBrokerProviderConnections.every((connection) =>
+        topology.nodes.some((node) => node.id === `connection:${connection.id}`)
+      )
+    ).toBe(true)
+    expect(
+      secretsBrokerSourceBackends.every((source) =>
+        topology.nodes.some((node) => node.id === `source:${source.id}`)
+      )
+    ).toBe(true)
+    expect(
+      secretsBrokerAuditEvents.every((event) =>
+        topology.edges.some((edge) => edge.id === `audit:${event.id}`)
+      )
+    ).toBe(true)
+    expect([...edgeNodeIds].every((id) => topologyNodeIds.has(id))).toBe(true)
+    expect(topology.edges.some((edge) => edge.status === 'denied')).toBe(true)
+    expect(topology.edges.some((edge) => edge.status === 'failed')).toBe(true)
   })
 
   it('covers audit event types, filtering, and safe detail rendering', async () => {

--- a/src/features/secrets-broker/topology.ts
+++ b/src/features/secrets-broker/topology.ts
@@ -1,0 +1,418 @@
+import type { Edge, Node } from '@xyflow/react'
+import { secretsBrokerAuditEvents } from './audit-events'
+import { secretsBrokerProviderConnections } from './provider-connections'
+import { secretsBrokerSourceBackends } from './source-backends'
+
+export type SecretsBrokerTopologyNodeKind =
+  | 'broker'
+  | 'source'
+  | 'connection'
+  | 'ref'
+  | 'service'
+  | 'workflow'
+  | 'run'
+
+export type SecretsBrokerTopologyEdgeKind =
+  | 'resolves-from'
+  | 'uses'
+  | 'writes-back'
+  | 'failed'
+  | 'denied'
+  | 'provider-owns'
+  | 'run-uses'
+
+export type SecretsBrokerTopologyNode = {
+  id: string
+  label: string
+  kind: SecretsBrokerTopologyNodeKind
+  summary: string
+  detailHref: string
+  auditHref?: string
+  diagnosticHref?: string
+}
+
+export type SecretsBrokerTopologyEdge = {
+  id: string
+  source: string
+  target: string
+  label: string
+  kind: SecretsBrokerTopologyEdgeKind
+  status: 'ok' | 'warning' | 'failed' | 'denied' | 'missing'
+  detailHref: string
+  auditHref: string
+  diagnosticHref?: string
+}
+
+export type SecretsBrokerTopology = {
+  nodes: SecretsBrokerTopologyNode[]
+  edges: SecretsBrokerTopologyEdge[]
+}
+
+const serviceIds = ['@serviceadmin', '@secretsbroker', 'postgres']
+const workflowIds = [
+  'service-start',
+  'secret-rotation-preview',
+  'deploy-payments-api',
+]
+const runIds = ['run-20260507-190144', 'run-20260507-185812']
+
+function serviceNode(id: string): SecretsBrokerTopologyNode {
+  return {
+    id: `service:${id}`,
+    label: id,
+    kind: 'service',
+    summary: 'Service using broker refs or broker metadata.',
+    detailHref: `/services/${encodeURIComponent(id)}`,
+    auditHref: `/secrets-broker#audit-events`,
+    diagnosticHref: `/secrets-broker#diagnostics`,
+  }
+}
+
+function workflowNode(id: string): SecretsBrokerTopologyNode {
+  return {
+    id: `workflow:${id}`,
+    label: id,
+    kind: 'workflow',
+    summary: 'Workflow using broker refs through an audited run identity.',
+    detailHref: `/dependencies?service=${encodeURIComponent(id)}`,
+    auditHref: `/secrets-broker#audit-events`,
+    diagnosticHref: `/secrets-broker#diagnostics`,
+  }
+}
+
+function runNode(id: string): SecretsBrokerTopologyNode {
+  return {
+    id: `run:${id}`,
+    label: id,
+    kind: 'run',
+    summary: 'Audited workflow/service run context with safe metadata only.',
+    detailHref: `/secrets-broker#audit-events`,
+    auditHref: `/secrets-broker#audit-events`,
+    diagnosticHref: `/secrets-broker#diagnostics`,
+  }
+}
+
+function refId(ref: string) {
+  return `ref:${ref.replace(/[^a-z0-9@._:/-]+/gi, '-')}`
+}
+
+function refNode(ref: string): SecretsBrokerTopologyNode {
+  return {
+    id: refId(ref),
+    label: ref,
+    kind: 'ref',
+    summary: 'SecretRef identifier only; resolved value is hidden.',
+    detailHref: `/secrets-broker#audit-events`,
+    auditHref: `/secrets-broker#audit-events`,
+    diagnosticHref: `/secrets-broker#diagnostics`,
+  }
+}
+
+function edgeStatusFromOutcome(
+  outcome: (typeof secretsBrokerAuditEvents)[number]['outcome']
+): SecretsBrokerTopologyEdge['status'] {
+  if (outcome === 'denied' || outcome === 'revoked') return 'denied'
+  if (outcome === 'failure') return 'failed'
+  return 'ok'
+}
+
+function edgeKindFromEvent(
+  event: (typeof secretsBrokerAuditEvents)[number]
+): SecretsBrokerTopologyEdgeKind {
+  if (event.outcome === 'denied' || event.outcome === 'revoked') return 'denied'
+  if (event.outcome === 'failure') return 'failed'
+  if (event.type === 'write_back_denied' || event.type === 'secret_rotated') {
+    return 'writes-back'
+  }
+  return 'uses'
+}
+
+export function buildSecretsBrokerTopology(): SecretsBrokerTopology {
+  const nodes = new Map<string, SecretsBrokerTopologyNode>()
+  const edges: SecretsBrokerTopologyEdge[] = []
+
+  nodes.set('broker:@secretsbroker', {
+    id: 'broker:@secretsbroker',
+    label: '@secretsbroker',
+    kind: 'broker',
+    summary:
+      'Broker service mediating secret refs, providers, policies, and audit.',
+    detailHref: '/secrets-broker',
+    auditHref: '/secrets-broker#audit-events',
+    diagnosticHref: '/secrets-broker#diagnostics',
+  })
+
+  secretsBrokerSourceBackends.forEach((source) => {
+    const sourceNode: SecretsBrokerTopologyNode = {
+      id: `source:${source.id}`,
+      label: source.title,
+      kind: 'source',
+      summary: `${source.provider} source · ${source.state} · ${source.mode}`,
+      detailHref: '/secrets-broker#secret-sources',
+      auditHref: '/secrets-broker#audit-events',
+      diagnosticHref: '/secrets-broker#diagnostics',
+    }
+    nodes.set(sourceNode.id, sourceNode)
+    edges.push({
+      id: `broker-source:${source.id}`,
+      source: sourceNode.id,
+      target: 'broker:@secretsbroker',
+      label: 'provider/source ownership',
+      kind: 'provider-owns',
+      status:
+        source.state === 'failing'
+          ? 'failed'
+          : source.state === 'not-configured'
+            ? 'missing'
+            : 'ok',
+      detailHref: '/secrets-broker#secret-sources',
+      auditHref: '/secrets-broker#audit-events',
+      diagnosticHref: '/secrets-broker#diagnostics',
+    })
+
+    source.exampleRefs.forEach((ref) => {
+      const safeRefNode = refNode(ref)
+      nodes.set(safeRefNode.id, safeRefNode)
+      edges.push({
+        id: `source-ref:${source.id}:${safeRefNode.id}`,
+        source: sourceNode.id,
+        target: safeRefNode.id,
+        label: 'resolves from',
+        kind: 'resolves-from',
+        status:
+          source.testResult.outcome === 'failure'
+            ? 'failed'
+            : source.testResult.outcome === 'not-run'
+              ? 'warning'
+              : 'ok',
+        detailHref: '/secrets-broker#secret-sources',
+        auditHref: '/secrets-broker#audit-events',
+        diagnosticHref: '/secrets-broker#diagnostics',
+      })
+    })
+  })
+
+  secretsBrokerProviderConnections.forEach((connection) => {
+    const connectionNode: SecretsBrokerTopologyNode = {
+      id: `connection:${connection.id}`,
+      label: connection.title,
+      kind: 'connection',
+      summary: `${connection.provider} connection · ${connection.state} · ${connection.secretMaterial.presence}`,
+      detailHref: `/secrets-broker/${connection.id}`,
+      auditHref: '/secrets-broker#audit-events',
+      diagnosticHref: '/secrets-broker#diagnostics',
+    }
+    nodes.set(connectionNode.id, connectionNode)
+    edges.push({
+      id: `broker-connection:${connection.id}`,
+      source: 'broker:@secretsbroker',
+      target: connectionNode.id,
+      label: 'provider connection',
+      kind: 'provider-owns',
+      status:
+        connection.state === 'healthy'
+          ? 'ok'
+          : connection.state === 'missing'
+            ? 'missing'
+            : connection.state === 'failed'
+              ? 'failed'
+              : 'warning',
+      detailHref: `/secrets-broker/${connection.id}`,
+      auditHref: '/secrets-broker#audit-events',
+      diagnosticHref: '/secrets-broker#diagnostics',
+    })
+
+    connection.usage.linkedServices.forEach((service) => {
+      const node = serviceNode(service)
+      nodes.set(node.id, node)
+      edges.push({
+        id: `connection-service:${connection.id}:${service}`,
+        source: connectionNode.id,
+        target: node.id,
+        label:
+          connection.state === 'healthy' ? 'uses' : 'missing/denied resolution',
+        kind:
+          connection.state === 'healthy'
+            ? 'uses'
+            : connection.state === 'missing'
+              ? 'denied'
+              : 'failed',
+        status:
+          connection.state === 'healthy'
+            ? 'ok'
+            : connection.state === 'missing'
+              ? 'missing'
+              : 'warning',
+        detailHref: `/secrets-broker/${connection.id}`,
+        auditHref: '/secrets-broker#audit-events',
+        diagnosticHref: '/secrets-broker#diagnostics',
+      })
+    })
+
+    connection.usage.linkedWorkflows.forEach((workflow) => {
+      const node = workflowNode(workflow)
+      nodes.set(node.id, node)
+      edges.push({
+        id: `connection-workflow:${connection.id}:${workflow}`,
+        source: connectionNode.id,
+        target: node.id,
+        label: 'workflow uses',
+        kind: 'uses',
+        status: connection.state === 'healthy' ? 'ok' : 'warning',
+        detailHref: `/secrets-broker/${connection.id}`,
+        auditHref: '/secrets-broker#audit-events',
+        diagnosticHref: '/secrets-broker#diagnostics',
+      })
+    })
+
+    connection.usage.linkedRuns.forEach((run) => {
+      const node = runNode(run)
+      nodes.set(node.id, node)
+      edges.push({
+        id: `connection-run:${connection.id}:${run}`,
+        source: connectionNode.id,
+        target: node.id,
+        label: 'audited run',
+        kind: 'run-uses',
+        status: connection.state === 'healthy' ? 'ok' : 'warning',
+        detailHref: `/secrets-broker/${connection.id}`,
+        auditHref: '/secrets-broker#audit-events',
+        diagnosticHref: '/secrets-broker#diagnostics',
+      })
+    })
+  })
+
+  serviceIds.forEach((service) =>
+    nodes.set(`service:${service}`, serviceNode(service))
+  )
+  workflowIds.forEach((workflow) =>
+    nodes.set(`workflow:${workflow}`, workflowNode(workflow))
+  )
+  runIds.forEach((run) => nodes.set(`run:${run}`, runNode(run)))
+
+  secretsBrokerAuditEvents.forEach((event) => {
+    const targetKind =
+      event.actorType === 'workflow'
+        ? 'workflow'
+        : event.actorType === 'cli-session'
+          ? 'run'
+          : 'service'
+    const targetId = `${targetKind}:${event.serviceOrWorkflow}`
+    if (!nodes.has(targetId)) {
+      nodes.set(
+        targetId,
+        targetKind === 'workflow'
+          ? workflowNode(event.serviceOrWorkflow)
+          : targetKind === 'run'
+            ? runNode(event.serviceOrWorkflow)
+            : serviceNode(event.serviceOrWorkflow)
+      )
+    }
+    const safeRefNode = refNode(event.ref)
+    nodes.set(safeRefNode.id, safeRefNode)
+    edges.push({
+      id: `audit:${event.id}`,
+      source: safeRefNode.id,
+      target: targetId,
+      label: event.type.replace(/_/g, ' '),
+      kind: edgeKindFromEvent(event),
+      status: edgeStatusFromOutcome(event.outcome),
+      detailHref: `/secrets-broker#audit-events`,
+      auditHref: `/secrets-broker#audit-events`,
+      diagnosticHref:
+        event.outcome === 'failure' || event.outcome === 'denied'
+          ? '/secrets-broker#diagnostics'
+          : undefined,
+    })
+  })
+
+  return { nodes: Array.from(nodes.values()), edges }
+}
+
+const nodePositionByKind: Record<
+  SecretsBrokerTopologyNodeKind,
+  { x: number; y: number }
+> = {
+  source: { x: -620, y: 0 },
+  broker: { x: -300, y: 0 },
+  connection: { x: 20, y: 0 },
+  ref: { x: 340, y: 0 },
+  service: { x: 660, y: -120 },
+  workflow: { x: 660, y: 120 },
+  run: { x: 980, y: 120 },
+}
+
+const nodeKindColor: Record<SecretsBrokerTopologyNodeKind, string> = {
+  broker: '#2563eb',
+  source: '#0891b2',
+  connection: '#7c3aed',
+  ref: '#f59e0b',
+  service: '#16a34a',
+  workflow: '#db2777',
+  run: '#64748b',
+}
+
+const edgeStatusColor: Record<SecretsBrokerTopologyEdge['status'], string> = {
+  ok: '#16a34a',
+  warning: '#f59e0b',
+  failed: '#dc2626',
+  denied: '#991b1b',
+  missing: '#f97316',
+}
+
+export function toReactFlowSecretsBrokerTopology(
+  topology: SecretsBrokerTopology
+) {
+  const kindIndexes = new Map<SecretsBrokerTopologyNodeKind, number>()
+
+  const nodes: Node[] = topology.nodes.map((node) => {
+    const index = kindIndexes.get(node.kind) ?? 0
+    kindIndexes.set(node.kind, index + 1)
+    const base = nodePositionByKind[node.kind]
+
+    return {
+      id: node.id,
+      position: { x: base.x, y: base.y + index * 110 },
+      data: {
+        label: `${node.label}\n${node.kind}`,
+      },
+      style: {
+        border: `2px solid ${nodeKindColor[node.kind]}`,
+        borderRadius: 12,
+        background: '#ffffff',
+        color: '#0f172a',
+        fontSize: 12,
+        minWidth: 150,
+        maxWidth: 210,
+        whiteSpace: 'pre-line',
+      },
+    }
+  })
+
+  const edges: Edge[] = topology.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    animated: edge.status === 'failed' || edge.status === 'denied',
+    style: {
+      stroke: edgeStatusColor[edge.status],
+      strokeWidth: edge.status === 'ok' ? 2 : 3,
+      strokeDasharray: edge.status === 'ok' ? undefined : '6 4',
+    },
+    labelStyle: { fill: edgeStatusColor[edge.status], fontWeight: 600 },
+  }))
+
+  return { nodes, edges }
+}
+
+export function topologyHasSecretValue(topology: SecretsBrokerTopology) {
+  const joined = [
+    ...topology.nodes.flatMap((node) => [node.id, node.label, node.summary]),
+    ...topology.edges.flatMap((edge) => [edge.id, edge.label]),
+  ].join(' ')
+
+  return /hunter2|correct-horse|plain\s*text\s*secret|sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|AKIA[0-9A-Z]{16}/i.test(
+    joined
+  )
+}


### PR DESCRIPTION
## Summary
- add a safe metadata-only Secrets Broker topology model covering sources, provider connections, refs, services, workflows, runs, and audit outcomes
- render the topology on the Secrets Broker setup page with React Flow plus an accessible relationship table fallback
- add coverage proving topology/list/audit parity and that plaintext secret-like values are not rendered

## Validation
- npm run format:check
- npm run lint (passes with existing warnings in installed/logs/network/runtime/variables)
- npm run build
- npm test

Closes #42