### PR TITLE
ISS-67 add Secrets Broker policy simulation UI

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -6,6 +6,7 @@ import {
   KeyRound,
   LifeBuoy,
   LockKeyhole,
+  Scale,
   SlidersHorizontal,
   HardDrive,
   HelpCircle,
@@ -73,6 +74,11 @@ export const sidebarData: SidebarData = {
           title: 'Secrets Broker',
           url: '/secrets-broker',
           icon: KeyRound,
+        },
+        {
+          title: 'Policy Simulation',
+          url: '/secrets-policy-simulation',
+          icon: Scale,
         },
         {
           title: 'ZITADEL Session',

--- a/src/features/secrets-policy-simulation/index.tsx
+++ b/src/features/secrets-policy-simulation/index.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from 'react'
+import { ClipboardCheck, ShieldCheck } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  policyOutcomeCopy,
+  policySimulationScenarios,
+  type PolicySimulationOutcome,
+} from './policy-simulation'
+
+const outcomeVariant: Record<
+  PolicySimulationOutcome,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  allowed: 'default',
+  denied: 'destructive',
+  unknown: 'secondary',
+  locked: 'outline',
+  'source-auth-required': 'outline',
+}
+
+export function SecretsPolicySimulationPage() {
+  const [selectedScenarioId, setSelectedScenarioId] = useState(
+    policySimulationScenarios[0].id
+  )
+  const selectedScenario = useMemo(
+    () =>
+      policySimulationScenarios.find(
+        (scenario) => scenario.id === selectedScenarioId
+      ) ?? policySimulationScenarios[0],
+    [selectedScenarioId]
+  )
+  const outcomeCounts = useMemo(
+    () =>
+      policySimulationScenarios.reduce<Record<PolicySimulationOutcome, number>>(
+        (counts, scenario) => ({
+          ...counts,
+          [scenario.outcome]: counts[scenario.outcome] + 1,
+        }),
+        {
+          allowed: 0,
+          denied: 0,
+          unknown: 0,
+          locked: 0,
+          'source-auth-required': 0,
+        }
+      ),
+    []
+  )
+
+  usePageMetadata({
+    title: 'Service Admin - Secrets Policy Simulation',
+    description:
+      'Metadata-only Secrets Broker policy simulation and dry-run decisions.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <ShieldCheck className='size-5' /> Secrets Broker policy
+              simulation
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Dry-run whether a service, workflow, or run identity would be
+              allowed to read or write a broker ref. This surface shows policy
+              metadata, source state, lifecycle refs, and audit context only; it
+              never resolves, mutates, or renders raw secret values.
+            </p>
+          </div>
+          <Badge variant='secondary'>Read-only dry run</Badge>
+        </div>
+
+        <Alert>
+          <ClipboardCheck className='size-4' />
+          <AlertTitle>Simulation only — no broker mutation</AlertTitle>
+          <AlertDescription>
+            Results explain the expected policy decision before a risky
+            operation starts. Use the linked policy/source/lifecycle/audit refs
+            to investigate; rerun against the live broker before executing a
+            real workflow.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-5'>
+          {Object.entries(outcomeCounts).map(([outcome, count]) => (
+            <Card key={outcome}>
+              <CardHeader className='pb-2'>
+                <CardDescription>
+                  {policyOutcomeCopy[outcome as PolicySimulationOutcome]}
+                </CardDescription>
+                <CardTitle className='text-3xl'>{count}</CardTitle>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Policy request</CardTitle>
+            <CardDescription>
+              Select a representative dry-run outcome. Inputs are ref metadata
+              and identity refs only, not secret payloads.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div>
+              <label
+                htmlFor='policy-simulation-scenario'
+                className='mb-1 block text-xs text-muted-foreground'
+              >
+                Simulation scenario
+              </label>
+              <select
+                id='policy-simulation-scenario'
+                className='h-9 w-full rounded-md border bg-background px-3 text-sm md:w-[28rem]'
+                value={selectedScenarioId}
+                onChange={(event) => setSelectedScenarioId(event.target.value)}
+              >
+                {policySimulationScenarios.map((scenario) => (
+                  <option key={scenario.id} value={scenario.id}>
+                    {scenario.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className='grid gap-3 md:grid-cols-3'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Service</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.identity.service}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Workflow</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.identity.workflow}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Run ref</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.identity.runRef}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Namespace</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.request.namespace}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Broker ref</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.request.ref}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs text-muted-foreground'>Action</div>
+                <div className='font-medium'>
+                  {selectedScenario.request.action}
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle>Simulation result</CardTitle>
+              <CardDescription>
+                Decision metadata and the reason operators can review before
+                executing a real read, run, rotation, or write-back.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='space-y-4'>
+              <div className='flex flex-wrap items-center gap-3'>
+                <Badge variant={outcomeVariant[selectedScenario.outcome]}>
+                  {policyOutcomeCopy[selectedScenario.outcome]}
+                </Badge>
+                <Badge variant='outline'>
+                  mutation: {selectedScenario.decision.dryRunMutation}
+                </Badge>
+              </div>
+              <div>
+                <div className='font-medium'>
+                  {selectedScenario.decision.title}
+                </div>
+                <p className='mt-1 text-sm text-muted-foreground'>
+                  {selectedScenario.decision.reason}
+                </p>
+              </div>
+              <div className='rounded-lg border p-3 text-sm'>
+                <div className='text-muted-foreground'>Next action</div>
+                <div className='font-medium'>{selectedScenario.nextAction}</div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Linked context</CardTitle>
+              <CardDescription>
+                Stable refs for policy, source, lifecycle, and audit context.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='grid gap-3 text-sm'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Policy</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.decision.policyRef}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Source</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.decision.sourceRef}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Lifecycle</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.decision.lifecycleRef}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Audit dry-run</div>
+                <div className='font-medium break-all'>
+                  {selectedScenario.decision.auditRef}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-policy-simulation/policy-simulation.test.tsx
+++ b/src/features/secrets-policy-simulation/policy-simulation.test.tsx
@@ -1,0 +1,80 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  policySimulationHasSecretMaterial,
+  policySimulationScenarios,
+} from './policy-simulation'
+
+describe('Secrets Broker policy simulation surface', () => {
+  it('renders an allowed read dry-run without resolving secret values', async () => {
+    await renderRoute('/secrets-policy-simulation')
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Secrets Broker policy simulation/i,
+      })
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Simulation only — no broker mutation/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Allowed service read/i)).toBeVisible()
+    expect(screen.getAllByText(/Allowed/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/@serviceadmin/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(
+        /secret:\/\/local\/default\/@serviceadmin\/DIAGNOSTICS_SALT/i
+      )
+    ).toBeVisible()
+    expect(screen.getByText(/mutation: none/i)).toBeVisible()
+    expect(screen.getByText(/policy:\/\/secrets\/serviceadmin/i)).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse|sk_live|bearer\s+[a-z0-9]/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('covers denied unknown locked and source-auth-required outcomes', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-policy-simulation')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Simulation scenario/i),
+      'denied-write'
+    )
+    expect(screen.getByText(/Write-back would be denied/i)).toBeVisible()
+    expect(screen.getAllByText(/Denied/i)[0]).toBeVisible()
+    expect(screen.getByText(/rotation-readonly/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Simulation scenario/i),
+      'missing-ref'
+    )
+    expect(screen.getByText(/Ref existence is unknown/i)).toBeVisible()
+    expect(screen.getAllByText(/Unknown \/ missing ref/i)[0]).toBeVisible()
+    expect(screen.getByText(/MISSING_ARCHIVE_KEY/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Simulation scenario/i),
+      'locked-source'
+    )
+    expect(screen.getByText(/Source is locked/i)).toBeVisible()
+    expect(screen.getAllByText(/Locked/i)[0]).toBeVisible()
+    expect(screen.getByText(/providers\/local\/locked/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Simulation scenario/i),
+      'source-auth-required'
+    )
+    expect(screen.getByText(/External source auth is required/i)).toBeVisible()
+    expect(screen.getAllByText(/Source auth required/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/providers\/1password\/auth-required/i)
+    ).toBeVisible()
+  })
+
+  it('keeps policy simulation fixtures free of secret material', () => {
+    expect(policySimulationScenarios).toHaveLength(5)
+    expect(policySimulationHasSecretMaterial()).toBe(false)
+  })
+})

