### PR TITLE
Add Secrets Broker backup/key management UI

### DIFF
--- a/src/features/secrets-broker/backup-key-management.ts
+++ b/src/features/secrets-broker/backup-key-management.ts
@@ -1,0 +1,129 @@
+export type SecretsBrokerBackupState = 'ready' | 'missing' | 'stale' | 'blocked'
+
+export type SecretsBrokerRotationState =
+  | 'current'
+  | 'rotation-due'
+  | 'recovery-risk'
+  | 'blocked'
+
+export type SecretsBrokerBackupKeyAction = {
+  id:
+    | 'create-backup'
+    | 'verify-restore-readiness'
+    | 'restore-from-backup'
+    | 'rotate-master-key'
+  label: string
+  state: 'available' | 'disabled' | 'danger'
+  confirmationCopy?: string
+  disabledReason?: string
+}
+
+export type SecretsBrokerBackupKeyStatus = {
+  serviceId: string
+  backup: {
+    state: SecretsBrokerBackupState
+    lastBackupAt?: string
+    artifact: string
+    location: string
+    restoreReadiness: string
+    restoreLastVerifiedAt?: string
+    warning?: string
+  }
+  key: {
+    state: SecretsBrokerRotationState
+    keyVersion: string
+    keyId: string
+    rotationStatus: string
+    recoveryMaterial: string
+    warning?: string
+  }
+  actions: SecretsBrokerBackupKeyAction[]
+  audit: Array<{
+    id: string
+    operation: string
+    outcome: string
+    at: string
+    metadata: string
+  }>
+}
+
+export const secretsBrokerBackupKeyStatus: SecretsBrokerBackupKeyStatus = {
+  serviceId: '@secretsbroker',
+  backup: {
+    state: 'stale',
+    lastBackupAt: '2026-05-08T08:56:00Z',
+    artifact: 'backup-20260508-085600.sbk.json',
+    location: 'operator-controlled encrypted artifact store',
+    restoreReadiness: 'key id matched; decryptability verified in dry-run',
+    restoreLastVerifiedAt: '2026-05-08T09:05:00Z',
+    warning:
+      'Backup is older than the latest key rotation. Create a fresh encrypted artifact before planned maintenance.',
+  },
+  key: {
+    state: 'recovery-risk',
+    keyVersion: 'v4',
+    keyId: 'mkid_7f3a…9c21',
+    rotationStatus: 'rotation available after fresh backup',
+    recoveryMaterial: 'recovery material registered but not recently verified',
+    warning:
+      'Verify portable master-key recovery material before restore or rotation. The UI never displays key material.',
+  },
+  actions: [
+    {
+      id: 'create-backup',
+      label: 'Create encrypted backup',
+      state: 'available',
+    },
+    {
+      id: 'verify-restore-readiness',
+      label: 'Verify restore readiness',
+      state: 'available',
+    },
+    {
+      id: 'restore-from-backup',
+      label: 'Restore from backup',
+      state: 'danger',
+      confirmationCopy:
+        'Restore @secretsbroker from encrypted backup metadata only. Confirm artifact path, key id match, and maintenance window; raw secret values and key material stay hidden.',
+    },
+    {
+      id: 'rotate-master-key',
+      label: 'Rotate master key',
+      state: 'danger',
+      confirmationCopy:
+        'Rotate the portable master key after a fresh encrypted backup. Existing services may need restart; never paste key material into Service Admin.',
+    },
+  ],
+  audit: [
+    {
+      id: 'evt-backup-001',
+      operation: 'backup_create',
+      outcome: 'ready',
+      at: '2026-05-08T08:56:00Z',
+      metadata: 'encrypted artifact created · 12 refs · key version v4',
+    },
+    {
+      id: 'evt-backup-002',
+      operation: 'backup_restore_verify',
+      outcome: 'ready',
+      at: '2026-05-08T09:05:00Z',
+      metadata: 'dry-run decryptability verified · no store overwrite',
+    },
+    {
+      id: 'evt-backup-003',
+      operation: 'key_rotate_preview',
+      outcome: 'recovery_risk',
+      at: '2026-05-08T09:12:00Z',
+      metadata: 'fresh backup recommended before rotation',
+    },
+  ],
+}
+
+const secretLikePattern =
+  /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|api[_-]?key\s*=|sk-[a-z0-9]|ghp_[a-z0-9])/i
+
+export function backupKeyStatusHasSecretMaterial(
+  status: SecretsBrokerBackupKeyStatus
+): boolean {
+  return secretLikePattern.test(JSON.stringify(status))
+}

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -38,6 +38,12 @@ import {
   type SecretsBrokerAuditOutcome,
 } from './audit-events'
 import {
+  secretsBrokerBackupKeyStatus,
+  type SecretsBrokerBackupKeyAction,
+  type SecretsBrokerBackupState,
+  type SecretsBrokerRotationState,
+} from './backup-key-management'
+import {
   countDiagnosticsByStatus,
   secretsBrokerDiagnostics,
   type SecretsBrokerDiagnostic,
@@ -327,6 +333,40 @@ const brokerOverviewStateCopy: Record<SecretsBrokerOverviewState, string> = {
   unconfigured: 'Setup needed',
 }
 
+const backupStateCopy: Record<SecretsBrokerBackupState, string> = {
+  ready: 'Ready',
+  missing: 'Missing backup',
+  stale: 'Backup stale',
+  blocked: 'Blocked',
+}
+
+const backupStateVariant: Record<
+  SecretsBrokerBackupState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  ready: 'default',
+  missing: 'destructive',
+  stale: 'secondary',
+  blocked: 'destructive',
+}
+
+const rotationStateCopy: Record<SecretsBrokerRotationState, string> = {
+  current: 'Current',
+  'rotation-due': 'Rotation due',
+  'recovery-risk': 'Recovery risk',
+  blocked: 'Blocked',
+}
+
+const rotationStateVariant: Record<
+  SecretsBrokerRotationState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  current: 'default',
+  'rotation-due': 'secondary',
+  'recovery-risk': 'destructive',
+  blocked: 'destructive',
+}
+
 const brokerOverviewStateVariant: Record<
   SecretsBrokerOverviewState,
   'default' | 'secondary' | 'destructive' | 'outline'
