### PR TITLE
Add Secrets Broker workflow authoring boundary

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -58,6 +58,11 @@ import {
   buildSecretsBrokerTopology,
   toReactFlowSecretsBrokerTopology,
 } from './topology'
+import {
+  countWorkflowRefStatuses,
+  workflowAuthoringBoundaries,
+  type WorkflowSecretRefStatus,
+} from './workflow-authoring'
 
 type WizardSource = {
   id: string
@@ -428,6 +433,23 @@ const providerConnectionProviders = Array.from(
     secretsBrokerProviderConnections.map((connection) => connection.provider)
   )
 )
+
+const workflowRefStatusCopy: Record<WorkflowSecretRefStatus, string> = {
+  valid: 'Valid',
+  missing: 'Missing',
+  denied: 'Denied',
+  warning: 'Needs retest',
+}
+
+const workflowRefStatusVariant: Record<
+  WorkflowSecretRefStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  valid: 'default',
+  missing: 'destructive',
+  denied: 'destructive',
+  warning: 'secondary',
+}
 
 function filterProviderConnections(
   connections: SecretsBrokerProviderConnectionDetail[],
@@ -828,6 +850,9 @@ export function SecretsBrokerSetupWizard() {
   const [connectionQueryFilter, setConnectionQueryFilter] = useState('')
   const [overviewScenarioId, setOverviewScenarioId] =
     useState<SecretsBrokerOverviewState>('healthy')
+  const [selectedWorkflowBoundaryId, setSelectedWorkflowBoundaryId] = useState(
+    workflowAuthoringBoundaries[0].id
+  )
   const brokerOverview =
     brokerOverviewScenarios.find(
       (scenario) => scenario.id === overviewScenarioId
@@ -861,6 +886,18 @@ export function SecretsBrokerSetupWizard() {
     secretsBrokerProviderConnections.filter((connection) =>
       ['degraded', 'failed', 'missing'].includes(connection.state)
     ).length
+  const selectedWorkflowBoundary =
+    workflowAuthoringBoundaries.find(
+      (workflow) => workflow.id === selectedWorkflowBoundaryId
+    ) ?? workflowAuthoringBoundaries[0]
+  const workflowRefCounts = countWorkflowRefStatuses()
+  const workflowRefsNeedingAction =
+    workflowRefCounts.denied +
+    workflowRefCounts.missing +
+    workflowRefCounts.warning
+  const selectedWorkflowBlocksSave = selectedWorkflowBoundary.refs.some((ref) =>
+    ['denied', 'missing'].includes(ref.status)
+  )
   const filteredAuditEvents = useMemo(
     () =>
       filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
@@ -1393,6 +1430,196 @@ export function SecretsBrokerSetupWizard() {
                 </table>
               </div>
             )}
+          </CardContent>
+        </Card>
+
+        <Card id='workflow-authoring-boundary'>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <TerminalSquare className='size-4' /> Workflow authoring
+                  boundary
+                </CardTitle>
+                <CardDescription>
+                  Metadata-only guidance for authors wiring Secrets Broker refs
+                  into workflows. This panel validates refs and generates safe
+                  snippets without becoming a Dagu editor or resolving secret
+                  values.
+                </CardDescription>
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                <Badge variant='secondary'>No Dagu editor</Badge>
+                <Badge variant='outline'>SecretRefs only</Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-4'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Workflows</div>
+                <div className='text-2xl font-bold'>
+                  {workflowAuthoringBoundaries.length}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Valid refs</div>
+                <div className='text-2xl font-bold'>
+                  {workflowRefCounts.valid}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Need action</div>
+                <div className='text-2xl font-bold'>
+                  {workflowRefsNeedingAction}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>
+                  Value policy
+                </div>
+                <div className='mt-1'>metadata-only validation</div>
+              </div>
+            </div>
+
+            <div className='grid gap-4 lg:grid-cols-[0.9fr_1.1fr]'>
+              <div className='space-y-3'>
+                <div>
+                  <label
+                    htmlFor='workflow-authoring-scenario'
+                    className='mb-1 block text-xs text-muted-foreground'
+                  >
+                    Authoring scenario
+                  </label>
+                  <select
+                    id='workflow-authoring-scenario'
+                    className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                    value={selectedWorkflowBoundaryId}
+                    onChange={(event) =>
+                      setSelectedWorkflowBoundaryId(event.target.value)
+                    }
+                  >
+                    {workflowAuthoringBoundaries.map((workflow) => (
+                      <option key={workflow.id} value={workflow.id}>
+                        {workflow.title}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className='rounded-lg border p-4 text-sm'>
+                  <div className='mb-2 flex flex-wrap items-start justify-between gap-2'>
+                    <div>
+                      <div className='font-medium'>
+                        {selectedWorkflowBoundary.title}
+                      </div>
+                      <div className='text-xs text-muted-foreground'>
+                        {selectedWorkflowBoundary.owner} ·{' '}
+                        {selectedWorkflowBoundary.targetRuntime}
+                      </div>
+                    </div>
+                    <Badge
+                      variant={
+                        selectedWorkflowBoundary.status === 'ready'
+                          ? 'default'
+                          : 'secondary'
+                      }
+                    >
+                      {selectedWorkflowBoundary.status === 'ready'
+                        ? 'Ready to save'
+                        : 'Needs action'}
+                    </Badge>
+                  </div>
+                  <p className='text-muted-foreground'>
+                    {selectedWorkflowBoundary.summary}
+                  </p>
+                  {selectedWorkflowBlocksSave ? (
+                    <div className='mt-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-destructive'>
+                      Missing or denied refs should block save/run handoff until
+                      policy and metadata issues are resolved.
+                    </div>
+                  ) : (
+                    <div className='mt-3 rounded-md border p-3 text-muted-foreground'>
+                      Ref checks are metadata-valid. Continue to provider tests
+                      before any execution handoff.
+                    </div>
+                  )}
+                </div>
+
+                <div className='rounded-lg border p-4 text-sm'>
+                  <div className='font-medium'>Boundary guardrails</div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {selectedWorkflowBoundary.guardrails.map((guardrail) => (
+                      <li key={guardrail}>{guardrail}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+
+              <div className='space-y-4'>
+                <div className='overflow-x-auto rounded-lg border'>
+                  <table className='w-full text-sm'>
+                    <thead className='bg-muted/50 text-left'>
+                      <tr>
+                        <th className='p-3 font-medium'>SecretRef</th>
+                        <th className='p-3 font-medium'>Provider</th>
+                        <th className='p-3 font-medium'>Status</th>
+                        <th className='p-3 font-medium'>Save/run guidance</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedWorkflowBoundary.refs.map((ref) => (
+                        <tr key={ref.id} className='border-t align-top'>
+                          <td className='p-3'>
+                            <div className='font-medium'>{ref.label}</div>
+                            <div className='font-mono text-xs break-all text-muted-foreground'>
+                              {ref.ref}
+                            </div>
+                          </td>
+                          <td className='p-3'>
+                            <div>{ref.provider}</div>
+                            <div className='text-xs text-muted-foreground'>
+                              {ref.connection}
+                            </div>
+                          </td>
+                          <td className='p-3'>
+                            <Badge
+                              variant={workflowRefStatusVariant[ref.status]}
+                            >
+                              {workflowRefStatusCopy[ref.status]}
+                            </Badge>
+                            <div className='mt-2 text-xs text-muted-foreground'>
+                              {ref.policyDecision}
+                            </div>
+                          </td>
+                          <td className='p-3'>
+                            <div>{ref.message}</div>
+                            <div className='mt-1 text-xs text-muted-foreground'>
+                              {ref.suggestedFix}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                <div className='rounded-lg border p-4'>
+                  <div className='mb-2 flex flex-wrap items-center justify-between gap-2'>
+                    <div className='font-medium'>Generated safe snippet</div>
+                    <Badge variant='secondary'>values hidden</Badge>
+                  </div>
+                  <pre className='overflow-x-auto rounded-md bg-muted/60 p-3 text-xs'>
+                    {selectedWorkflowBoundary.snippet}
+                  </pre>
+                  <p className='mt-2 text-xs text-muted-foreground'>
+                    Snippets are authoring aids only. They contain SecretRef
+                    identifiers and validation flags, never resolved/plaintext
+                    secret values or raw provider command output.
+                  </p>
+                </div>
+              </div>
+            </div>
           </CardContent>
         </Card>
 

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -16,6 +16,10 @@ import {
   sourceBackendHasSecretValue,
 } from './source-backends'
 import { buildSecretsBrokerTopology, topologyHasSecretValue } from './topology'
+import {
+  workflowAuthoringBoundaries,
+  workflowAuthoringHasSecretValue,
+} from './workflow-authoring'
 
 describe('Secrets Broker setup wizard', () => {
   it('shows the safe setup contract without plaintext values', async () => {
@@ -24,7 +28,7 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       await screen.findByRole('heading', { name: /Secrets Broker setup/i })
     ).toBeVisible()
-    expect(screen.getByText(/Values hidden/i)).toBeVisible()
+    expect(screen.getAllByText(/Values hidden/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Local encrypted vault/i)[0]).toBeVisible()
     expect(screen.getAllByText(/OpenClaw exec adapter/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
@@ -284,6 +288,72 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       secretsBrokerProviderConnections.some(providerConnectionHasSecretValue)
     ).toBe(false)
+  })
+
+  it('renders workflow authoring boundary with safe validation and snippets', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getByText(/Workflow authoring boundary/i)).toBeVisible()
+    expect(screen.getByText(/No Dagu editor/i)).toBeVisible()
+    expect(screen.getByText(/SecretRefs only/i)).toBeVisible()
+    expect(screen.getByText(/metadata-only validation/i)).toBeVisible()
+    expect(screen.getAllByText(/Service start bootstrap/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/Service Admin session signing secret/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/secret:\/\/local\/default\/.*SESSION_SECRET/i)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Generated safe snippet/i)).toBeVisible()
+    expect(screen.getAllByText(/values hidden/i)[0]).toBeVisible()
+    expect(screen.getByText(/revealValues: false/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Authoring scenario/i),
+      'deploy-payments-api'
+    )
+
+    expect(screen.getAllByText(/Deploy payments API/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/policy denies this workflow identity/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Ref metadata is missing/i)).toBeVisible()
+    expect(screen.getAllByText(/Denied/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Missing/i)[0]).toBeVisible()
+    expect(screen.getByText(/blockOn: \[missing, denied\]/i)).toBeVisible()
+    expect(
+      screen.getByText(/Missing or denied refs should block save\/run handoff/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/ghp_ex…oken/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/sk-thi…nder/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps workflow authoring fixtures and generated snippets secret-safe', () => {
+    expect(workflowAuthoringHasSecretValue()).toBe(false)
+    expect(
+      workflowAuthoringBoundaries.every((workflow) =>
+        workflow.snippet.includes('revealValues: false')
+      )
+    ).toBe(true)
+    expect(
+      workflowAuthoringBoundaries.some((workflow) =>
+        workflow.refs.some((ref) => ref.status === 'denied')
+      )
+    ).toBe(true)
+    expect(
+      workflowAuthoringBoundaries.some((workflow) =>
+        workflow.refs.some((ref) => ref.status === 'missing')
+      )
+    ).toBe(true)
+    expect(
+      workflowAuthoringBoundaries
+        .flatMap((workflow) => workflow.refs)
+        .every((ref) => ref.ref.startsWith('secret://'))
+    ).toBe(true)
   })
 
   it('renders Secrets Broker topology graph and accessible relationship fallback', async () => {

--- a/src/features/secrets-broker/workflow-authoring.ts
+++ b/src/features/secrets-broker/workflow-authoring.ts
@@ -1,0 +1,177 @@
+export type WorkflowSecretRefStatus = 'valid' | 'missing' | 'denied' | 'warning'
+
+export type WorkflowSecretRefCheck = {
+  id: string
+  ref: string
+  label: string
+  provider: string
+  connection: string
+  status: WorkflowSecretRefStatus
+  policyDecision: string
+  message: string
+  suggestedFix: string
+}
+
+export type WorkflowAuthoringBoundary = {
+  id: string
+  title: string
+  owner: string
+  summary: string
+  targetRuntime: string
+  status: 'ready' | 'needs-action'
+  refs: WorkflowSecretRefCheck[]
+  snippet: string
+  guardrails: string[]
+}
+
+export const workflowAuthoringBoundaries: WorkflowAuthoringBoundary[] = [
+  {
+    id: 'service-start',
+    title: 'Service start bootstrap',
+    owner: '@serviceadmin',
+    summary:
+      'Validate startup SecretRefs before a service author saves a bootstrap workflow or service action.',
+    targetRuntime:
+      'Service Admin workflow metadata; execution stays outside this panel.',
+    status: 'ready',
+    refs: [
+      {
+        id: 'serviceadmin-session-secret',
+        ref: 'secret://local/default/@serviceadmin/SESSION_SECRET',
+        label: 'Service Admin session signing secret',
+        provider: 'local encrypted store',
+        connection: 'local-default',
+        status: 'valid',
+        policyDecision:
+          'policy/serviceadmin/session-secret allows metadata validation',
+        message: 'Ref exists and can be validated without resolving the value.',
+        suggestedFix: 'No action required before save.',
+      },
+      {
+        id: 'node-npm-token',
+        ref: 'secret://file/global/node/NPM_TOKEN',
+        label: 'Node package registry token',
+        provider: 'file source',
+        connection: 'env-provider',
+        status: 'warning',
+        policyDecision:
+          'policy/node/npm-token requires scoped file grant review',
+        message:
+          'Ref is known, but the source should be re-tested before a run.',
+        suggestedFix:
+          'Retest the file source and confirm the narrow grant path.',
+      },
+    ],
+    snippet: [
+      'secrets:',
+      '  SESSION_SECRET: secret://local/default/@serviceadmin/SESSION_SECRET',
+      '  NPM_TOKEN: secret://file/global/node/NPM_TOKEN',
+      'validation:',
+      '  mode: metadata-only',
+      '  revealValues: false',
+    ].join('\n'),
+    guardrails: [
+      'Save-time checks validate ref presence, provider connection state, and policy result only.',
+      'The generated snippet contains SecretRef identifiers, never resolved values.',
+      'Execution and run details stay in the workflow engine/operator companion.',
+    ],
+  },
+  {
+    id: 'deploy-payments-api',
+    title: 'Deploy payments API',
+    owner: 'payments-api',
+    summary:
+      'Show authors missing and denied refs before a workflow can be saved or handed to a runner.',
+    targetRuntime:
+      'Workflow authoring metadata; Dagu-specific execution remains out of scope.',
+    status: 'needs-action',
+    refs: [
+      {
+        id: 'payments-stripe-key',
+        ref: 'secret://vault/payments/STRIPE_KEY',
+        label: 'Stripe API key',
+        provider: 'Vault',
+        connection: 'vault-ops',
+        status: 'denied',
+        policyDecision: 'policy/payments/prod-deny blocks deploy-payments-api',
+        message: 'Policy denies this workflow identity before run.',
+        suggestedFix:
+          'Request policy review or select a workflow identity allowed to use this ref.',
+      },
+      {
+        id: 'payments-db-password',
+        ref: 'secret://local/default/payments-api/DB_PASSWORD',
+        label: 'Payments database password',
+        provider: 'local encrypted store',
+        connection: 'local-default',
+        status: 'missing',
+        policyDecision:
+          'policy/payments/db-password cannot find metadata entry',
+        message: 'Ref metadata is missing, so save/run should be blocked.',
+        suggestedFix:
+          'Create/import the ref metadata in Secrets Broker, then validate again.',
+      },
+    ],
+    snippet: [
+      'secrets:',
+      '  STRIPE_KEY: secret://vault/payments/STRIPE_KEY',
+      '  DB_PASSWORD: secret://local/default/payments-api/DB_PASSWORD',
+      'validation:',
+      '  mode: metadata-only',
+      '  blockOn: [missing, denied]',
+      '  revealValues: false',
+    ].join('\n'),
+    guardrails: [
+      'Denied and missing refs are visible before save/run handoff.',
+      'Authors get policy and remediation context without broker value resolution.',
+      'No Dagu editor controls are rendered in Service Admin for this slice.',
+    ],
+  },
+]
+
+export function countWorkflowRefStatuses(
+  workflows: WorkflowAuthoringBoundary[] = workflowAuthoringBoundaries
+) {
+  return workflows
+    .flatMap((workflow) => workflow.refs)
+    .reduce(
+      (counts, ref) => {
+        counts[ref.status] += 1
+        return counts
+      },
+      { valid: 0, missing: 0, denied: 0, warning: 0 } as Record<
+        WorkflowSecretRefStatus,
+        number
+      >
+    )
+}
+
+export function workflowAuthoringHasSecretValue(
+  workflows: WorkflowAuthoringBoundary[] = workflowAuthoringBoundaries
+) {
+  const joined = workflows
+    .flatMap((workflow) => [
+      workflow.id,
+      workflow.title,
+      workflow.owner,
+      workflow.summary,
+      workflow.targetRuntime,
+      workflow.snippet,
+      ...workflow.guardrails,
+      ...workflow.refs.flatMap((ref) => [
+        ref.id,
+        ref.ref,
+        ref.label,
+        ref.provider,
+        ref.connection,
+        ref.policyDecision,
+        ref.message,
+        ref.suggestedFix,
+      ]),
+    ])
+    .join(' ')
+
+  return /hunter2|correct-horse|plain\s*text\s*secret|sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|AKIA[0-9A-Z]{16}/i.test(
+    joined
+  )
+}


### PR DESCRIPTION
## Summary
- add a metadata-only Secrets Broker workflow authoring boundary panel
- surface valid/warning/missing/denied SecretRef checks with save/run guidance
- generate safe SecretRef snippets with explicit no-value rendering guardrails
- add fixture/unit coverage for validation states, missing/denied messaging, snippets, and no-secret rendering

Closes #41

## Validation
- npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx
- npm run format:check
- npm run lint (passes with 7 existing warnings in installed/logs/network/runtime/variables)
- npm run build
- npm test