### PR TITLE
ISS-68 add fleet overview planning UI

### DIFF
--- a/docs/fleet-overview-planning.md
+++ b/docs/fleet-overview-planning.md
@@ -1,0 +1,40 @@
+# Multi-instance and fleet overview planning
+
+Issue: service-lasso/lasso-serviceadmin#68
+
+The fleet overview surface is a bounded planning/metadata UI for future Service Lasso multi-instance visibility. The current implementation is intentionally local-only.
+
+## Current behavior
+
+- Shows the current local Service Admin instance.
+- Shows future remote instance placeholders so the UI/data model does not assume exactly one instance forever.
+- Renders metadata only: instance id/name, local/remote marker, health, version, services count, broker state, last check, discovery ref, registration state, and security boundary.
+- Documents discovery assumptions and security boundaries in the UI.
+
+## Not implemented in this slice
+
+This slice does **not** implement:
+
+- remote control
+- remote restart/deploy actions
+- cross-instance Secrets Broker reads/writes/rotations
+- raw secret reveal
+- remote log access
+- credential storage
+- automatic LAN/cloud discovery
+- trust establishment or registration workflow
+
+## Future assumptions
+
+Future remote registration should require:
+
+- explicit operator action
+- authenticated instance identity
+- stable instance refs
+- per-instance policy decisions
+- audit reasons for any privileged action
+- clear separation between metadata visibility and control-plane actions
+
+## Secret-safety boundary
+
+Fleet overview rows must not contain raw secrets, provider tokens, API keys, auth cookies, private keys, recovery material, passwords, raw environment values, or credential payloads. Placeholder remote rows should describe planned metadata fields only.

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -1,5 +1,6 @@
 import {
   Boxes,
+  Building2,
   Command,
   GitBranch,
   Globe,
@@ -44,6 +45,11 @@ export const sidebarData: SidebarData = {
           title: 'Services',
           url: '/services',
           icon: Boxes,
+        },
+        {
+          title: 'Fleet Overview',
+          url: '/fleet-overview',
+          icon: Building2,
         },
         {
           title: 'Dependencies',

--- a/src/features/fleet-overview/fleet-overview.test.tsx
+++ b/src/features/fleet-overview/fleet-overview.test.tsx
@@ -1,0 +1,53 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  countFleetInstancesByKind,
+  fleetInstanceSummaries,
+  fleetOverviewHasSecretMaterial,
+} from './fleet-overview'
+
+describe('fleet overview planning surface', () => {
+  it('renders the current local-only instance and future placeholders', async () => {
+    await renderRoute('/fleet-overview')
+
+    expect(
+      await screen.findByRole('heading', { name: /Fleet overview planning/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Local-only current state/i)).toBeVisible()
+    expect(screen.getByText(/No cross-instance control/i)).toBeVisible()
+    expect(screen.getByText(/Local development instance/i)).toBeVisible()
+    expect(screen.getAllByText(/Future remote/i)[0]).toBeVisible()
+    expect(screen.getByText(/Future LAN lab instance/i)).toBeVisible()
+    expect(screen.getByText(/Future production read-only view/i)).toBeVisible()
+    expect(
+      screen.getByText(/instance:\/\/local\/serviceadmin\/default/i)
+    ).toBeVisible()
+  })
+
+  it('shows metadata fields and blocks privileged cross-instance actions', async () => {
+    await renderRoute('/fleet-overview')
+
+    expect(
+      screen.queryByText(/service-lasso-local-dev/i)
+    ).not.toBeInTheDocument()
+    expect(screen.getAllByText(/local workstation/i)[0]).toBeVisible()
+    expect(screen.getByText(/self-registered local instance/i)).toBeVisible()
+    expect(screen.getByText(/remote restart/i)).toBeVisible()
+    expect(screen.getByText(/cross-instance secret read/i)).toBeVisible()
+    expect(screen.getByText(/fleet-wide rotation/i)).toBeVisible()
+    expect(screen.getByText(/No remote control is implemented/i)).toBeVisible()
+    expect(
+      screen.getByText(/No cross-instance Secrets Broker reads/i)
+    ).toBeVisible()
+  })
+
+  it('keeps fleet metadata fixtures free of secret material', () => {
+    expect(fleetInstanceSummaries).toHaveLength(3)
+    expect(countFleetInstancesByKind()).toEqual({
+      local: 1,
+      'future-remote': 2,
+    })
+    expect(fleetOverviewHasSecretMaterial()).toBe(false)
+  })
+})

--- a/src/features/fleet-overview/fleet-overview.ts
+++ b/src/features/fleet-overview/fleet-overview.ts
@@ -1,0 +1,129 @@
+export type FleetInstanceKind = 'local' | 'future-remote'
+export type FleetInstanceHealth = 'healthy' | 'degraded' | 'unknown' | 'planned'
+export type FleetBrokerState =
+  | 'ready'
+  | 'degraded'
+  | 'unconfigured'
+  | 'not-connected'
+
+export interface FleetInstanceSummary {
+  id: string
+  name: string
+  kind: FleetInstanceKind
+  health: FleetInstanceHealth
+  version: string
+  servicesCount: number
+  brokerState: FleetBrokerState
+  lastCheck: string
+  region: string
+  discoveryRef: string
+  registrationState: string
+  securityBoundary: string
+  allowedActions: string[]
+  unavailableActions: string[]
+}
+
+export const fleetDiscoveryAssumptions = [
+  'The current Service Admin instance remains local-first and self-contained.',
+  'Remote instances must be registered by explicit operator action in a future authenticated workflow.',
+  'Discovery metadata must use stable instance refs and health summaries, not credentials or secret payloads.',
+  'Fleet views can compare status across instances but cannot bypass per-instance policy decisions.',
+]
+
+export const fleetSecurityBoundaries = [
+  'No remote control is implemented in this planning slice.',
+  'No cross-instance Secrets Broker reads, writes, rotations, or raw secret reveal actions are available.',
+  'Remote placeholders expose planned metadata fields only; credentials, tokens, cookies, and private keys are excluded.',
+  'Any future remote action must require explicit identity, policy, audit reason, and per-instance approval.',
+]
+
+export const fleetInstanceSummaries: FleetInstanceSummary[] = [
+  {
+    id: 'local-dev-primary',
+    name: 'Local development instance',
+    kind: 'local',
+    health: 'healthy',
+    version: '2.2.1',
+    servicesCount: 7,
+    brokerState: 'ready',
+    lastCheck: '2026-05-08T13:42:00Z',
+    region: 'local workstation',
+    discoveryRef: 'instance://local/serviceadmin/default',
+    registrationState: 'self-registered local instance',
+    securityBoundary:
+      'local-only metadata; no remote tunnel or cross-instance secret access',
+    allowedActions: [
+      'view local metadata',
+      'open local service dashboard',
+      'review local broker status',
+    ],
+    unavailableActions: [
+      'remote restart',
+      'cross-instance secret read',
+      'fleet-wide rotation',
+    ],
+  },
+  {
+    id: 'future-lan-lab',
+    name: 'Future LAN lab instance',
+    kind: 'future-remote',
+    health: 'planned',
+    version: 'registration pending',
+    servicesCount: 0,
+    brokerState: 'not-connected',
+    lastCheck: 'not connected',
+    region: 'planned LAN',
+    discoveryRef: 'instance://planned/lan-lab',
+    registrationState: 'placeholder only; no remote handshake configured',
+    securityBoundary:
+      'planned metadata row only; no credentials or network route stored',
+    allowedActions: ['review registration requirements'],
+    unavailableActions: ['remote control', 'secret sync', 'remote logs'],
+  },
+  {
+    id: 'future-prod-readonly',
+    name: 'Future production read-only view',
+    kind: 'future-remote',
+    health: 'planned',
+    version: 'registration pending',
+    servicesCount: 0,
+    brokerState: 'not-connected',
+    lastCheck: 'not connected',
+    region: 'planned production',
+    discoveryRef: 'instance://planned/prod-readonly',
+    registrationState: 'placeholder only; requires separate approval model',
+    securityBoundary:
+      'read-only planning row; no production access or secret material',
+    allowedActions: ['review security model'],
+    unavailableActions: [
+      'remote deploy',
+      'raw secret reveal',
+      'bulk operation',
+    ],
+  },
+]
+
+export function countFleetInstancesByKind(
+  summaries = fleetInstanceSummaries
+): Record<FleetInstanceKind, number> {
+  return summaries.reduce(
+    (counts, summary) => ({
+      ...counts,
+      [summary.kind]: counts[summary.kind] + 1,
+    }),
+    { local: 0, 'future-remote': 0 } satisfies Record<FleetInstanceKind, number>
+  )
+}
+
+export function fleetOverviewHasSecretMaterial(
+  summaries = fleetInstanceSummaries
+): boolean {
+  const serialized = JSON.stringify(summaries)
+  return (
+    /\b(bearer|basic)\s+(?!auth\b)[a-z0-9._~+/=-]{8,}/i.test(serialized) ||
+    /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/i.test(
+      serialized
+    ) ||
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/i.test(serialized)
+  )
+}

--- a/src/features/fleet-overview/index.tsx
+++ b/src/features/fleet-overview/index.tsx
@@ -1,0 +1,254 @@
+import { Building2, MapPinned, ShieldCheck } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  countFleetInstancesByKind,
+  fleetDiscoveryAssumptions,
+  fleetInstanceSummaries,
+  fleetSecurityBoundaries,
+  type FleetInstanceHealth,
+  type FleetInstanceKind,
+} from './fleet-overview'
+
+const kindVariant: Record<
+  FleetInstanceKind,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  local: 'default',
+  'future-remote': 'outline',
+}
+
+const healthVariant: Record<
+  FleetInstanceHealth,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  healthy: 'default',
+  degraded: 'destructive',
+  unknown: 'secondary',
+  planned: 'outline',
+}
+
+export function FleetOverviewPage() {
+  const counts = countFleetInstancesByKind()
+  const localInstance = fleetInstanceSummaries.find(
+    (instance) => instance.kind === 'local'
+  )
+
+  usePageMetadata({
+    title: 'Service Admin - Fleet Overview',
+    description:
+      'Local-only multi-instance and fleet overview planning metadata surface.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <Building2 className='size-5' /> Fleet overview planning
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Planning metadata for future Service Lasso multi-instance and
+              fleet visibility. Today this is explicitly local-only: remote
+              instances are placeholders, with no remote control, cross-instance
+              secret access, or privileged fleet actions.
+            </p>
+          </div>
+          <Badge variant='secondary'>Local-only current state</Badge>
+        </div>
+
+        <Alert>
+          <ShieldCheck className='size-4' />
+          <AlertTitle>No cross-instance control in this slice</AlertTitle>
+          <AlertDescription>
+            This surface models metadata shape and security boundaries only. It
+            does not create remote connections, store credentials, read remote
+            logs, or access Secrets Broker values across instances.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-4'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Total modeled instances</CardDescription>
+              <CardTitle className='text-3xl'>
+                {fleetInstanceSummaries.length}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Local active</CardDescription>
+              <CardTitle className='text-3xl'>{counts.local}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Future remote placeholders</CardDescription>
+              <CardTitle className='text-3xl'>
+                {counts['future-remote']}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Local services</CardDescription>
+              <CardTitle className='text-3xl'>
+                {localInstance?.servicesCount ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Instance summaries</CardTitle>
+            <CardDescription>
+              Current local instance plus future remote placeholders. Rows show
+              metadata and boundaries only.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            {fleetInstanceSummaries.map((instance) => (
+              <div key={instance.id} className='rounded-lg border p-4'>
+                <div className='flex flex-wrap items-start justify-between gap-3'>
+                  <div>
+                    <div className='flex flex-wrap items-center gap-2'>
+                      <h2 className='font-semibold'>{instance.name}</h2>
+                      <Badge variant={kindVariant[instance.kind]}>
+                        {instance.kind === 'local' ? 'Local' : 'Future remote'}
+                      </Badge>
+                      <Badge variant={healthVariant[instance.health]}>
+                        {instance.health}
+                      </Badge>
+                    </div>
+                    <p className='mt-1 text-sm text-muted-foreground'>
+                      {instance.securityBoundary}
+                    </p>
+                  </div>
+                  <Badge variant='outline'>{instance.brokerState}</Badge>
+                </div>
+
+                <div className='mt-4 grid gap-3 text-sm md:grid-cols-3'>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Instance id</div>
+                    <div className='font-medium break-all'>{instance.id}</div>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Version</div>
+                    <div className='font-medium'>{instance.version}</div>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Last check</div>
+                    <div className='font-medium'>{instance.lastCheck}</div>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Region</div>
+                    <div className='font-medium'>{instance.region}</div>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Services</div>
+                    <div className='font-medium'>{instance.servicesCount}</div>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-muted-foreground'>Discovery ref</div>
+                    <div className='font-medium break-all'>
+                      {instance.discoveryRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border p-3 md:col-span-3'>
+                    <div className='text-muted-foreground'>
+                      Registration state
+                    </div>
+                    <div className='font-medium'>
+                      {instance.registrationState}
+                    </div>
+                  </div>
+                </div>
+
+                <div className='mt-4 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-sm font-medium'>Available now</div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-sm text-muted-foreground'>
+                      {instance.allowedActions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border p-3'>
+                    <div className='text-sm font-medium'>Unavailable here</div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-sm text-muted-foreground'>
+                      {instance.unavailableActions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <div className='grid gap-4 lg:grid-cols-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <MapPinned className='size-4' /> Discovery assumptions
+              </CardTitle>
+              <CardDescription>
+                Explicit assumptions before adding any real remote registration.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+                {fleetDiscoveryAssumptions.map((assumption) => (
+                  <li key={assumption}>{assumption}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Security boundaries</CardTitle>
+              <CardDescription>
+                Guardrails for future fleet work and current local-only UI.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+                {fleetSecurityBoundaries.map((boundary) => (
+                  <li key={boundary}>{boundary}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        </div>
+      </Main>
+    </>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as AuthenticatedNetworkIndexRouteImport } from './routes/_authent
 import { Route as AuthenticatedLogsIndexRouteImport } from './routes/_authenticated/logs/index'
 import { Route as AuthenticatedInstalledIndexRouteImport } from './routes/_authenticated/installed/index'
 import { Route as AuthenticatedHelpCenterIndexRouteImport } from './routes/_authenticated/help-center/index'
+import { Route as AuthenticatedFleetOverviewIndexRouteImport } from './routes/_authenticated/fleet-overview/index'
 import { Route as AuthenticatedDependenciesIndexRouteImport } from './routes/_authenticated/dependencies/index'
 import { Route as AuthenticatedChatsIndexRouteImport } from './routes/_authenticated/chats/index'
 import { Route as AuthenticatedAuthSessionIndexRouteImport } from './routes/_authenticated/auth-session/index'
@@ -206,6 +207,12 @@ const AuthenticatedHelpCenterIndexRoute =
     path: '/help-center/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedFleetOverviewIndexRoute =
+  AuthenticatedFleetOverviewIndexRouteImport.update({
+    id: '/fleet-overview/',
+    path: '/fleet-overview/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedDependenciesIndexRoute =
   AuthenticatedDependenciesIndexRouteImport.update({
     id: '/dependencies/',
@@ -315,6 +322,7 @@ export interface FileRoutesByFullPath {
   '/auth-session/': typeof AuthenticatedAuthSessionIndexRoute
   '/chats/': typeof AuthenticatedChatsIndexRoute
   '/dependencies/': typeof AuthenticatedDependenciesIndexRoute
+  '/fleet-overview/': typeof AuthenticatedFleetOverviewIndexRoute
   '/help-center/': typeof AuthenticatedHelpCenterIndexRoute
   '/installed/': typeof AuthenticatedInstalledIndexRoute
   '/logs/': typeof AuthenticatedLogsIndexRoute
@@ -356,6 +364,7 @@ export interface FileRoutesByTo {
   '/auth-session': typeof AuthenticatedAuthSessionIndexRoute
   '/chats': typeof AuthenticatedChatsIndexRoute
   '/dependencies': typeof AuthenticatedDependenciesIndexRoute
+  '/fleet-overview': typeof AuthenticatedFleetOverviewIndexRoute
   '/help-center': typeof AuthenticatedHelpCenterIndexRoute
   '/installed': typeof AuthenticatedInstalledIndexRoute
   '/logs': typeof AuthenticatedLogsIndexRoute
@@ -402,6 +411,7 @@ export interface FileRoutesById {
   '/_authenticated/auth-session/': typeof AuthenticatedAuthSessionIndexRoute
   '/_authenticated/chats/': typeof AuthenticatedChatsIndexRoute
   '/_authenticated/dependencies/': typeof AuthenticatedDependenciesIndexRoute
+  '/_authenticated/fleet-overview/': typeof AuthenticatedFleetOverviewIndexRoute
   '/_authenticated/help-center/': typeof AuthenticatedHelpCenterIndexRoute
   '/_authenticated/installed/': typeof AuthenticatedInstalledIndexRoute
   '/_authenticated/logs/': typeof AuthenticatedLogsIndexRoute
@@ -446,6 +456,7 @@ export interface FileRouteTypes {
     | '/auth-session/'
     | '/chats/'
     | '/dependencies/'
+    | '/fleet-overview/'
     | '/help-center/'
     | '/installed/'
     | '/logs/'
@@ -487,6 +498,7 @@ export interface FileRouteTypes {
     | '/auth-session'
     | '/chats'
     | '/dependencies'
+    | '/fleet-overview'
     | '/help-center'
     | '/installed'
     | '/logs'
@@ -532,6 +544,7 @@ export interface FileRouteTypes {
     | '/_authenticated/auth-session/'
     | '/_authenticated/chats/'
     | '/_authenticated/dependencies/'
+    | '/_authenticated/fleet-overview/'
     | '/_authenticated/help-center/'
     | '/_authenticated/installed/'
     | '/_authenticated/logs/'
@@ -767,6 +780,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedHelpCenterIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/fleet-overview/': {
+      id: '/_authenticated/fleet-overview/'
+      path: '/fleet-overview'
+      fullPath: '/fleet-overview/'
+      preLoaderRoute: typeof AuthenticatedFleetOverviewIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/dependencies/': {
       id: '/_authenticated/dependencies/'
       path: '/dependencies'
@@ -901,6 +921,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedAuthSessionIndexRoute: typeof AuthenticatedAuthSessionIndexRoute
   AuthenticatedChatsIndexRoute: typeof AuthenticatedChatsIndexRoute
   AuthenticatedDependenciesIndexRoute: typeof AuthenticatedDependenciesIndexRoute
+  AuthenticatedFleetOverviewIndexRoute: typeof AuthenticatedFleetOverviewIndexRoute
   AuthenticatedHelpCenterIndexRoute: typeof AuthenticatedHelpCenterIndexRoute
   AuthenticatedInstalledIndexRoute: typeof AuthenticatedInstalledIndexRoute
   AuthenticatedLogsIndexRoute: typeof AuthenticatedLogsIndexRoute
@@ -926,6 +947,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedAuthSessionIndexRoute: AuthenticatedAuthSessionIndexRoute,
   AuthenticatedChatsIndexRoute: AuthenticatedChatsIndexRoute,
   AuthenticatedDependenciesIndexRoute: AuthenticatedDependenciesIndexRoute,
+  AuthenticatedFleetOverviewIndexRoute: AuthenticatedFleetOverviewIndexRoute,
   AuthenticatedHelpCenterIndexRoute: AuthenticatedHelpCenterIndexRoute,
   AuthenticatedInstalledIndexRoute: AuthenticatedInstalledIndexRoute,
   AuthenticatedLogsIndexRoute: AuthenticatedLogsIndexRoute,

--- a/src/routes/_authenticated/fleet-overview/index.tsx
+++ b/src/routes/_authenticated/fleet-overview/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { FleetOverviewPage } from '@/features/fleet-overview'
+
+export const Route = createFileRoute('/_authenticated/fleet-overview/')({
+  component: FleetOverviewPage,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -25,6 +25,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Service - Service Admin UI',
   },
   {
+    path: '/fleet-overview',
+    heading: /^Fleet overview planning$/i,
+    title: 'Service Admin - Fleet Overview',
+  },
+  {
     path: '/dependencies',
     heading: /^Dependencies$/i,
     title: 'Service Admin - Dependencies',


### PR DESCRIPTION
## Summary

Implements the bounded planning surface for service-lasso/lasso-serviceadmin#68.

- Adds `/fleet-overview` as a local-only multi-instance/fleet overview planning route.
- Defines explicit metadata shape for local plus future remote placeholder instances: id/name, local/remote marker, health, version, services count, broker state, last check, discovery ref, registration state, and security boundary.
- Renders the current local instance plus future remote placeholders with clear unavailable privileged actions.
- Documents discovery/registration assumptions and security boundaries in `docs/fleet-overview-planning.md`.
- Adds tests for route rendering, local-only placeholder behavior, blocked privileged/cross-instance actions, and fixture secret-safety.

## Safety boundaries

This PR does not implement remote control, remote connections, remote logs, cross-instance Secrets Broker reads/writes/rotations, raw secret reveal, credential storage, automatic discovery, or privileged fleet-wide actions.

## Validation

- `npm test -- --run src/features/fleet-overview/fleet-overview.test.tsx src/test/app-screens.test.tsx` — PASS, 26 tests
- `npx prettier --write docs/fleet-overview-planning.md src/features/fleet-overview/index.tsx src/features/fleet-overview/fleet-overview.ts src/features/fleet-overview/fleet-overview.test.tsx src/routes/_authenticated/fleet-overview/index.tsx src/components/layout/data/sidebar-data.ts src/test/app-screens.test.tsx src/routeTree.gen.ts` — PASS
- `npm run format:check` — PASS
- `npm run lint` — PASS with existing warnings in installed/logs/network/runtime/variables; no errors
- `npm test` — PASS, 90 tests
- `npm run build` — PASS
- `git diff --check` — PASS

## Merge status

Holding merge pending independent validation/review approval.