--- a/src/features/secrets-policy-simulation/policy-simulation.ts
+++ b/src/features/secrets-policy-simulation/policy-simulation.ts
@@ -1,0 +1,194 @@
+export type PolicySimulationOutcome =
+  | 'allowed'
+  | 'denied'
+  | 'unknown'
+  | 'locked'
+  | 'source-auth-required'
+
+export type PolicySimulationAction = 'read' | 'write' | 'write-back' | 'rotate'
+
+export interface PolicySimulationScenario {
+  id: string
+  label: string
+  outcome: PolicySimulationOutcome
+  identity: {
+    service: string
+    workflow: string
+    runRef: string
+  }
+  request: {
+    namespace: string
+    ref: string
+    action: PolicySimulationAction
+  }
+  decision: {
+    title: string
+    reason: string
+    policyRef: string
+    sourceRef: string
+    lifecycleRef: string
+    auditRef: string
+    dryRunMutation: 'none'
+  }
+  nextAction: string
+}
+
+export const policyOutcomeCopy: Record<PolicySimulationOutcome, string> = {
+  allowed: 'Allowed',
+  denied: 'Denied',
+  unknown: 'Unknown / missing ref',
+  locked: 'Locked',
+  'source-auth-required': 'Source auth required',
+}
+
+export const policySimulationScenarios: PolicySimulationScenario[] = [
+  {
+    id: 'allowed-read',
+    label: 'Allowed service read',
+    outcome: 'allowed',
+    identity: {
+      service: '@serviceadmin',
+      workflow: 'diagnostics-support-bundle',
+      runRef: 'run://serviceadmin/diagnostics/2026-05-08T13:28Z',
+    },
+    request: {
+      namespace: 'service-lasso/runtime',
+      ref: 'secret://local/default/@serviceadmin/DIAGNOSTICS_SALT',
+      action: 'read',
+    },
+    decision: {
+      title: 'Read would be allowed',
+      reason:
+        'The service identity has read access to this namespace and the local encrypted source is available.',
+      policyRef: 'policy://secrets/serviceadmin/read-runtime-metadata',
+      sourceRef: 'source://local/default',
+      lifecycleRef: 'lifecycle://@secretsbroker/providers/local/ready',
+      auditRef: 'audit://policy-sim/sim_8f23_allowed',
+      dryRunMutation: 'none',
+    },
+    nextAction:
+      'Proceed only if the calling workflow still avoids logging or rendering resolved values.',
+  },
+  {
+    id: 'denied-write',
+    label: 'Denied write-back',
+    outcome: 'denied',
+    identity: {
+      service: 'payments-api',
+      workflow: 'stripe-key-rotation',
+      runRef: 'run://dagu/payments/rotate-stripe-key/dry-run',
+    },
+    request: {
+      namespace: 'service-lasso/payments',
+      ref: 'secret://vault/kv/service-lasso/payments/STRIPE_KEY',
+      action: 'write-back',
+    },
+    decision: {
+      title: 'Write-back would be denied',
+      reason:
+        'The workflow identity can request rotation but cannot write to the production payments namespace.',
+      policyRef: 'policy://secrets/payments/rotation-readonly',
+      sourceRef: 'source://vault-east/kv',
+      lifecycleRef: 'lifecycle://@secretsbroker/providers/vault-east/ready',
+      auditRef: 'audit://policy-sim/sim_9d41_denied',
+      dryRunMutation: 'none',
+    },
+    nextAction:
+      'Request a scoped break-glass policy or run through the approved production rotation workflow.',
+  },
+  {
+    id: 'missing-ref',
+    label: 'Missing ref lookup',
+    outcome: 'unknown',
+    identity: {
+      service: 'backup-worker',
+      workflow: 'nightly-offsite-backup',
+      runRef: 'run://dagu/backup/nightly/dry-run',
+    },
+    request: {
+      namespace: 'service-lasso/backups',
+      ref: 'secret://vault/kv/service-lasso/backups/MISSING_ARCHIVE_KEY',
+      action: 'read',
+    },
+    decision: {
+      title: 'Ref existence is unknown',
+      reason:
+        'The namespace policy can be evaluated, but the source reports no metadata for this ref.',
+      policyRef: 'policy://secrets/backups/read',
+      sourceRef: 'source://vault-east/kv',
+      lifecycleRef: 'lifecycle://@secretsbroker/providers/vault-east/ready',
+      auditRef: 'audit://policy-sim/sim_2c11_unknown',
+      dryRunMutation: 'none',
+    },
+    nextAction:
+      'Create the ref metadata or correct the workflow reference before starting the backup run.',
+  },
+  {
+    id: 'locked-source',
+    label: 'Locked local source',
+    outcome: 'locked',
+    identity: {
+      service: '@serviceadmin',
+      workflow: 'local-dev-startup',
+      runRef: 'run://local/serviceadmin/startup/checks',
+    },
+    request: {
+      namespace: 'service-lasso/local-dev',
+      ref: 'secret://local/default/@serviceadmin/SESSION_SECRET',
+      action: 'read',
+    },
+    decision: {
+      title: 'Source is locked',
+      reason:
+        'Policy permits the request, but the local encrypted store is locked and cannot provide ref metadata.',
+      policyRef: 'policy://secrets/local-dev/read',
+      sourceRef: 'source://local/default',
+      lifecycleRef: 'lifecycle://@secretsbroker/providers/local/locked',
+      auditRef: 'audit://policy-sim/sim_77aa_locked',
+      dryRunMutation: 'none',
+    },
+    nextAction:
+      'Unlock or re-wrap the local store, then rerun the simulation before service startup.',
+  },
+  {
+    id: 'source-auth-required',
+    label: 'External source auth required',
+    outcome: 'source-auth-required',
+    identity: {
+      service: 'customer-sync',
+      workflow: 'sync-crm-nightly',
+      runRef: 'run://dagu/customer-sync/nightly/dry-run',
+    },
+    request: {
+      namespace: 'service-lasso/customer-sync',
+      ref: 'secret://op/service-lasso/customer-sync/CRM_API_TOKEN',
+      action: 'read',
+    },
+    decision: {
+      title: 'External source auth is required',
+      reason:
+        'The policy can be evaluated, but the password-manager source requires operator authentication first.',
+      policyRef: 'policy://secrets/customer-sync/read',
+      sourceRef: 'source://1password/service-lasso',
+      lifecycleRef:
+        'lifecycle://@secretsbroker/providers/1password/auth-required',
+      auditRef: 'audit://policy-sim/sim_4f19_auth_required',
+      dryRunMutation: 'none',
+    },
+    nextAction:
+      'Authenticate the external source and rerun the dry-run before starting the workflow.',
+  },
+]
+
+export function policySimulationHasSecretMaterial(
+  scenarios = policySimulationScenarios
+): boolean {
+  const serialized = JSON.stringify(scenarios)
+  return (
+    /\b(bearer|basic)\s+(?!auth\b)[a-z0-9._~+/=-]{8,}/i.test(serialized) ||
+    /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|password|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/i.test(
+      serialized
+    ) ||
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/i.test(serialized)
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as AuthenticatedTasksIndexRouteImport } from './routes/_authentic
 import { Route as AuthenticatedSupportBundleIndexRouteImport } from './routes/_authenticated/support-bundle/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedServicesIndexRouteImport } from './routes/_authenticated/services/index'
+import { Route as AuthenticatedSecretsPolicySimulationIndexRouteImport } from './routes/_authenticated/secrets-policy-simulation/index'
 import { Route as AuthenticatedSecretsBrokerIndexRouteImport } from './routes/_authenticated/secrets-broker/index'
 import { Route as AuthenticatedRuntimeIndexRouteImport } from './routes/_authenticated/runtime/index'
 import { Route as AuthenticatedNetworkIndexRouteImport } from './routes/_authenticated/network/index'
@@ -162,6 +163,12 @@ const AuthenticatedServicesIndexRoute =
   AuthenticatedServicesIndexRouteImport.update({
     id: '/services/',
     path: '/services/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedSecretsPolicySimulationIndexRoute =
+  AuthenticatedSecretsPolicySimulationIndexRouteImport.update({
+    id: '/secrets-policy-simulation/',
+    path: '/secrets-policy-simulation/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedSecretsBrokerIndexRoute =
@@ -314,6 +321,7 @@ export interface FileRoutesByFullPath {
   '/network/': typeof AuthenticatedNetworkIndexRoute
   '/runtime/': typeof AuthenticatedRuntimeIndexRoute
   '/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
+  '/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/services/': typeof AuthenticatedServicesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/support-bundle/': typeof AuthenticatedSupportBundleIndexRoute
@@ -354,6 +362,7 @@ export interface FileRoutesByTo {
   '/network': typeof AuthenticatedNetworkIndexRoute
   '/runtime': typeof AuthenticatedRuntimeIndexRoute
   '/secrets-broker': typeof AuthenticatedSecretsBrokerIndexRoute
+  '/secrets-policy-simulation': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/services': typeof AuthenticatedServicesIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/support-bundle': typeof AuthenticatedSupportBundleIndexRoute
@@ -399,6 +408,7 @@ export interface FileRoutesById {
   '/_authenticated/network/': typeof AuthenticatedNetworkIndexRoute
   '/_authenticated/runtime/': typeof AuthenticatedRuntimeIndexRoute
   '/_authenticated/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
+  '/_authenticated/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/_authenticated/services/': typeof AuthenticatedServicesIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/_authenticated/support-bundle/': typeof AuthenticatedSupportBundleIndexRoute
@@ -442,6 +452,7 @@ export interface FileRouteTypes {
     | '/network/'
     | '/runtime/'
     | '/secrets-broker/'
+    | '/secrets-policy-simulation/'
     | '/services/'
     | '/settings/'
     | '/support-bundle/'
@@ -482,6 +493,7 @@ export interface FileRouteTypes {
     | '/network'
     | '/runtime'
     | '/secrets-broker'
+    | '/secrets-policy-simulation'
     | '/services'
     | '/settings'
     | '/support-bundle'
@@ -526,6 +538,7 @@ export interface FileRouteTypes {
     | '/_authenticated/network/'
     | '/_authenticated/runtime/'
     | '/_authenticated/secrets-broker/'
+    | '/_authenticated/secrets-policy-simulation/'
     | '/_authenticated/services/'
     | '/_authenticated/settings/'
     | '/_authenticated/support-bundle/'
@@ -703,6 +716,13 @@ declare module '@tanstack/react-router' {
       path: '/services'
       fullPath: '/services/'
       preLoaderRoute: typeof AuthenticatedServicesIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/secrets-policy-simulation/': {
+      id: '/_authenticated/secrets-policy-simulation/'
+      path: '/secrets-policy-simulation'
+      fullPath: '/secrets-policy-simulation/'
+      preLoaderRoute: typeof AuthenticatedSecretsPolicySimulationIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/secrets-broker/': {
@@ -887,6 +907,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedNetworkIndexRoute: typeof AuthenticatedNetworkIndexRoute
   AuthenticatedRuntimeIndexRoute: typeof AuthenticatedRuntimeIndexRoute
   AuthenticatedSecretsBrokerIndexRoute: typeof AuthenticatedSecretsBrokerIndexRoute
+  AuthenticatedSecretsPolicySimulationIndexRoute: typeof AuthenticatedSecretsPolicySimulationIndexRoute
   AuthenticatedServicesIndexRoute: typeof AuthenticatedServicesIndexRoute
   AuthenticatedSupportBundleIndexRoute: typeof AuthenticatedSupportBundleIndexRoute
   AuthenticatedTasksIndexRoute: typeof AuthenticatedTasksIndexRoute
@@ -911,6 +932,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedNetworkIndexRoute: AuthenticatedNetworkIndexRoute,
   AuthenticatedRuntimeIndexRoute: AuthenticatedRuntimeIndexRoute,
   AuthenticatedSecretsBrokerIndexRoute: AuthenticatedSecretsBrokerIndexRoute,
+  AuthenticatedSecretsPolicySimulationIndexRoute:
+    AuthenticatedSecretsPolicySimulationIndexRoute,
   AuthenticatedServicesIndexRoute: AuthenticatedServicesIndexRoute,
   AuthenticatedSupportBundleIndexRoute: AuthenticatedSupportBundleIndexRoute,
   AuthenticatedTasksIndexRoute: AuthenticatedTasksIndexRoute,

--- a/src/routes/_authenticated/secrets-policy-simulation/index.tsx
+++ b/src/routes/_authenticated/secrets-policy-simulation/index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretsPolicySimulationPage } from '@/features/secrets-policy-simulation'
+
+export const Route = createFileRoute(
+  '/_authenticated/secrets-policy-simulation/'
+)({
+  component: SecretsPolicySimulationPage,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -54,6 +54,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Setup',
   },
   {
+    path: '/secrets-policy-simulation',
+    heading: /^Secrets Broker policy simulation$/i,
+    title: 'Service Admin - Secrets Policy Simulation',
+  },
+  {
     path: '/auth-session',
     heading: /^ZITADEL session and roles$/i,
     title: 'Service Admin - ZITADEL Session',


### PR DESCRIPTION
## Summary

Closes #67.

Adds a metadata-only Secrets Broker policy simulation/dry-run surface:
- Adds `/secrets-policy-simulation` for read-only policy decisions before risky broker reads/writes/write-backs/rotations.
- Covers allowed, denied, unknown/missing ref, locked source, and source-auth-required outcomes.
- Shows service/workflow/run identity, namespace, broker ref, requested action, outcome reason, and policy/source/lifecycle/audit refs.
- Clearly labels the surface as simulation-only with `mutation: none`.
- Adds sidebar navigation and route registration.
- Adds tests for representative outcomes and no-secret rendering.

## Validation

- `npm run format:check` — passed
- `npm run lint` — passed with existing warnings only in pre-existing files
- `npm test -- --run src/features/secrets-policy-simulation/policy-simulation.test.tsx src/test/app-screens.test.tsx` — 25/25 passed
- `npm test` — passed, 86/86
- `npm run build` — passed (`tsc -b && vite build`)
- `git diff --check` — passed

## Secret-safety evidence

- The UI renders metadata, refs, statuses, reasons, and context links only.
- It does not resolve, mutate, export, or render raw secret values.
- Tests assert no bearer/token-like canaries are rendered.
- `policySimulationHasSecretMaterial()` asserts fixtures contain no raw bearer/auth material, token/client/session secret assignments, passwords, private keys, recovery material, or environment values.