### PR TITLE
ISS-64 add provider lifecycle reconnect UI

### DIFF
--- a/src/features/secrets-broker/connection-detail.tsx
+++ b/src/features/secrets-broker/connection-detail.tsx
@@ -31,6 +31,7 @@ import {
   type SecretsBrokerProviderConnectionAction,
   type SecretsBrokerProviderConnectionDetail,
   type SecretsBrokerProviderConnectionState,
+  type SecretsBrokerProviderLifecycleStatus,
   type SecretsBrokerSecretMaterialState,
 } from './provider-connections'
 
@@ -64,6 +65,32 @@ const materialStateCopy: Record<SecretsBrokerSecretMaterialState, string> = {
   revoked: 'Revoked',
 }
 
+const lifecycleStatusCopy: Record<
+  SecretsBrokerProviderLifecycleStatus,
+  string
+> = {
+  connected: 'Connected',
+  expiring: 'Expiring',
+  'auth-required': 'Auth required',
+  'reconnect-required': 'Reconnect required',
+  revoked: 'Revoked',
+  'permission-changed': 'Permission changed',
+  degraded: 'Degraded',
+}
+
+const lifecycleStatusVariant: Record<
+  SecretsBrokerProviderLifecycleStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  connected: 'default',
+  expiring: 'secondary',
+  'auth-required': 'destructive',
+  'reconnect-required': 'secondary',
+  revoked: 'destructive',
+  'permission-changed': 'secondary',
+  degraded: 'secondary',
+}
+
 const actionVariant: Record<
   SecretsBrokerProviderConnectionAction['state'],
   'default' | 'secondary' | 'destructive' | 'outline'
@@ -71,6 +98,7 @@ const actionVariant: Record<
   available: 'secondary',
   disabled: 'outline',
   danger: 'destructive',