@@ -492,6 +532,176 @@ const auditOutcomes = Array.from(
 const auditProviders = Array.from(
   new Set(secretsBrokerAuditEvents.map((event) => event.provider))
 )
+
+function BackupKeyActionButton({
+  action,
+}: {
+  action: SecretsBrokerBackupKeyAction
+}) {
+  return (
+    <div className='rounded-lg border p-3 text-sm'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <Button
+          type='button'
+          size='sm'
+          variant={action.state === 'danger' ? 'destructive' : 'outline'}
+          disabled={action.state === 'disabled'}
+        >
+          {action.label}
+        </Button>
+        <Badge variant={action.state === 'danger' ? 'destructive' : 'outline'}>
+          {action.state}
+        </Badge>
+      </div>
+      {action.confirmationCopy ? (
+        <p className='mt-2 text-xs text-muted-foreground'>
+          Confirmation required: {action.confirmationCopy}
+        </p>
+      ) : null}
+      {action.disabledReason ? (
+        <p className='mt-2 text-xs text-muted-foreground'>
+          {action.disabledReason}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function BackupKeyManagementPanel() {
+  const status = secretsBrokerBackupKeyStatus
+
+  return (
+    <Card id='backup-key-management'>
+      <CardHeader>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <div>
+            <CardTitle className='flex items-center gap-2'>
+              <FileKey2 className='size-4' /> Backup, restore, and key
+              management
+            </CardTitle>
+            <CardDescription>
+              Safe operator view for encrypted backup status, restore readiness,
+              portable master-key posture, and key rotation actions. Metadata
+              only: raw secret values and key material are never rendered.
+            </CardDescription>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Badge variant={backupStateVariant[status.backup.state]}>
+              {backupStateCopy[status.backup.state]}
+            </Badge>
+            <Badge variant={rotationStateVariant[status.key.state]}>
+              {rotationStateCopy[status.key.state]}
+            </Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <div className='rounded-lg border p-4 text-sm'>
+            <div className='mb-2 flex items-center gap-2 font-medium'>
+              <ClipboardCheck className='size-4' /> Backup status
+            </div>
+            <div className='grid gap-3 sm:grid-cols-2'>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Last backup
+                </div>
+                <div>{status.backup.lastBackupAt ?? 'not available'}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Artifact
+                </div>
+                <div>{status.backup.artifact}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Storage location
+                </div>
+                <div>{status.backup.location}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Restore readiness
+                </div>
+                <div>{status.backup.restoreReadiness}</div>
+                <div className='text-xs text-muted-foreground'>
+                  verified {status.backup.restoreLastVerifiedAt ?? 'never'}
+                </div>
+              </div>
+            </div>
+            {status.backup.warning ? (
+              <div className='mt-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-destructive'>
+                {status.backup.warning}
+              </div>
+            ) : null}
+          </div>
+
+          <div className='rounded-lg border p-4 text-sm'>
+            <div className='mb-2 flex items-center gap-2 font-medium'>
+              <KeyRound className='size-4' /> Portable master-key status
+            </div>
+            <div className='grid gap-3 sm:grid-cols-2'>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Key version
+                </div>
+                <div>{status.key.keyVersion}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Key id
+                </div>
+                <div>{status.key.keyId}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Rotation status
+                </div>
+                <div>{status.key.rotationStatus}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Recovery material
+                </div>
+                <div>{status.key.recoveryMaterial}</div>
+              </div>
+            </div>
+            {status.key.warning ? (
+              <div className='mt-3 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-destructive'>
+                {status.key.warning}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'>
+          {status.actions.map((action) => (
+            <BackupKeyActionButton key={action.id} action={action} />
+          ))}
+        </div>
+
+        <div className='rounded-lg border p-4 text-sm'>
+          <div className='mb-3 flex flex-wrap items-center justify-between gap-2'>
+            <div className='font-medium'>Recent backup/key audit metadata</div>
+            <Badge variant='secondary'>No values or key material</Badge>
+          </div>
+          <div className='grid gap-3 lg:grid-cols-3'>
+            {status.audit.map((event) => (
+              <div key={event.id} className='rounded-md bg-muted/40 p-3'>
+                <div className='font-medium'>{event.operation}</div>
+                <div className='text-xs text-muted-foreground'>
+                  {event.at} · {event.outcome}
+                </div>
+                <div className='mt-2'>{event.metadata}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
 
 function SourceIcon({ source }: { source: WizardSource }) {
   if (source.id === 'local-vault') return <LockKeyhole className='size-4' />
@@ -1165,6 +1375,8 @@ export function SecretsBrokerSetupWizard() {
             </CardContent>
           </Card>
         </div>
+
+        <BackupKeyManagementPanel />
 
         <Card id='secret-sources'>
           <CardHeader>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -6,6 +6,10 @@ import {
   filterSecretsBrokerAuditEvents,
   secretsBrokerAuditEvents,
 } from './audit-events'
+import {
+  backupKeyStatusHasSecretMaterial,
+  secretsBrokerBackupKeyStatus,
+} from './backup-key-management'
 import { secretsBrokerDiagnostics, scrubSecretLikeOutput } from './diagnostics'
 import {
   providerConnectionHasSecretValue,
@@ -120,6 +124,50 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Confirm operation, policy decision, and audit reason/i)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+  })
+
+  it('renders backup restore and key-management metadata without raw material', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(
+      screen.getByText(/Backup, restore, and key management/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Backup stale/i)).toBeVisible()
+    expect(screen.getByText(/Recovery risk/i)).toBeVisible()
+    expect(screen.getByText(/Last backup/i)).toBeVisible()
+    expect(screen.getAllByText(/Restore readiness/i)[0]).toBeVisible()
+    expect(screen.getByText(/key version v4/i)).toBeVisible()
+    expect(screen.getByText(/mkid_7f3a…9c21/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Create encrypted backup/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Verify restore readiness/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Restore from backup/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Rotate master key/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Confirm artifact path/i)).toBeVisible()
+    expect(screen.getByText(/never paste key material/i)).toBeVisible()
+    expect(screen.getByText(/Recent backup\/key audit metadata/i)).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/portable-master-key-value/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/generated-secret-value/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps backup and key-management fixtures free of secret material', () => {
+    expect(backupKeyStatusHasSecretMaterial(secretsBrokerBackupKeyStatus)).toBe(
+      false
+    )
   })
 
   it('renders secret sources and backends with warning states and metadata-only test results', async () => {


### PR DESCRIPTION
## Summary

- Added a Secrets Broker backup/restore/key-management panel to the `/secrets-broker` setup surface.
- Introduced safe metadata fixtures/API shape for backup status, restore readiness, key version, portable master-key recovery posture, key rotation state, and recent backup/key audit metadata.
- Added action affordances for encrypted backup creation, restore-readiness verification, restore, and master-key rotation with explicit confirmation copy for destructive operations.
- Added tests proving the panel renders actionable backup/key metadata without raw secret values or key material.

## Validation

- `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 21 passed
- `npm test` — 72 passed
- `npm run build` — passed
- `npm run lint` — passed with 7 existing warnings in unrelated files (`installed`, `logs`, `network`, `runtime`, `variables`)
- `npm run format:check` — passed
- `git diff --check` — passed

## Notes

- This remains metadata-only; no raw secrets, provider secrets, or portable master-key material are represented or rendered.
- Destructive restore/rotation controls are gated with confirmation copy in the UI surface.

Closes #63
