### PR TITLE
ISS-65 add ZITADEL session role UI

### DIFF
--- a/docs/zitadel-session-surface.md
+++ b/docs/zitadel-session-surface.md
@@ -1,0 +1,42 @@
+# ZITADEL session and role surface
+
+Issue: `service-lasso/lasso-serviceadmin#65`
+
+Service Admin can render ZITADEL-backed session and role metadata when a consumer app/facade provides it. This surface is intentionally metadata-only.
+
+## Dependency on consumer app/facade integration
+
+The Service Admin UI does not authenticate directly with ZITADEL in this issue. A consumer app/facade is expected to provide safe session metadata such as:
+
+- workspace id
+- app id
+- auth provider status (`zitadel` or `not-configured`)
+- session mode
+- metadata update time
+- stable subject and organization refs
+- role names
+- permission decisions and denial reasons
+
+Provider credentials, auth cookies, bearer values, raw session material, client secrets, and recovery material must not be passed into or rendered by this UI.
+
+## Optional local development behavior
+
+ZITADEL remains optional. Service Admin local development flows stay open unless an app explicitly enables protected mode in its facade/configuration. If ZITADEL is not configured, the UI should render a setup-needed state instead of forcing login.
+
+## Supported states
+
+- Signed in: active facade session metadata is available.
+- Login required: ZITADEL is configured, but no active local session metadata is available.
+- Setup needed: the consumer app has not configured ZITADEL integration.
+- Permission denied: a session exists, but required role/permission grants are missing.
+
+## Secret-safety requirements
+
+Render only metadata/status/ref/role/permission text. Do not render:
+
+- provider access material
+- auth cookies
+- bearer values
+- raw session secrets
+- ZITADEL client secrets
+- recovery keys or private keys

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -4,6 +4,7 @@ import {
   GitBranch,
   Globe,
   KeyRound,
+  LockKeyhole,
   SlidersHorizontal,
   HardDrive,
   HelpCircle,
@@ -71,6 +72,11 @@ export const sidebarData: SidebarData = {
           title: 'Secrets Broker',
           url: '/secrets-broker',
           icon: KeyRound,
+        },
+        {
+          title: 'ZITADEL Session',
+          url: '/auth-session',
+          icon: LockKeyhole,
         },
         {
           title: 'Network',

--- a/src/features/auth-session/index.tsx
+++ b/src/features/auth-session/index.tsx
@@ -1,0 +1,351 @@
+import { useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  LockKeyhole,
+  ShieldCheck,
+  UserCheck,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  zitadelSessionScenarios,
+  type ZitadelPermissionDecision,
+  type ZitadelSessionState,
+} from './zitadel-session'
+
+const stateCopy: Record<ZitadelSessionState, string> = {
+  'signed-in': 'Signed in',
+  'signed-out': 'Login required',
+  'setup-needed': 'Setup needed',
+  'permission-denied': 'Permission denied',
+}
+
+const stateVariant: Record<
+  ZitadelSessionState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  'signed-in': 'default',
+  'signed-out': 'secondary',
+  'setup-needed': 'outline',
+  'permission-denied': 'destructive',
+}
+
+const permissionVariant: Record<
+  ZitadelPermissionDecision,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  allowed: 'default',
+  denied: 'destructive',
+  review: 'secondary',
+}
+
+function StateIcon({ state }: { state: ZitadelSessionState }) {
+  if (state === 'signed-in') return <UserCheck className='size-4' />
+  if (state === 'permission-denied') return <LockKeyhole className='size-4' />
+  return <AlertTriangle className='size-4' />
+}
+
+export function AuthSessionPage() {
+  const [selectedScenarioId, setSelectedScenarioId] = useState(
+    zitadelSessionScenarios[0].id
+  )
+  const selectedScenario = useMemo(
+    () =>
+      zitadelSessionScenarios.find(
+        (scenario) => scenario.id === selectedScenarioId
+      ) ?? zitadelSessionScenarios[0],
+    [selectedScenarioId]
+  )
+
+  const deniedPermissionCount = selectedScenario.permissions.filter(
+    (permission) => permission.decision === 'denied'
+  ).length
+
+  usePageMetadata({
+    title: 'Service Admin - ZITADEL Session',
+    description:
+      'Metadata-only ZITADEL login, session, role, and permission integration surface.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <ShieldCheck className='size-5' /> ZITADEL session and roles
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Service Admin auth integration preview for consumer apps that opt
+              into ZITADEL-backed sessions. This page renders facade metadata,
+              roles, and permission decisions only; provider credentials and
+              session secrets are never displayed.
+            </p>
+          </div>
+          <Badge variant='secondary'>Metadata only</Badge>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Session state preview</CardTitle>
+            <CardDescription>
+              Choose the facade-reported state to inspect signed-in,
+              login-required, setup-needed, and permission-denied behaviour.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div>
+              <label
+                htmlFor='zitadel-session-scenario'
+                className='mb-1 block text-xs text-muted-foreground'
+              >
+                Auth scenario
+              </label>
+              <select
+                id='zitadel-session-scenario'
+                className='h-9 w-full rounded-md border bg-background px-3 text-sm md:w-[24rem]'
+                value={selectedScenarioId}
+                onChange={(event) => setSelectedScenarioId(event.target.value)}
+              >
+                {zitadelSessionScenarios.map((scenario) => (
+                  <option key={scenario.id} value={scenario.id}>
+                    {scenario.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className='grid gap-3 md:grid-cols-4'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>State</div>
+                <Badge variant={stateVariant[selectedScenario.state]}>
+                  <StateIcon state={selectedScenario.state} />
+                  {stateCopy[selectedScenario.state]}
+                </Badge>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Provider</div>
+                <div className='font-medium'>
+                  {selectedScenario.facade.authProvider}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Roles</div>
+                <div className='font-medium'>
+                  {selectedScenario.roles.length}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Denied</div>
+                <div className='font-medium'>{deniedPermissionCount}</div>
+              </div>
+            </div>
+
+            <div className='rounded-lg border p-4'>
+              <div className='font-medium'>{selectedScenario.label}</div>
+              <p className='mt-1 text-sm text-muted-foreground'>
+                {selectedScenario.summary}
+              </p>
+              <div className='mt-3 rounded-md border p-3 text-sm'>
+                <div className='text-muted-foreground'>Required action</div>
+                <div className='font-medium'>
+                  {selectedScenario.requiredAction}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Facade session metadata</CardTitle>
+              <CardDescription>
+                Consumer app/facade integration fields. These are identifiers
+                and status metadata, not credential material.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-3 text-sm md:grid-cols-2'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Workspace</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.facade.workspaceId}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>App</div>
+                <div className='font-medium'>
+                  {selectedScenario.facade.appId}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Session mode</div>
+                <div className='font-medium'>
+                  {selectedScenario.facade.sessionMode}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Metadata updated</div>
+                <div className='font-medium'>
+                  {selectedScenario.facade.metadataUpdatedAt}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>User and role summary</CardTitle>
+              <CardDescription>
+                Stable user refs and role names only. No auth cookies, bearer
+                values, or session secrets are rendered.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4 text-sm'>
+              {selectedScenario.user ? (
+                <div className='grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Display name</div>
+                    <div className='font-medium'>
+                      {selectedScenario.user.displayName}
+                    </div>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Email</div>
+                    <div className='font-medium'>
+                      {selectedScenario.user.email}
+                    </div>
+                  </div>
+                  <div className='rounded-lg border p-3 md:col-span-2'>
+                    <div className='text-muted-foreground'>Subject ref</div>
+                    <div className='font-medium break-all'>
+                      {selectedScenario.user.subjectRef}
+                    </div>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>
+                      Organization ref
+                    </div>
+                    <div className='font-medium break-all'>
+                      {selectedScenario.user.organizationRef}
+                    </div>
+                  </div>
+                  <div className='rounded-lg border p-3'>
+                    <div className='text-muted-foreground'>Workspace role</div>
+                    <div className='font-medium'>
+                      {selectedScenario.user.workspaceRole}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className='rounded-lg border border-dashed p-4 text-muted-foreground'>
+                  No signed-in user metadata is available for this scenario.
+                </div>
+              )}
+
+              <div>
+                <div className='mb-2 text-xs font-medium text-muted-foreground uppercase'>
+                  Roles
+                </div>
+                <div className='flex flex-wrap gap-2'>
+                  {selectedScenario.roles.length === 0 ? (
+                    <Badge variant='outline'>none until login</Badge>
+                  ) : (
+                    selectedScenario.roles.map((role) => (
+                      <Badge key={role} variant='outline'>
+                        {role}
+                      </Badge>
+                    ))
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Permission decisions</CardTitle>
+            <CardDescription>
+              Protected Service Admin surfaces can explain grants, denials, and
+              review states without exposing provider/session material.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='overflow-x-auto rounded-lg border p-0'>
+            <table className='w-full text-sm'>
+              <thead className='bg-muted/50 text-left'>
+                <tr>
+                  <th className='p-3 font-medium'>Scope</th>
+                  <th className='p-3 font-medium'>Decision</th>
+                  <th className='p-3 font-medium'>Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {selectedScenario.permissions.map((permission) => (
+                  <tr key={permission.scope} className='border-t align-top'>
+                    <td className='p-3 font-mono text-xs'>
+                      {permission.scope}
+                    </td>
+                    <td className='p-3'>
+                      <Badge variant={permissionVariant[permission.decision]}>
+                        {permission.decision}
+                      </Badge>
+                    </td>
+                    <td className='p-3 text-muted-foreground'>
+                      {permission.reason}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Optional ZITADEL integration guardrails</CardTitle>
+            <CardDescription>
+              This UI depends on consumer app/facade integration. It should not
+              force authentication onto core local development by default.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-3'>
+            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+              {selectedScenario.guardrails.map((guardrail) => (
+                <li key={guardrail}>{guardrail}</li>
+              ))}
+            </ul>
+            <Button asChild variant='secondary'>
+              <a href='/docs/zitadel-session-surface.md'>
+                Read integration note
+              </a>
+            </Button>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/auth-session/zitadel-session.test.tsx
+++ b/src/features/auth-session/zitadel-session.test.tsx
@@ -1,0 +1,94 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  zitadelSessionHasSecretMaterial,
+  zitadelSessionScenarios,
+} from './zitadel-session'
+
+describe('ZITADEL session and role surface', () => {
+  it('renders signed-in session metadata and role summaries without secret material', async () => {
+    await renderRoute('/auth-session')
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /ZITADEL session and roles/i,
+      })
+    ).toBeVisible()
+    expect(screen.getAllByText(/Signed-in admin/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Signed in/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/workspace:service-lasso\/local-dev/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/zitadel-subject:\/\/service-lasso\/users\/max/i)
+    ).toBeVisible()
+    expect(screen.getByText(/serviceadmin.operator/i)).toBeVisible()
+    expect(
+      screen.getByText(/serviceadmin:secrets:values:reveal/i)
+    ).toBeVisible()
+    expect(screen.getByText(/raw secret reveal is not enabled/i)).toBeVisible()
+    expect(screen.getByText(/Metadata only/i)).toBeVisible()
+    expect(
+      screen.queryByText(/access_token|refresh_token|id_token|session_secret/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/bearer\s+[a-z0-9_-]+\.[a-z0-9._-]+/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('covers signed-out setup-needed and permission-denied states', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/auth-session')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Auth scenario/i),
+      'signed-out'
+    )
+    expect(screen.getAllByText(/Login required/i)[0]).toBeVisible()
+    expect(screen.getByText(/Start the ZITADEL login flow/i)).toBeVisible()
+    expect(screen.getByText(/No signed-in user metadata/i)).toBeVisible()
+    expect(screen.getByText(/none until login/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Auth scenario/i),
+      'setup-needed'
+    )
+    expect(screen.getAllByText(/Setup needed/i)[0]).toBeVisible()
+    expect(screen.getByText(/not-configured/i)).toBeVisible()
+    expect(screen.getByText(/local-dev-open/i)).toBeVisible()
+    expect(screen.getByText(/Do not force ZITADEL/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Auth scenario/i),
+      'permission-denied'
+    )
+    expect(screen.getAllByText(/Permission denied/i)[0]).toBeVisible()
+    expect(screen.getByText(/Readonly Operator/i)).toBeVisible()
+    expect(screen.getByText(/workspace-viewer/i)).toBeVisible()
+    expect(screen.getByText(/operator role is required/i)).toBeVisible()
+    expect(screen.getByText(/least-privilege role/i)).toBeVisible()
+  })
+
+  it('renders permission decisions as metadata only', async () => {
+    await renderRoute('/auth-session')
+
+    const permissionTable = screen.getByRole('table')
+    expect(
+      within(permissionTable).getByText(/serviceadmin:services:read/i)
+    ).toBeVisible()
+    expect(within(permissionTable).getAllByText(/allowed/i)[0]).toBeVisible()
+    expect(within(permissionTable).getAllByText(/denied/i)[0]).toBeVisible()
+  })
+
+  it('keeps ZITADEL session fixtures free of secret material', () => {
+    expect(zitadelSessionHasSecretMaterial()).toBe(false)
+    expect(zitadelSessionScenarios).toHaveLength(4)
+    expect(
+      zitadelSessionScenarios.some(
+        (scenario) => scenario.state === 'permission-denied'
+      )
+    ).toBe(true)
+  })
+})

--- a/src/features/auth-session/zitadel-session.ts
+++ b/src/features/auth-session/zitadel-session.ts
@@ -1,0 +1,211 @@
+export type ZitadelSessionState =
+  | 'signed-in'
+  | 'signed-out'
+  | 'setup-needed'
+  | 'permission-denied'
+
+export type ZitadelPermissionDecision = 'allowed' | 'denied' | 'review'
+
+export type ZitadelSessionScenario = {
+  id: string
+  label: string
+  state: ZitadelSessionState
+  summary: string
+  facade: {
+    workspaceId: string
+    appId: string
+    authProvider: 'zitadel' | 'not-configured'
+    sessionMode: string
+    metadataUpdatedAt: string
+  }
+  user?: {
+    displayName: string
+    email: string
+    subjectRef: string
+    organizationRef: string
+    workspaceRole: string
+  }
+  roles: string[]
+  permissions: Array<{
+    scope: string
+    decision: ZitadelPermissionDecision
+    reason: string
+  }>
+  requiredAction: string
+  guardrails: string[]
+}
+
+export const zitadelSessionScenarios: ZitadelSessionScenario[] = [
+  {
+    id: 'signed-in-admin',
+    label: 'Signed-in admin',
+    state: 'signed-in',
+    summary:
+      'Facade metadata reports an active ZITADEL-backed local session for this workspace.',
+    facade: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      sessionMode: 'optional-auth-enabled',
+      metadataUpdatedAt: '2026-05-08T12:48:00Z',
+    },
+    user: {
+      displayName: 'Max Barrass',
+      email: 'max@service-lasso.local',
+      subjectRef: 'zitadel-subject://service-lasso/users/max',
+      organizationRef: 'zitadel-org://service-lasso',
+      workspaceRole: 'workspace-admin',
+    },
+    roles: [
+      'serviceadmin.viewer',
+      'serviceadmin.operator',
+      'secrets.metadata.read',
+    ],
+    permissions: [
+      {
+        scope: 'serviceadmin:services:read',
+        decision: 'allowed',
+        reason: 'workspace role grants service inventory visibility',
+      },
+      {
+        scope: 'serviceadmin:secrets:metadata:read',
+        decision: 'allowed',
+        reason: 'metadata-only Secrets Broker access granted',
+      },
+      {
+        scope: 'serviceadmin:secrets:values:reveal',
+        decision: 'denied',
+        reason: 'raw secret reveal is not enabled for this surface',
+      },
+    ],
+    requiredAction:
+      'No login action required. Continue using metadata-only protected surfaces.',
+    guardrails: [
+      'Session display is derived from facade metadata, not browser credential storage.',
+      'Subject and organization refs are stable identifiers, not bearer credentials.',
+      'Denied sensitive permissions stay visible so operators know why an action is blocked.',
+    ],
+  },
+  {
+    id: 'signed-out',
+    label: 'Signed out / login required',
+    state: 'signed-out',
+    summary:
+      'ZITADEL is configured for this app, but no active local session metadata is available.',
+    facade: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      sessionMode: 'login-required-for-protected-surfaces',
+      metadataUpdatedAt: '2026-05-08T12:49:00Z',
+    },
+    roles: [],
+    permissions: [
+      {
+        scope: 'serviceadmin:dashboard:read',
+        decision: 'review',
+        reason: 'available after login handshake completes',
+      },
+      {
+        scope: 'serviceadmin:services:write',
+        decision: 'denied',
+        reason: 'no active session metadata',
+      },
+    ],
+    requiredAction:
+      'Start the ZITADEL login flow from the consumer app, then refresh session metadata.',
+    guardrails: [
+      'Local development may continue without auth unless the app explicitly enables protected mode.',
+      'Login prompts should redirect through the consumer app facade, not store provider credentials in Service Admin.',
+    ],
+  },
+  {
+    id: 'setup-needed',
+    label: 'Setup needed',
+    state: 'setup-needed',
+    summary:
+      'The consumer app has not enabled ZITADEL integration, so protected auth surfaces stay optional.',
+    facade: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'not-configured',
+      sessionMode: 'local-dev-open',
+      metadataUpdatedAt: '2026-05-08T12:50:00Z',
+    },
+    roles: ['local-dev-fallback'],
+    permissions: [
+      {
+        scope: 'serviceadmin:local-dev:read',
+        decision: 'allowed',
+        reason: 'auth integration is optional for local preview',
+      },
+      {
+        scope: 'serviceadmin:protected:write',
+        decision: 'review',
+        reason: 'requires consumer app/facade ZITADEL configuration',
+      },
+    ],
+    requiredAction:
+      'Configure the consumer app facade with ZITADEL issuer, client, and workspace mapping before enforcing auth.',
+    guardrails: [
+      'Do not force ZITADEL on existing local development flows without explicit app config.',
+      'Setup guidance references configuration metadata only and never asks operators to paste secrets into the UI.',
+    ],
+  },
+  {
+    id: 'permission-denied',
+    label: 'Permission denied',
+    state: 'permission-denied',
+    summary:
+      'The user is signed in, but the facade reports insufficient role grants for this protected surface.',
+    facade: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      sessionMode: 'protected-surface-denied',
+      metadataUpdatedAt: '2026-05-08T12:51:00Z',
+    },
+    user: {
+      displayName: 'Readonly Operator',
+      email: 'readonly@service-lasso.local',
+      subjectRef: 'zitadel-subject://service-lasso/users/readonly-operator',
+      organizationRef: 'zitadel-org://service-lasso',
+      workspaceRole: 'workspace-viewer',
+    },
+    roles: ['serviceadmin.viewer'],
+    permissions: [
+      {
+        scope: 'serviceadmin:services:read',
+        decision: 'allowed',
+        reason: 'viewer role grants read-only inventory access',
+      },
+      {
+        scope: 'serviceadmin:services:restart',
+        decision: 'denied',
+        reason: 'operator role is required for lifecycle actions',
+      },
+      {
+        scope: 'serviceadmin:secrets:metadata:read',
+        decision: 'denied',
+        reason: 'Secrets Broker metadata role is not assigned',
+      },
+    ],
+    requiredAction:
+      'Ask a workspace admin to grant the least-privilege role required for this surface.',
+    guardrails: [
+      'Denied permissions are shown as policy metadata only.',
+      'Escalation guidance avoids displaying auth cookies, bearer material, or session secrets.',
+    ],
+  },
+]
+
+export function getZitadelSessionScenario(id: string) {
+  return zitadelSessionScenarios.find((scenario) => scenario.id === id)
+}
+
+export function zitadelSessionHasSecretMaterial() {
+  const joined = JSON.stringify(zitadelSessionScenarios)
+  return /bearer\s+[a-z0-9_-]+\.[a-z0-9._-]+|id_token|access_token|refresh_token|session_secret|client_secret|password\s*=|token\s*=|secret\s*=/i.test(
+    joined
+  )
+}

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -124,7 +124,7 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Confirm operation, policy decision, and audit reason/i)
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
-  })
+  }, 10000)
 
   it('renders backup restore and key-management metadata without raw material', async () => {
     await renderRoute('/secrets-broker')

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as AuthenticatedInstalledIndexRouteImport } from './routes/_authe
 import { Route as AuthenticatedHelpCenterIndexRouteImport } from './routes/_authenticated/help-center/index'
 import { Route as AuthenticatedDependenciesIndexRouteImport } from './routes/_authenticated/dependencies/index'
 import { Route as AuthenticatedChatsIndexRouteImport } from './routes/_authenticated/chats/index'
+import { Route as AuthenticatedAuthSessionIndexRouteImport } from './routes/_authenticated/auth-session/index'
 import { Route as AuthenticatedAppsIndexRouteImport } from './routes/_authenticated/apps/index'
 import { Route as ClerkAuthenticatedUserManagementRouteImport } from './routes/clerk/_authenticated/user-management'
 import { Route as ClerkauthSignUpRouteImport } from './routes/clerk/(auth)/sign-up'
@@ -202,6 +203,12 @@ const AuthenticatedChatsIndexRoute = AuthenticatedChatsIndexRouteImport.update({
   path: '/chats/',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedAuthSessionIndexRoute =
+  AuthenticatedAuthSessionIndexRouteImport.update({
+    id: '/auth-session/',
+    path: '/auth-session/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedAppsIndexRoute = AuthenticatedAppsIndexRouteImport.update({
   id: '/apps/',
   path: '/apps/',
@@ -291,6 +298,7 @@ export interface FileRoutesByFullPath {
   '/clerk/sign-up': typeof ClerkauthSignUpRoute
   '/clerk/user-management': typeof ClerkAuthenticatedUserManagementRoute
   '/apps/': typeof AuthenticatedAppsIndexRoute
+  '/auth-session/': typeof AuthenticatedAuthSessionIndexRoute
   '/chats/': typeof AuthenticatedChatsIndexRoute
   '/dependencies/': typeof AuthenticatedDependenciesIndexRoute
   '/help-center/': typeof AuthenticatedHelpCenterIndexRoute
@@ -329,6 +337,7 @@ export interface FileRoutesByTo {
   '/clerk/sign-up': typeof ClerkauthSignUpRoute
   '/clerk/user-management': typeof ClerkAuthenticatedUserManagementRoute
   '/apps': typeof AuthenticatedAppsIndexRoute
+  '/auth-session': typeof AuthenticatedAuthSessionIndexRoute
   '/chats': typeof AuthenticatedChatsIndexRoute
   '/dependencies': typeof AuthenticatedDependenciesIndexRoute
   '/help-center': typeof AuthenticatedHelpCenterIndexRoute
@@ -372,6 +381,7 @@ export interface FileRoutesById {
   '/clerk/(auth)/sign-up': typeof ClerkauthSignUpRoute
   '/clerk/_authenticated/user-management': typeof ClerkAuthenticatedUserManagementRoute
   '/_authenticated/apps/': typeof AuthenticatedAppsIndexRoute
+  '/_authenticated/auth-session/': typeof AuthenticatedAuthSessionIndexRoute
   '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
   '/_authenticated/dependencies/': typeof AuthenticatedDependenciesIndexRoute
   '/_authenticated/help-center/': typeof AuthenticatedHelpCenterIndexRoute
@@ -413,6 +423,7 @@ export interface FileRouteTypes {
     | '/clerk/sign-up'
     | '/clerk/user-management'
     | '/apps/'
+    | '/auth-session/'
     | '/chats/'
     | '/dependencies/'
     | '/help-center/'
@@ -451,6 +462,7 @@ export interface FileRouteTypes {
     | '/clerk/sign-up'
     | '/clerk/user-management'
     | '/apps'
+    | '/auth-session'
     | '/chats'
     | '/dependencies'
     | '/help-center'
@@ -493,6 +505,7 @@ export interface FileRouteTypes {
     | '/clerk/(auth)/sign-up'
     | '/clerk/_authenticated/user-management'
     | '/_authenticated/apps/'
+    | '/_authenticated/auth-session/'
     | '/_authenticated/chats/'
     | '/_authenticated/dependencies/'
     | '/_authenticated/help-center/'
@@ -728,6 +741,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedChatsIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/auth-session/': {
+      id: '/_authenticated/auth-session/'
+      path: '/auth-session'
+      fullPath: '/auth-session/'
+      preLoaderRoute: typeof AuthenticatedAuthSessionIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/apps/': {
       id: '/_authenticated/apps/'
       path: '/apps'
@@ -838,6 +858,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSecretsBrokerConnectionIdRoute: typeof AuthenticatedSecretsBrokerConnectionIdRoute
   AuthenticatedServicesServiceIdRoute: typeof AuthenticatedServicesServiceIdRoute
   AuthenticatedAppsIndexRoute: typeof AuthenticatedAppsIndexRoute
+  AuthenticatedAuthSessionIndexRoute: typeof AuthenticatedAuthSessionIndexRoute
   AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
   AuthenticatedDependenciesIndexRoute: typeof AuthenticatedDependenciesIndexRoute
   AuthenticatedHelpCenterIndexRoute: typeof AuthenticatedHelpCenterIndexRoute
@@ -860,6 +881,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
     AuthenticatedSecretsBrokerConnectionIdRoute,
   AuthenticatedServicesServiceIdRoute: AuthenticatedServicesServiceIdRoute,
   AuthenticatedAppsIndexRoute: AuthenticatedAppsIndexRoute,
+  AuthenticatedAuthSessionIndexRoute: AuthenticatedAuthSessionIndexRoute,
   AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,
   AuthenticatedDependenciesIndexRoute: AuthenticatedDependenciesIndexRoute,
   AuthenticatedHelpCenterIndexRoute: AuthenticatedHelpCenterIndexRoute,

--- a/src/routes/_authenticated/auth-session/index.tsx
+++ b/src/routes/_authenticated/auth-session/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { AuthSessionPage } from '@/features/auth-session'
+
+export const Route = createFileRoute('/_authenticated/auth-session/')({
+  component: AuthSessionPage,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -54,6 +54,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Setup',
   },
   {
+    path: '/auth-session',
+    heading: /^ZITADEL session and roles$/i,
+    title: 'Service Admin - ZITADEL Session',
+  },
+  {
     path: '/network',
     heading: /^Network$/i,
     title: 'Service Admin - Network',


### PR DESCRIPTION
## Summary

Closes #65.

Adds a focused Service Admin ZITADEL login/session/role integration surface:
- Adds `/auth-session` with signed-in, login-required, setup-needed, and permission-denied state previews.
- Renders facade session metadata, stable user refs, role summaries, and permission decisions only.
- Adds sidebar navigation and route registration for the new surface.
- Documents that this UI depends on consumer app/facade integration and keeps ZITADEL optional for local development unless explicitly configured.
- Adds tests covering representative auth states and no-secret rendering.

## Validation

- `npm run format:check` — passed
- `npm test -- --run src/features/auth-session/zitadel-session.test.tsx src/test/app-screens.test.tsx` — 24 passed
- `npm run build` — passed (`tsc -b && vite build`)
- `git diff --check` — passed
- `npm run lint` — passed with existing warnings only (TanStack Table/react-hooks warnings in pre-existing installed/logs/network/runtime/variables files)

## Secret-safety evidence

- Production fixture/rendering uses metadata/status/ref/role/permission text only.
- `zitadelSessionHasSecretMaterial()` asserts no bearer-style values, token fields, session secret fields, client secret fields, password assignments, or secret assignments are present in fixtures.
- UI tests assert token/session-secret canaries are not rendered.
- Docs explicitly forbid passing provider credentials, auth cookies, bearer values, raw session material, client secrets, and recovery/private key material into this UI.