### PR TITLE
ISS-66 add secret-safe support bundle export

### DIFF
--- a/docs/support-bundle-export.md
+++ b/docs/support-bundle-export.md
@@ -1,0 +1,47 @@
+# Secret-safe support bundle export
+
+Issue: service-lasso/lasso-serviceadmin#66
+
+The Service Admin support bundle surface provides a local diagnostics preview and export payload for support triage. It is intentionally secret-safe by default.
+
+## Included diagnostics
+
+The bundle preview and payload include:
+
+- service inventory: service id, version/source ref, and lifecycle state
+- runtime and health summaries: check ids, health status, and diagnostic refs
+- Secrets Broker source statuses: provider refs, lifecycle state, and safe error codes
+- selected recent error/log excerpts after line-level redaction
+- a redaction report with counts and source refs only
+- a machine-readable manifest containing generated timestamp, section list, and redaction policy
+
+## Excluded or redacted material
+
+The bundle must not include raw values for:
+
+- secret values
+- provider tokens
+- API keys
+- auth cookies
+- private keys
+- recovery material
+- passwords
+- unredacted environment values
+- raw ZITADEL/OIDC bearer, access, refresh, or id tokens
+- raw session/client secret material
+
+The UI uses policy text and redacted placeholders such as `[REDACTED_SECRET]` and `[REDACTED_AUTHORIZATION]`; placeholders are not credential material.
+
+## Operator workflow
+
+1. Open **Support Bundle** in Service Admin.
+2. Review the warning and included section preview.
+3. Inspect the manifest and redaction policy.
+4. Prepare the export payload for local review.
+5. Share only after operator review in the support workflow.
+
+No upload is performed by this UI.
+
+## Local development
+
+This is a local diagnostics surface. It does not require a remote support backend, ZITADEL protected mode, or Secrets Broker provider credentials to render in local development.

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -4,6 +4,7 @@ import {
   GitBranch,
   Globe,
   KeyRound,
+  LifeBuoy,
   LockKeyhole,
   SlidersHorizontal,
   HardDrive,
@@ -77,6 +78,11 @@ export const sidebarData: SidebarData = {
           title: 'ZITADEL Session',
           url: '/auth-session',
           icon: LockKeyhole,
+        },
+        {
+          title: 'Support Bundle',
+          url: '/support-bundle',
+          icon: LifeBuoy,
         },
         {
           title: 'Network',

--- a/src/features/support-bundle/index.tsx
+++ b/src/features/support-bundle/index.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from 'react'
+import { Download, FileText, ShieldAlert } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  buildSupportBundlePayload,
+  type SupportBundleSection,
+} from './support-bundle'
+
+const severityVariant: Record<
+  SupportBundleSection['severity'],
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  info: 'secondary',
+  warning: 'outline',
+  error: 'destructive',
+}
+
+export function SupportBundlePage() {
+  const [preparedBundle, setPreparedBundle] = useState('')
+  const bundle = useMemo(() => buildSupportBundlePayload(), [])
+  const manifestPreview = useMemo(
+    () => JSON.stringify(bundle.manifest, null, 2),
+    [bundle]
+  )
+  const bundlePreview = useMemo(() => JSON.stringify(bundle, null, 2), [bundle])
+  const redactionCount = bundle.diagnostics.redactionReport.reduce(
+    (total, item) => total + Number(item.redactions),
+    0
+  )
+
+  usePageMetadata({
+    title: 'Service Admin - Support Bundle',
+    description:
+      'Secret-safe Service Lasso diagnostics support bundle preview and export.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <FileText className='size-5' /> Support bundle export
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Preview and prepare a local diagnostics bundle for support triage.
+              The bundle is secret-safe by default: raw secrets, tokens, API
+              keys, cookies, private keys, recovery material, passwords, and
+              environment values are excluded or redacted before export.
+            </p>
+          </div>
+          <Badge variant='secondary'>Secret-safe diagnostics</Badge>
+        </div>
+
+        <Alert>
+          <ShieldAlert className='size-4' />
+          <AlertTitle>Review before sharing</AlertTitle>
+          <AlertDescription>
+            This preview shows every included section and the manifest redaction
+            policy before export. Operators should still review the generated
+            bundle in their support workflow before sending it externally.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-4'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Sections</CardDescription>
+              <CardTitle className='text-3xl'>
+                {bundle.manifest.sections.length}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Redactions</CardDescription>
+              <CardTitle className='text-3xl'>{redactionCount}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Policy</CardDescription>
+              <CardTitle className='text-base'>
+                {bundle.manifest.redactionPolicy.mode}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Instance</CardDescription>
+              <CardTitle className='text-base'>
+                {bundle.manifest.instanceRef}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Included sections preview</CardTitle>
+            <CardDescription>
+              The export contains only metadata, refs, safe status codes,
+              summaries, and redacted log excerpts.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 md:grid-cols-2'>
+            {bundle.manifest.sections.map((section) => (
+              <div key={section.id} className='rounded-lg border p-4'>
+                <div className='flex items-start justify-between gap-3'>
+                  <div>
+                    <div className='font-medium'>{section.title}</div>
+                    <p className='mt-1 text-sm text-muted-foreground'>
+                      {section.summary}
+                    </p>
+                  </div>
+                  <Badge variant={severityVariant[section.severity]}>
+                    {section.severity}
+                  </Badge>
+                </div>
+                <div className='mt-3 text-xs text-muted-foreground'>
+                  {section.itemCount} item{section.itemCount === 1 ? '' : 's'}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Redaction policy</CardTitle>
+              <CardDescription>
+                Rules applied before diagnostics are displayed or exported.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              <div>
+                <div className='mb-2 text-sm font-medium'>Rules</div>
+                <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+                  {bundle.manifest.redactionPolicy.rules.map((rule) => (
+                    <li key={rule}>{rule}</li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <div className='mb-2 text-sm font-medium'>
+                  Excluded material
+                </div>
+                <div className='flex flex-wrap gap-2'>
+                  {bundle.manifest.redactionPolicy.excludedMaterial.map(
+                    (item) => (
+                      <Badge key={item} variant='outline'>
+                        {item}
+                      </Badge>
+                    )
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Redacted error preview</CardTitle>
+              <CardDescription>
+                Recent log excerpts after line-level redaction.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className='space-y-2'>
+                {bundle.diagnostics.recentErrors.map((line) => (
+                  <code
+                    key={line}
+                    className='block rounded-md border bg-muted px-3 py-2 text-xs break-all'
+                  >
+                    {line}
+                  </code>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Machine-readable manifest</CardTitle>
+            <CardDescription>
+              Included with the bundle so support tooling can verify timestamp,
+              sections, and redaction policy.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <pre className='max-h-80 overflow-auto rounded-lg border bg-muted p-4 text-xs'>
+              {manifestPreview}
+            </pre>
+            <div className='flex flex-wrap items-center gap-3'>
+              <Button onClick={() => setPreparedBundle(bundlePreview)}>
+                <Download className='size-4' /> Prepare export manifest
+              </Button>
+              {preparedBundle ? (
+                <span className='text-sm text-muted-foreground'>
+                  Export payload prepared for local review. No upload is
+                  performed by this UI.
+                </span>
+              ) : null}
+            </div>
+            {preparedBundle ? (
+              <pre
+                aria-label='Prepared support bundle payload'
+                className='max-h-80 overflow-auto rounded-lg border bg-muted p-4 text-xs'
+              >
+                {preparedBundle}
+              </pre>
+            ) : null}
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/support-bundle/support-bundle.test.tsx
+++ b/src/features/support-bundle/support-bundle.test.tsx
@@ -1,0 +1,81 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  buildSupportBundlePayload,
+  redactDiagnosticText,
+  supportBundleHasSecretMaterial,
+} from './support-bundle'
+
+describe('support bundle export surface', () => {
+  it('renders support bundle preview sections and warning before export', async () => {
+    await renderRoute('/support-bundle')
+
+    expect(
+      await screen.findByRole('heading', { name: /Support bundle export/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Review before sharing/i)).toBeVisible()
+    expect(screen.getByText(/Secret-safe diagnostics/i)).toBeVisible()
+    expect(screen.getAllByText(/Service inventory/i)[0]).toBeVisible()
+    expect(
+      screen.getAllByText(/Runtime and health summaries/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/Secrets Broker source statuses/i)[0]
+    ).toBeVisible()
+    expect(screen.getAllByText(/Recent redacted errors/i)[0]).toBeVisible()
+    expect(screen.getByText(/Machine-readable manifest/i)).toBeVisible()
+    expect(screen.getAllByText(/secret-safe-by-default/i)[0]).toBeVisible()
+  })
+
+  it('prepares a local payload without rendering raw secret-like values', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/support-bundle')
+
+    await user.click(
+      screen.getByRole('button', { name: /Prepare export manifest/i })
+    )
+
+    const preparedPayload = screen.getByLabelText(/Prepared support bundle/i)
+    expect(preparedPayload).toBeVisible()
+    expect(
+      within(preparedPayload).getByText(/\[REDACTED_SECRET\]/i)
+    ).toBeVisible()
+    expect(
+      within(preparedPayload).getByText(/\[REDACTED_AUTHORIZATION\]/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByText(/provider-login-needed|session-cookie-placeholder/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/bearer\s+[a-z0-9._~+/=-]+\.[a-z0-9._~+/=-]+/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/-----BEGIN PRIVATE KEY-----/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('redacts common secret-like diagnostic values', () => {
+    const redacted = redactDiagnosticText(
+      'authorization=ok bearer abc.def.ghi api_key=sk_test_canary password=hunter2 cookie=session-canary -----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----'
+    )
+
+    expect(redacted).toContain('[REDACTED_AUTHORIZATION]')
+    expect(redacted).toContain('api_key=[REDACTED_SECRET]')
+    expect(redacted).toContain('password=[REDACTED_SECRET]')
+    expect(redacted).toContain('cookie=[REDACTED_SECRET]')
+    expect(redacted).toContain('[REDACTED_PRIVATE_KEY]')
+    expect(redacted).not.toContain('sk_test_canary')
+    expect(redacted).not.toContain('hunter2')
+    expect(redacted).not.toContain('session-canary')
+  })
+
+  it('keeps generated support bundle fixtures free of secret material', () => {
+    const payload = buildSupportBundlePayload()
+
+    expect(payload.manifest.sections).toHaveLength(6)
+    expect(payload.manifest.redactionPolicy.mode).toBe('secret-safe-by-default')
+    expect(supportBundleHasSecretMaterial(payload)).toBe(false)
+  })
+})

--- a/src/features/support-bundle/support-bundle.ts
+++ b/src/features/support-bundle/support-bundle.ts
@@ -1,0 +1,215 @@
+export type SupportBundleSeverity = 'info' | 'warning' | 'error'
+
+export type SupportBundleSectionId =
+  | 'manifest'
+  | 'service-inventory'
+  | 'runtime-health'
+  | 'secrets-broker'
+  | 'recent-errors'
+  | 'redaction-report'
+
+export interface SupportBundleSection {
+  id: SupportBundleSectionId
+  title: string
+  summary: string
+  itemCount: number
+  severity: SupportBundleSeverity
+}
+
+export interface SupportBundleManifest {
+  bundleVersion: string
+  generatedAt: string
+  instanceRef: string
+  sections: SupportBundleSection[]
+  redactionPolicy: {
+    mode: 'secret-safe-by-default'
+    rules: string[]
+    excludedMaterial: string[]
+  }
+}
+
+export interface SupportBundlePayload {
+  manifest: SupportBundleManifest
+  diagnostics: {
+    serviceInventory: Array<Record<string, string>>
+    runtimeHealth: Array<Record<string, string>>
+    secretsBroker: Array<Record<string, string>>
+    recentErrors: string[]
+    redactionReport: Array<Record<string, string | number>>
+  }
+}
+
+export const supportBundleRedactionRules = [
+  'Bearer and Basic authorization values are replaced with [REDACTED_AUTHORIZATION].',
+  'Token, API key, secret, password, cookie, and private-key assignments are replaced with [REDACTED_SECRET].',
+  'Environment values are summarized by key/reference only; raw values are excluded.',
+  'Logs are included only after line-level redaction.',
+]
+
+export const supportBundleExcludedMaterial = [
+  'raw secret values',
+  'provider tokens',
+  'API keys',
+  'auth cookies',
+  'private keys',
+  'recovery material',
+  'passwords',
+  'unredacted environment values',
+]
+
+const assignmentPattern =
+  /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
+const authPattern = /\b(bearer|basic)\s+[a-z0-9._~+/=-]+/gi
+const privateKeyPattern =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gi
+
+export function redactDiagnosticText(value: string): string {
+  return value
+    .replace(privateKeyPattern, '[REDACTED_PRIVATE_KEY]')
+    .replace(authPattern, '[REDACTED_AUTHORIZATION]')
+    .replace(
+      assignmentPattern,
+      (_match, key: string) => `${key}=[REDACTED_SECRET]`
+    )
+}
+
+export function containsSecretLikeMaterial(value: string): boolean {
+  const hasPrivateKey =
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/i.test(
+      value
+    )
+  const hasAuthCredential =
+    /\b(bearer|basic)\s+(?!and\b|authorization\b)[a-z0-9._~+/=-]{8,}/i.test(
+      value
+    )
+  const hasUnredactedAssignment = [
+    ...value.matchAll(
+      /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
+    ),
+  ].some((match) => !match[2].startsWith('[REDACTED_'))
+
+  return hasPrivateKey || hasAuthCredential || hasUnredactedAssignment
+}
+
+const rawRecentErrors = [
+  '2026-05-08T12:40:01Z WARN @secretsbroker provider=vault-east status=auth-required access_token=provider-login-needed',
+  '2026-05-08T12:41:14Z ERROR @serviceadmin export denied: cookie=session-cookie-placeholder',
+  '2026-05-08T12:42:22Z INFO service-broker retry scheduled for service=@secretsbroker correlation=diag_9bf12',
+]
+
+export function buildSupportBundlePayload(
+  generatedAt = '2026-05-08T13:10:00.000Z'
+): SupportBundlePayload {
+  const recentErrors = rawRecentErrors.map(redactDiagnosticText)
+  const redactionReport = rawRecentErrors.map((line, index) => ({
+    source: `recent-errors:${index + 1}`,
+    redactions: line === recentErrors[index] ? 0 : 1,
+    status: 'redacted',
+  }))
+
+  const sections: SupportBundleSection[] = [
+    {
+      id: 'manifest',
+      title: 'Manifest and redaction policy',
+      summary: 'Bundle version, generated timestamp, section list, and policy.',
+      itemCount: 1,
+      severity: 'info',
+    },
+    {
+      id: 'service-inventory',
+      title: 'Service inventory',
+      summary: 'Installed local services, versions, and lifecycle status.',
+      itemCount: 4,
+      severity: 'info',
+    },
+    {
+      id: 'runtime-health',
+      title: 'Runtime and health summaries',
+      summary: 'Runtime state, uptime, last check, and degraded dependencies.',
+      itemCount: 3,
+      severity: 'warning',
+    },
+    {
+      id: 'secrets-broker',
+      title: 'Secrets Broker source statuses',
+      summary:
+        'Provider/source refs, lifecycle status, and safe error codes only.',
+      itemCount: 3,
+      severity: 'warning',
+    },
+    {
+      id: 'recent-errors',
+      title: 'Recent redacted errors',
+      summary: 'Selected log lines after authorization and secret redaction.',
+      itemCount: recentErrors.length,
+      severity: 'error',
+    },
+    {
+      id: 'redaction-report',
+      title: 'Redaction report',
+      summary: 'Per-source redaction counts without exposing removed values.',
+      itemCount: redactionReport.length,
+      severity: 'info',
+    },
+  ]
+
+  return {
+    manifest: {
+      bundleVersion: 'support-bundle.v1',
+      generatedAt,
+      instanceRef: 'service-lasso-local-dev',
+      sections,
+      redactionPolicy: {
+        mode: 'secret-safe-by-default',
+        rules: supportBundleRedactionRules,
+        excludedMaterial: supportBundleExcludedMaterial,
+      },
+    },
+    diagnostics: {
+      serviceInventory: [
+        { service: '@serviceadmin', version: '2.2.1', state: 'running' },
+        { service: '@secretsbroker', version: 'local', state: 'degraded' },
+        { service: '@traefik', version: 'local', state: 'running' },
+        { service: 'service-broker', version: 'local', state: 'running' },
+      ],
+      runtimeHealth: [
+        { check: 'serviceadmin-ui', status: 'healthy', ref: 'health_ui_001' },
+        {
+          check: 'secretsbroker-provider-auth',
+          status: 'auth-required',
+          ref: 'diag_provider_auth',
+        },
+        {
+          check: 'log-redaction',
+          status: 'enabled',
+          ref: 'redaction_policy_v1',
+        },
+      ],
+      secretsBroker: [
+        {
+          providerRef: 'vault-east',
+          status: 'auth-required',
+          safeErrorCode: 'PROVIDER_AUTH_REQUIRED',
+        },
+        {
+          providerRef: 'local-encrypted-store',
+          status: 'ready',
+          safeErrorCode: 'NONE',
+        },
+        {
+          providerRef: 'openclaw-exec-adapter',
+          status: 'policy-denied',
+          safeErrorCode: 'POLICY_NAMESPACE_DENIED',
+        },
+      ],
+      recentErrors,
+      redactionReport,
+    },
+  }
+}
+
+export function supportBundleHasSecretMaterial(
+  payload = buildSupportBundlePayload()
+): boolean {
+  return containsSecretLikeMaterial(JSON.stringify(payload))
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as AuthenticatedSettingsRouteRouteImport } from './routes/_authen
 import { Route as AuthenticatedVariablesIndexRouteImport } from './routes/_authenticated/variables/index'
 import { Route as AuthenticatedUsersIndexRouteImport } from './routes/_authenticated/users/index'
 import { Route as AuthenticatedTasksIndexRouteImport } from './routes/_authenticated/tasks/index'
+import { Route as AuthenticatedSupportBundleIndexRouteImport } from './routes/_authenticated/support-bundle/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedServicesIndexRouteImport } from './routes/_authenticated/services/index'
 import { Route as AuthenticatedSecretsBrokerIndexRouteImport } from './routes/_authenticated/secrets-broker/index'
@@ -145,6 +146,12 @@ const AuthenticatedTasksIndexRoute = AuthenticatedTasksIndexRouteImport.update({
   path: '/tasks/',
   getParentRoute: () => AuthenticatedRouteRoute,
 } as any)
+const AuthenticatedSupportBundleIndexRoute =
+  AuthenticatedSupportBundleIndexRouteImport.update({
+    id: '/support-bundle/',
+    path: '/support-bundle/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: '/',
@@ -309,6 +316,7 @@ export interface FileRoutesByFullPath {
   '/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/services/': typeof AuthenticatedServicesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/support-bundle/': typeof AuthenticatedSupportBundleIndexRoute
   '/tasks/': typeof AuthenticatedTasksIndexRoute
   '/users/': typeof AuthenticatedUsersIndexRoute
   '/variables/': typeof AuthenticatedVariablesIndexRoute
@@ -348,6 +356,7 @@ export interface FileRoutesByTo {
   '/secrets-broker': typeof AuthenticatedSecretsBrokerIndexRoute
   '/services': typeof AuthenticatedServicesIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/support-bundle': typeof AuthenticatedSupportBundleIndexRoute
   '/tasks': typeof AuthenticatedTasksIndexRoute
   '/users': typeof AuthenticatedUsersIndexRoute
   '/variables': typeof AuthenticatedVariablesIndexRoute
@@ -392,6 +401,7 @@ export interface FileRoutesById {
   '/_authenticated/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/_authenticated/services/': typeof AuthenticatedServicesIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/_authenticated/support-bundle/': typeof AuthenticatedSupportBundleIndexRoute
   '/_authenticated/tasks/': typeof AuthenticatedTasksIndexRoute
   '/_authenticated/users/': typeof AuthenticatedUsersIndexRoute
   '/_authenticated/variables/': typeof AuthenticatedVariablesIndexRoute
@@ -434,6 +444,7 @@ export interface FileRouteTypes {
     | '/secrets-broker/'
     | '/services/'
     | '/settings/'
+    | '/support-bundle/'
     | '/tasks/'
     | '/users/'
     | '/variables/'
@@ -473,6 +484,7 @@ export interface FileRouteTypes {
     | '/secrets-broker'
     | '/services'
     | '/settings'
+    | '/support-bundle'
     | '/tasks'
     | '/users'
     | '/variables'
@@ -516,6 +528,7 @@ export interface FileRouteTypes {
     | '/_authenticated/secrets-broker/'
     | '/_authenticated/services/'
     | '/_authenticated/settings/'
+    | '/_authenticated/support-bundle/'
     | '/_authenticated/tasks/'
     | '/_authenticated/users/'
     | '/_authenticated/variables/'
@@ -669,6 +682,13 @@ declare module '@tanstack/react-router' {
       path: '/tasks'
       fullPath: '/tasks/'
       preLoaderRoute: typeof AuthenticatedTasksIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/support-bundle/': {
+      id: '/_authenticated/support-bundle/'
+      path: '/support-bundle'
+      fullPath: '/support-bundle/'
+      preLoaderRoute: typeof AuthenticatedSupportBundleIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/settings/': {
@@ -868,6 +888,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedRuntimeIndexRoute: typeof AuthenticatedRuntimeIndexRoute
   AuthenticatedSecretsBrokerIndexRoute: typeof AuthenticatedSecretsBrokerIndexRoute
   AuthenticatedServicesIndexRoute: typeof AuthenticatedServicesIndexRoute
+  AuthenticatedSupportBundleIndexRoute: typeof AuthenticatedSupportBundleIndexRoute
   AuthenticatedTasksIndexRoute: typeof AuthenticatedTasksIndexRoute
   AuthenticatedUsersIndexRoute: typeof AuthenticatedUsersIndexRoute
   AuthenticatedVariablesIndexRoute: typeof AuthenticatedVariablesIndexRoute
@@ -891,6 +912,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedRuntimeIndexRoute: AuthenticatedRuntimeIndexRoute,
   AuthenticatedSecretsBrokerIndexRoute: AuthenticatedSecretsBrokerIndexRoute,
   AuthenticatedServicesIndexRoute: AuthenticatedServicesIndexRoute,
+  AuthenticatedSupportBundleIndexRoute: AuthenticatedSupportBundleIndexRoute,
   AuthenticatedTasksIndexRoute: AuthenticatedTasksIndexRoute,
   AuthenticatedUsersIndexRoute: AuthenticatedUsersIndexRoute,
   AuthenticatedVariablesIndexRoute: AuthenticatedVariablesIndexRoute,

--- a/src/routes/_authenticated/support-bundle/index.tsx
+++ b/src/routes/_authenticated/support-bundle/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SupportBundlePage } from '@/features/support-bundle'
+
+export const Route = createFileRoute('/_authenticated/support-bundle/')({
+  component: SupportBundlePage,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -59,6 +59,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - ZITADEL Session',
   },
   {
+    path: '/support-bundle',
+    heading: /^Support bundle export$/i,
+    title: 'Service Admin - Support Bundle',
+  },
+  {
     path: '/network',
     heading: /^Network$/i,
     title: 'Service Admin - Network',


### PR DESCRIPTION
## Summary

Closes #66.

Adds a secret-safe Service Admin support bundle export surface:
- Adds `/support-bundle` preview/export page with warning, included-section preview, redaction policy, redacted error preview, machine-readable manifest, and local export payload preparation.
- Adds support bundle model/redaction helpers for service inventory, runtime/health summaries, Secrets Broker source statuses, recent errors, and redaction report metadata.
- Adds navigation and route registration for the new support bundle surface.
- Documents the support bundle contract, included diagnostics, excluded/redacted material, and operator review workflow.
- Adds tests for UI preview/export behavior and common secret-like redaction.

## Validation

- `npm run format:check` — passed
- `npm run lint` — passed with existing warnings only in pre-existing files
- `npm test` — passed, 82/82
- `npm run build` — passed (`tsc -b && vite build`)
- `git diff --check` — passed

## Secret-safety evidence

- Export payload uses metadata/refs/status/safe error codes/redacted log excerpts only.
- Raw values for secrets, provider tokens, API keys, auth cookies, private keys, recovery material, passwords, environment values, bearer tokens, and session/client secret material are excluded or redacted.
- Tests cover redaction of bearer, API key, password, cookie, and private-key canaries.
- `supportBundleHasSecretMaterial()` asserts the generated fixture payload contains no unredacted secret-like material.
- UI prepares payload locally only; no upload is performed.