+  unsupported: 'outline',
 }
 
 function StateIcon({ state }: { state: SecretsBrokerProviderConnectionState }) {
@@ -141,10 +169,11 @@ function ActionButton({
       <Button
         type='button'
         variant={actionVariant[action.state]}
-        disabled={action.state === 'disabled'}
+        disabled={action.state === 'disabled' || action.state === 'unsupported'}
         className='w-full justify-start'
       >
         {action.label}
+        {action.state === 'unsupported' ? ' unavailable' : ''}
       </Button>
       {action.confirmationCopy ? (
         <p className='mt-2 text-xs text-muted-foreground'>
@@ -153,7 +182,8 @@ function ActionButton({
       ) : null}
       {action.disabledReason ? (
         <p className='mt-2 text-xs text-muted-foreground'>
-          Disabled: {action.disabledReason}
+          {action.state === 'unsupported' ? 'Unavailable' : 'Disabled'}:{' '}
+          {action.disabledReason}
         </p>
       ) : null}
     </div>
@@ -230,6 +260,58 @@ export function SecretsBrokerProviderConnectionDetailPage({
         </Card>
 
         <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <Clock3 className='size-4' /> Lifecycle status
+              </CardTitle>
+              <CardDescription>
+                Normalized provider lifecycle metadata for reconnect, refresh,
+                and retry decisions.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-3 text-sm'>
+              <Badge
+                variant={lifecycleStatusVariant[connection.lifecycle.status]}
+              >
+                {lifecycleStatusCopy[connection.lifecycle.status]}
+              </Badge>
+              <p>{connection.lifecycle.summary}</p>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Last check</div>
+                <div className='font-medium'>
+                  {connection.lifecycle.lastCheckedAt}
+                </div>
+              </div>
+              {connection.lifecycle.lastRefreshError ? (
+                <div className='rounded-lg border p-3'>
+                  <div className='text-muted-foreground'>
+                    Last refresh/check error
+                  </div>
+                  <div className='font-medium'>
+                    {connection.lifecycle.lastRefreshError}
+                  </div>
+                </div>
+              ) : null}
+              <div className='flex flex-wrap gap-2'>
+                {connection.lifecycle.auditEventRef ? (
+                  <Button asChild size='sm' variant='outline'>
+                    <a href='#recent-audit-events'>
+                      Audit {connection.lifecycle.auditEventRef}
+                    </a>
+                  </Button>
+                ) : null}
+                {connection.lifecycle.diagnosticRef ? (
+                  <Button asChild size='sm' variant='outline'>
+                    <a href='/secrets-broker#diagnostics'>
+                      Diagnostics {connection.lifecycle.diagnosticRef}
+                    </a>
+                  </Button>
+                ) : null}
+              </div>
+            </CardContent>
+          </Card>
+
           <Card>
             <CardHeader>
               <CardTitle className='flex items-center gap-2'>
@@ -425,7 +507,7 @@ export function SecretsBrokerProviderConnectionDetailPage({
           </Card>
         </div>
 
-        <Card>
+        <Card id='recent-audit-events'>
           <CardHeader>
             <CardTitle>Recent audit events</CardTitle>
             <CardDescription>

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -53,6 +53,7 @@ import {
   secretsBrokerProviderConnections,
   type SecretsBrokerProviderConnectionDetail,
   type SecretsBrokerProviderConnectionState,
+  type SecretsBrokerProviderLifecycleStatus,
 } from './provider-connections'
 import {
   countSourceBackendsByState,
@@ -463,6 +464,32 @@ const providerConnectionStatusVariant: Record<
   missing: 'destructive',
 }
 
+const providerLifecycleStatusCopy: Record<
+  SecretsBrokerProviderLifecycleStatus,
+  string
+> = {
+  connected: 'Connected',
+  expiring: 'Expiring',
+  'auth-required': 'Auth required',
+  'reconnect-required': 'Reconnect required',
+  revoked: 'Revoked',
+  'permission-changed': 'Permission changed',
+  degraded: 'Degraded',
+}
+
+const providerLifecycleStatusVariant: Record<
+  SecretsBrokerProviderLifecycleStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  connected: 'default',
+  expiring: 'secondary',
+  'auth-required': 'destructive',
+  'reconnect-required': 'secondary',
+  revoked: 'destructive',
+  'permission-changed': 'secondary',
+  degraded: 'secondary',
+}
+
 const providerConnectionStates = Array.from(
   new Set(
     secretsBrokerProviderConnections.map((connection) => connection.state)
@@ -514,6 +541,9 @@ function filterProviderConnections(
         connection.source,
         connection.connectionRef,
         connection.health.label,
+        connection.lifecycle.label,
+        connection.lifecycle.status,
+        connection.lifecycle.lastRefreshError ?? '',
       ]
         .join(' ')
         .toLowerCase()
@@ -1536,9 +1566,10 @@ export function SecretsBrokerSetupWizard() {
                       <th className='p-3 font-medium'>Connection label</th>
                       <th className='p-3 font-medium'>Auth method</th>
                       <th className='p-3 font-medium'>Status</th>
+                      <th className='p-3 font-medium'>Lifecycle</th>
                       <th className='p-3 font-medium'>Secret material</th>
                       <th className='p-3 font-medium'>Expiry / refresh</th>
-                      <th className='p-3 font-medium'>Last used/error</th>
+                      <th className='p-3 font-medium'>Last check/error</th>
                       <th className='p-3 font-medium'>Actions</th>
                     </tr>
                   </thead>
@@ -1579,6 +1610,24 @@ export function SecretsBrokerSetupWizard() {
                           ) : null}
                         </td>
                         <td className='p-3'>
+                          <Badge
+                            variant={
+                              providerLifecycleStatusVariant[
+                                connection.lifecycle.status
+                              ]
+                            }
+                          >
+                            {
+                              providerLifecycleStatusCopy[
+                                connection.lifecycle.status
+                              ]
+                            }
+                          </Badge>
+                          <div className='mt-2 text-xs text-muted-foreground'>
+                            {connection.lifecycle.summary}
+                          </div>
+                        </td>
+                        <td className='p-3'>
                           <div>{connection.secretMaterial.presence}</div>
                           <div className='text-xs text-muted-foreground'>
                             value hidden
@@ -1592,15 +1641,36 @@ export function SecretsBrokerSetupWizard() {
                           </div>
                         </td>
                         <td className='p-3'>
-                          <div>
-                            {connection.usage.lastSuccessfulResolve ??
-                              'no successful resolve yet'}
-                          </div>
-                          {connection.usage.lastFailure ? (
+                          <div>{connection.lifecycle.lastCheckedAt}</div>
+                          {connection.lifecycle.lastRefreshError ? (
                             <div className='text-xs text-destructive'>
-                              {connection.usage.lastFailure}
+                              {connection.lifecycle.lastRefreshError}
                             </div>
-                          ) : null}
+                          ) : (
+                            <div className='text-xs text-muted-foreground'>
+                              last resolve:{' '}
+                              {connection.usage.lastSuccessfulResolve ??
+                                'not recorded'}
+                            </div>
+                          )}
+                          <div className='mt-2 flex flex-wrap gap-1 text-xs'>
+                            {connection.lifecycle.auditEventRef ? (
+                              <a
+                                href='#audit-events'
+                                className='text-primary underline-offset-4 hover:underline'
+                              >
+                                Audit {connection.lifecycle.auditEventRef}
+                              </a>
+                            ) : null}
+                            {connection.lifecycle.diagnosticRef ? (
+                              <a
+                                href='#diagnostics'
+                                className='text-primary underline-offset-4 hover:underline'
+                              >
+                                Diagnostics {connection.lifecycle.diagnosticRef}
+                              </a>
+                            ) : null}
+                          </div>
                         </td>
                         <td className='p-3'>
                           <div className='flex flex-wrap gap-2'>
@@ -1618,9 +1688,20 @@ export function SecretsBrokerSetupWizard() {
                                   type='button'
                                   size='sm'
                                   variant='outline'
-                                  disabled={action.state === 'disabled'}
+                                  disabled={
+                                    action.state === 'disabled' ||
+                                    action.state === 'unsupported'
+                                  }
+                                  title={
+                                    action.state === 'unsupported'
+                                      ? action.disabledReason
+                                      : undefined
+                                  }
                                 >
                                   {action.label}
+                                  {action.state === 'unsupported'
+                                    ? ' unavailable'
+                                    : ''}
                                 </Button>
                               ))}
                             <Button asChild size='sm' variant='secondary'>
@@ -1635,6 +1716,21 @@ export function SecretsBrokerSetupWizard() {
                               View audit
                             </Button>
                           </div>
+                          {connection.actions
+                            .filter(
+                              (action) =>
+                                action.state === 'unsupported' &&
+                                action.disabledReason
+                            )
+                            .map((action) => (
+                              <div
+                                key={`${action.id}-unsupported-reason`}
+                                className='mt-2 text-xs text-muted-foreground'
+                              >
+                                {action.label} unavailable:{' '}
+                                {action.disabledReason}
+                              </div>
+                            ))}
                         </td>
                       </tr>
                     ))}

--- a/src/features/secrets-broker/provider-connections.ts
+++ b/src/features/secrets-broker/provider-connections.ts
@@ -5,6 +5,15 @@ export type SecretsBrokerProviderConnectionState =
   | 'disabled'
   | 'missing'
 
+export type SecretsBrokerProviderLifecycleStatus =
+  | 'connected'
+  | 'expiring'
+  | 'auth-required'
+  | 'reconnect-required'
+  | 'revoked'
+  | 'permission-changed'
+  | 'degraded'
+
 export type SecretsBrokerSecretMaterialState =
   | 'present'
   | 'missing'
@@ -21,7 +30,7 @@ export type SecretsBrokerProviderConnectionAction = {
     | 'disable-enable'
     | 'delete-connection'
   label: string
-  state: 'available' | 'disabled' | 'danger'
+  state: 'available' | 'disabled' | 'danger' | 'unsupported'
   confirmationCopy?: string
   disabledReason?: string
 }
@@ -33,6 +42,15 @@ export type SecretsBrokerProviderConnectionDetail = {
   source: string
   connectionRef: string
   state: SecretsBrokerProviderConnectionState
+  lifecycle: {
+    status: SecretsBrokerProviderLifecycleStatus
+    label: string
+    summary: string
+    lastCheckedAt: string
+    lastRefreshError?: string
+    auditEventRef?: string
+    diagnosticRef?: string
+  }
   health: {
     label: string
     checkedAt: string
@@ -77,6 +95,15 @@ export const secretsBrokerProviderConnections: SecretsBrokerProviderConnectionDe
       source: '@secretsbroker/local/default',
       connectionRef: 'secret://local/default',
       state: 'healthy',
+      lifecycle: {
+        status: 'connected',
+        label: 'Connected',
+        summary:
+          'Metadata checks and test resolve are current; no reconnect is required.',
+        lastCheckedAt: '2026-05-07T19:04:00Z',
+        auditEventRef: 'evt-connection-001',
+        diagnosticRef: 'diag-broker-api',
+      },
       health: {
         label: 'Ready for resolves',
         checkedAt: '2026-05-07T19:04:00Z',
@@ -174,6 +201,16 @@ export const secretsBrokerProviderConnections: SecretsBrokerProviderConnectionDe
       source: '@secretsbroker/external/ops',
       connectionRef: 'vault://kv/service-lasso',
       state: 'degraded',
+      lifecycle: {
+        status: 'auth-required',
+        label: 'Auth required',
+        summary:
+          'The provider still has metadata, but its operator auth session expired.',
+        lastCheckedAt: '2026-05-07T18:58:12Z',
+        lastRefreshError: 'source_auth_required',
+        auditEventRef: 'evt-connection-003',
+        diagnosticRef: 'diag-external-source-auth',
+      },
       health: {
         label: 'Authentication required',
         checkedAt: '2026-05-07T18:58:12Z',
@@ -267,6 +304,16 @@ export const secretsBrokerProviderConnections: SecretsBrokerProviderConnectionDe
       source: '@secretsbroker/external/aws',
       connectionRef: 'aws-secrets-manager://service-lasso/backup-worker',
       state: 'missing',
+      lifecycle: {
+        status: 'reconnect-required',
+        label: 'Reconnect required',
+        summary:
+          'The connection metadata exists, but a scoped credential handle must be added before tests can run.',
+        lastCheckedAt: '2026-05-07T18:45:00Z',
+        lastRefreshError: 'credential_handle_missing',
+        auditEventRef: 'evt-connection-005',
+        diagnosticRef: 'diag-provider-credentials',
+      },
       health: {
         label: 'Missing credentials',
         checkedAt: '2026-05-07T18:45:00Z',
@@ -335,6 +382,292 @@ export const secretsBrokerProviderConnections: SecretsBrokerProviderConnectionDe
           state: 'danger',
           confirmationCopy:
             'Delete the AWS backup worker connection metadata. No secret values will be shown or copied.',
+        },
+      ],
+    },
+    {
+      id: 'onepassword-ci',
+      title: '1Password CI item bridge',
+      provider: '1password',
+      source: '@secretsbroker/external/1password-ci',
+      connectionRef: 'op://service-lasso/ci/metadata',
+      state: 'failed',
+      lifecycle: {
+        status: 'revoked',
+        label: 'Revoked',
+        summary:
+          'The service account grant was revoked; retry is unavailable until a new grant is created.',
+        lastCheckedAt: '2026-05-07T18:34:00Z',
+        lastRefreshError: 'service_account_grant_revoked',
+        auditEventRef: 'evt-connection-006',
+        diagnosticRef: 'diag-provider-revoked-grant',
+      },
+      health: {
+        label: 'Grant revoked',
+        checkedAt: '2026-05-07T18:34:00Z',
+        nextAction:
+          'Create a replacement service account grant, then reconnect this bridge.',
+        failureReason: 'service_account_grant_revoked',
+      },
+      metadata: [
+        { label: 'Vault', value: 'service-lasso' },
+        { label: 'Auth mode', value: 'service account grant handle' },
+        { label: 'Values', value: 'hidden / revoked grant' },
+      ],
+      scopes: [
+        { label: 'ci read deploy refs', decision: 'denied' },
+        { label: 'rotate service account grant', decision: 'review' },
+      ],
+      secretMaterial: {
+        presence: 'revoked',
+        valueAvailable: false,
+        safeDescriptor:
+          'Grant metadata indicates revocation; no credential payload is available to render.',
+        updatedAt: '2026-05-07T18:00:00Z',
+      },
+      usage: {
+        lastSuccessfulResolve: '2026-05-07T17:55:00Z',
+        lastFailure: '2026-05-07T18:34:00Z — service_account_grant_revoked',
+        linkedServices: ['ci-runner'],
+        linkedWorkflows: ['release-serviceadmin'],
+        linkedRuns: ['run-20260507-183400'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-006',
+          type: 'grant revoked',
+          outcome: 'revoked',
+          at: '2026-05-07T18:34:00Z',
+          actor: 'operator:max',
+          reason: 'service_account_grant_revoked',
+        },
+      ],
+      actions: [
+        { id: 'reconnect', label: 'Reconnect', state: 'available' },
+        {
+          id: 'refresh-test-now',
+          label: 'Refresh/test now',
+          state: 'unsupported',
+          disabledReason: 'Revoked grants cannot be refreshed in place.',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'available',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'disabled',
+          disabledReason: 'Grant is already revoked.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Disable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete revoked 1Password bridge metadata. Secret values are not exported.',
+        },
+      ],
+    },
+    {
+      id: 'bitwarden-prod',
+      title: 'Bitwarden production collection',
+      provider: 'bitwarden',
+      source: '@secretsbroker/external/bitwarden-prod',
+      connectionRef: 'bws://service-lasso/prod',
+      state: 'degraded',
+      lifecycle: {
+        status: 'permission-changed',
+        label: 'Permission changed',
+        summary:
+          'Provider permissions changed after the last successful test; affected refs require policy review before retry.',
+        lastCheckedAt: '2026-05-07T18:22:00Z',
+        lastRefreshError: 'collection_permission_changed',
+        auditEventRef: 'evt-connection-007',
+        diagnosticRef: 'diag-provider-permission-drift',
+      },
+      health: {
+        label: 'Permission review required',
+        checkedAt: '2026-05-07T18:22:00Z',
+        nextAction:
+          'Review collection permissions and rerun a metadata-only connection test.',
+        failureReason: 'collection_permission_changed',
+      },
+      metadata: [
+        { label: 'Collection', value: 'service-lasso/prod' },
+        { label: 'Auth mode', value: 'machine credential handle' },
+        { label: 'Values', value: 'hidden / permission drift' },
+      ],
+      scopes: [
+        { label: 'prod services read runtime refs', decision: 'review' },
+        { label: 'list unrelated collections', decision: 'denied' },
+      ],
+      secretMaterial: {
+        presence: 'present',
+        valueAvailable: false,
+        safeDescriptor:
+          'Credential handle is present, but permission drift blocks trusted use.',
+        updatedAt: '2026-05-07T17:40:00Z',
+        refreshWindow: 'Retest after permission review.',
+      },
+      usage: {
+        lastSuccessfulResolve: '2026-05-07T17:58:00Z',
+        lastFailure: '2026-05-07T18:22:00Z — collection_permission_changed',
+        linkedServices: ['payments-api'],
+        linkedWorkflows: ['deploy-payments-api'],
+        linkedRuns: ['run-20260507-182200'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-007',
+          type: 'permission changed',
+          outcome: 'failure',
+          at: '2026-05-07T18:22:00Z',
+          actor: 'service:@secretsbroker',
+          reason: 'collection_permission_changed',
+        },
+      ],
+      actions: [
+        {
+          id: 'reconnect',
+          label: 'Reconnect',
+          state: 'unsupported',
+          disabledReason:
+            'Reconnect is unavailable until collection permissions are reviewed.',
+        },
+        {
+          id: 'refresh-test-now',
+          label: 'Refresh/test now',
+          state: 'available',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'disabled',
+          disabledReason: 'Permission review must complete before rotation.',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'danger',
+          confirmationCopy:
+            'Revoke Bitwarden production handle metadata without revealing values.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Disable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete Bitwarden production connection metadata only.',
+        },
+      ],
+    },
+    {
+      id: 'docker-mounted-secrets',
+      title: 'Docker mounted secrets source',
+      provider: 'docker-secrets',
+      source: '@secretsbroker/external/docker-mounted',
+      connectionRef: 'file:///run/secrets/service-lasso',
+      state: 'degraded',
+      lifecycle: {
+        status: 'degraded',
+        label: 'Degraded',
+        summary:
+          'Mounted metadata is reachable, but the last check reported stale file permissions.',
+        lastCheckedAt: '2026-05-07T18:10:00Z',
+        lastRefreshError: 'mounted_secret_permissions_stale',
+        auditEventRef: 'evt-connection-008',
+        diagnosticRef: 'diag-mounted-secret-permissions',
+      },
+      health: {
+        label: 'Stale mount permissions',
+        checkedAt: '2026-05-07T18:10:00Z',
+        nextAction:
+          'Restart the container mount and retry a metadata-only source check.',
+        failureReason: 'mounted_secret_permissions_stale',
+      },
+      metadata: [
+        { label: 'Mount', value: '/run/secrets/service-lasso' },
+        { label: 'Mode', value: 'read-only mounted metadata' },
+        { label: 'Values', value: 'hidden / not read by UI' },
+      ],
+      scopes: [
+        { label: 'container read mounted refs', decision: 'review' },
+        { label: 'write mounted values', decision: 'denied' },
+      ],
+      secretMaterial: {
+        presence: 'present',
+        valueAvailable: false,
+        safeDescriptor:
+          'Mounted secret files exist; the UI records metadata only and never reads file contents.',
+        updatedAt: '2026-05-07T17:50:00Z',
+      },
+      usage: {
+        lastSuccessfulResolve: '2026-05-07T17:49:00Z',
+        lastFailure: '2026-05-07T18:10:00Z — mounted_secret_permissions_stale',
+        linkedServices: ['echo-service'],
+        linkedWorkflows: ['service-start'],
+        linkedRuns: ['run-20260507-181000'],
+      },
+      recentAuditEvents: [
+        {
+          id: 'evt-connection-008',
+          type: 'metadata check degraded',
+          outcome: 'failure',
+          at: '2026-05-07T18:10:00Z',
+          actor: 'service:@secretsbroker',
+          reason: 'mounted_secret_permissions_stale',
+        },
+      ],
+      actions: [
+        {
+          id: 'reconnect',
+          label: 'Reconnect',
+          state: 'unsupported',
+          disabledReason:
+            'File mounts are refreshed by restarting the container mount.',
+        },
+        {
+          id: 'refresh-test-now',
+          label: 'Retry metadata check',
+          state: 'available',
+        },
+        {
+          id: 'replace-rotate-secret-material',
+          label: 'Replace/rotate secret material',
+          state: 'unsupported',
+          disabledReason:
+            'Mounted file providers rotate outside Service Admin.',
+        },
+        {
+          id: 'clear-revoke-secret-material',
+          label: 'Clear/revoke secret material',
+          state: 'unsupported',
+          disabledReason:
+            'Mounted file providers are revoked outside Service Admin.',
+        },
+        {
+          id: 'disable-enable',
+          label: 'Disable connection',
+          state: 'available',
+        },
+        {
+          id: 'delete-connection',
+          label: 'Delete connection',
+          state: 'danger',
+          confirmationCopy:
+            'Delete Docker mounted source metadata only; file contents are not shown.',
         },
       ],
     },

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -223,8 +223,19 @@ describe('Secrets Broker setup wizard', () => {
     ).toBeVisible()
     expect(screen.getAllByText(/Healthy/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Reconnect required/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Auth required/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Revoked/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Permission changed/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Degraded/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Failing/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Operator action required/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/source_auth_required/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/credential_handle_missing/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Audit evt-connection/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Diagnostics diag-/i)[0]).toBeVisible()
+    expect(
+      screen.getAllByText(/Reconnect unavailable: Reconnect is unavailable/i)[0]
+    ).toBeVisible()
     expect(screen.getAllByText(/value hidden/i)[0]).toBeVisible()
     expect(
       screen.getAllByRole('link', { name: /View details/i })[0]
@@ -275,6 +286,13 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getByText(/Safe metadata summary/i)).toBeVisible()
     expect(screen.getByText(/Status and health/i)).toBeVisible()
     expect(screen.getByText(/Secret material state/i)).toBeVisible()
+    expect(screen.getByText(/Lifecycle status/i)).toBeVisible()
+    expect(screen.getByText(/Connected/i)).toBeVisible()
+    expect(
+      screen.getByText(/Metadata checks and test resolve are current/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Audit evt-connection-001/i)).toBeVisible()
+    expect(screen.getByText(/Diagnostics diag-broker-api/i)).toBeVisible()
     expect(screen.getByText(/Presence: Present/i)).toBeVisible()
     expect(screen.getByText(/Raw value: hidden/i)).toBeVisible()
     expect(screen.getByText(/Copy value: unavailable/i)).toBeVisible()
@@ -324,6 +342,7 @@ describe('Secrets Broker setup wizard', () => {
     degraded.unmount()
     await renderRoute('/secrets-broker/aws-backup-worker')
     expect(screen.getByText(/Missing credentials/i)).toBeVisible()
+    expect(screen.getAllByText(/Reconnect required/i)[0]).toBeVisible()
     expect(screen.getAllByText(/credential_handle_missing/i)[0]).toBeVisible()
     expect(screen.getByText(/Add a scoped AWS profile/i)).toBeVisible()
     expect(


### PR DESCRIPTION
## Summary

Closes #64.

Adds focused Secrets Broker provider lifecycle UI polish:
- Adds normalized provider lifecycle states for connected, auth-required, reconnect-required, revoked, permission-changed, and degraded connection scenarios.
- Surfaces safe last check / refresh error metadata plus audit and diagnostic references without rendering raw credential/token/secret values.
- Adds reconnect/test/retry affordances where supported and renders unsupported actions as unavailable with visible explanations.
- Extends provider detail pages with lifecycle status cards and safe failure links.

## Validation

- `npm run format:check` — passed
- `npm test -- --run src/features/secrets-broker/secrets-broker-setup.test.tsx` — 21 passed
- `npm run build` — passed (`tsc -b && vite build`)
- `git diff --check` — passed

## Secret-safety evidence

- Provider fixtures continue to assert `providerConnectionHasSecretValue(...) === false`.
- Tests assert no copy-secret affordance and no known secret-like sample material is rendered.
- New lifecycle fixtures use only handles, refs, statuses, diagnostic ids, audit ids, and safe error codes.