### PR TITLE
fix: remove Dagu-specific broker UI copy

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -1444,12 +1444,12 @@ export function SecretsBrokerSetupWizard() {
                 <CardDescription>
                   Metadata-only guidance for authors wiring Secrets Broker refs
                   into workflows. This panel validates refs and generates safe
-                  snippets without becoming a Dagu editor or resolving secret
+                  snippets without becoming a runner editor or resolving secret
                   values.
                 </CardDescription>
               </div>
               <div className='flex flex-wrap gap-2'>
-                <Badge variant='secondary'>No Dagu editor</Badge>
+                <Badge variant='secondary'>No runner editor</Badge>
                 <Badge variant='outline'>SecretRefs only</Badge>
               </div>
             </div>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -295,7 +295,7 @@ describe('Secrets Broker setup wizard', () => {
     await renderRoute('/secrets-broker')
 
     expect(screen.getByText(/Workflow authoring boundary/i)).toBeVisible()
-    expect(screen.getByText(/No Dagu editor/i)).toBeVisible()
+    expect(screen.getByText(/No runner editor/i)).toBeVisible()
     expect(screen.getByText(/SecretRefs only/i)).toBeVisible()
     expect(screen.getByText(/metadata-only validation/i)).toBeVisible()
     expect(screen.getAllByText(/Service start bootstrap/i)[0]).toBeVisible()

--- a/src/features/secrets-broker/workflow-authoring.ts
+++ b/src/features/secrets-broker/workflow-authoring.ts
@@ -83,7 +83,7 @@ export const workflowAuthoringBoundaries: WorkflowAuthoringBoundary[] = [
     summary:
       'Show authors missing and denied refs before a workflow can be saved or handed to a runner.',
     targetRuntime:
-      'Workflow authoring metadata; Dagu-specific execution remains out of scope.',
+      'Workflow authoring metadata; execution-runner specifics remain out of scope.',
     status: 'needs-action',
     refs: [
       {
@@ -124,7 +124,7 @@ export const workflowAuthoringBoundaries: WorkflowAuthoringBoundary[] = [
     guardrails: [
       'Denied and missing refs are visible before save/run handoff.',
       'Authors get policy and remediation context without broker value resolution.',
-      'No Dagu editor controls are rendered in Service Admin for this slice.',
+      'No runner/editor controls are rendered in Service Admin for this slice.',
     ],
   },
 ]


### PR DESCRIPTION
## Summary

Follow-up to #41 / PR #61 after Max clarified that Dagu is only an optional managed service executable and should not be centered in Service Admin / Secrets Broker flows.

This PR removes the remaining Dagu-specific UI/test/fixture wording from the merged workflow-authoring boundary panel and replaces it with generic runner/execution wording.

## Changes

- `No Dagu editor` -> `No runner editor`
- `Dagu-specific execution remains out of scope` -> `execution-runner specifics remain out of scope`
- `No Dagu editor controls...` -> `No runner/editor controls...`

## Validation

- `npx prettier --write src/features/secrets-broker/index.tsx src/features/secrets-broker/secrets-broker-setup.test.tsx src/features/secrets-broker/workflow-authoring.ts`
- `npm run format:check` ✅
- `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` ✅ (19 passed)
- `rg -n "Dagu|dagu" src/features/secrets-broker/index.tsx src/features/secrets-broker/secrets-broker-setup.test.tsx src/features/secrets-broker/workflow-authoring.ts` ✅ no matches
- `git diff --check` ✅