### PR TITLE
ISS-39 add secret inventory metadata table

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -1,0 +1,40 @@
+# Secret inventory metadata table
+
+Issue: service-lasso/lasso-serviceadmin#39
+
+The secret inventory surface is an advanced Secrets Broker planning view for metadata/state-first ref visibility. It is intentionally not a password vault and does not resolve secret payloads.
+
+## Current behavior
+
+- Uses deterministic local fixture data only.
+- Shows namespace/ref id, source/backend, owning service/workspace, presence state, key version, last updated, last used, expiry/rotation status, and adjacent metadata links.
+- Links to provider metadata, ref usage, and audit views where applicable.
+- Shows unavailable privileged operations as explanatory text, not controls.
+
+## Not implemented in this slice
+
+This slice does **not** implement:
+
+- plaintext value rendering
+- raw reveal controls
+- clipboard/copy value controls
+- backend reads or writes
+- bulk edit or bulk rotation operations
+- provider credential access
+- arbitrary password-vault/note storage behavior
+- backend enforcement claims
+
+## Future requirements before privileged workflows
+
+Any future raw reveal or mutation workflow must be separate from this inventory table and must define:
+
+- authenticated identity requirements
+- policy decision inputs
+- audit reason and audit event behavior
+- timeout/cancellation behavior
+- no-logging/no-export boundaries for revealed values
+- tests proving values do not leak into ordinary UI, logs, diagnostics, support bundles, or table fixtures
+
+## Secret-safety boundary
+
+Rows may contain refs, status, ownership, and rotation metadata. Rows must not contain bearer/access/refresh/id tokens, provider tokens, API keys, auth cookies, private keys, recovery material, passwords, raw environment values, or credential payloads.

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -2,6 +2,7 @@ import {
   Boxes,
   Building2,
   Command,
+  DatabaseZap,
   GitBranch,
   Globe,
   KeyRound,
@@ -80,6 +81,11 @@ export const sidebarData: SidebarData = {
           title: 'Secrets Broker',
           url: '/secrets-broker',
           icon: KeyRound,
+        },
+        {
+          title: 'Secret Inventory',
+          url: '/secret-inventory',
+          icon: DatabaseZap,
         },
         {
           title: 'Policy Simulation',

--- a/src/features/secret-inventory/index.tsx
+++ b/src/features/secret-inventory/index.tsx
@@ -1,0 +1,248 @@
+import { Link } from '@tanstack/react-router'
+import { DatabaseZap, ShieldCheck } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  countSecretInventoryByState,
+  secretInventoryBoundaries,
+  secretInventoryRows,
+  type SecretInventoryState,
+} from './secret-inventory'
+
+const stateVariant: Record<
+  SecretInventoryState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  present: 'default',
+  missing: 'destructive',
+  stale: 'secondary',
+  'rotation-due': 'outline',
+}
+
+export function SecretInventoryPage() {
+  const counts = countSecretInventoryByState()
+
+  usePageMetadata({
+    title: 'Service Admin - Secret Inventory',
+    description:
+      'Metadata-only Secrets Broker inventory for refs, ownership, state, and rotation planning.',
+  })
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <DatabaseZap className='size-5' /> Secret inventory
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Advanced Secrets Broker planning view for ref metadata, ownership,
+              state, expiry, and rotation readiness. This local fixture table is
+              metadata-first and never resolves, displays, copies, exports, or
+              mutates secret values.
+            </p>
+          </div>
+          <Badge variant='secondary'>Deterministic local fixture</Badge>
+        </div>
+
+        <Alert>
+          <ShieldCheck className='size-4' />
+          <AlertTitle>No plaintext or privileged actions</AlertTitle>
+          <AlertDescription>
+            This is not a password vault and it does not include raw reveal,
+            clipboard, edit, bulk rotation, or backend write controls. Adjacent
+            links point to metadata-only provider, dependency, and audit views.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-5'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Total refs</CardDescription>
+              <CardTitle className='text-3xl'>
+                {secretInventoryRows.length}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Present</CardDescription>
+              <CardTitle className='text-3xl'>{counts.present}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Rotation due</CardDescription>
+              <CardTitle className='text-3xl'>
+                {counts['rotation-due']}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Stale</CardDescription>
+              <CardTitle className='text-3xl'>{counts.stale}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Missing</CardDescription>
+              <CardTitle className='text-3xl'>{counts.missing}</CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Metadata-first ref table</CardTitle>
+            <CardDescription>
+              Rows are deterministic sample data for planning large inventory
+              behavior. Secret payloads and privileged actions are deliberately
+              absent.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className='overflow-x-auto rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Namespace / ref</TableHead>
+                    <TableHead>Source / backend</TableHead>
+                    <TableHead>Owner</TableHead>
+                    <TableHead>State</TableHead>
+                    <TableHead>Key / rotation</TableHead>
+                    <TableHead>Last updated / used</TableHead>
+                    <TableHead>Metadata links</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {secretInventoryRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell className='min-w-72 align-top'>
+                        <div className='font-medium'>{row.namespace}</div>
+                        <div className='text-sm break-all text-muted-foreground'>
+                          {row.refId}
+                        </div>
+                        <div className='mt-2 text-xs text-muted-foreground'>
+                          {row.safeNotes}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-56 align-top'>
+                        <Badge variant='outline'>{row.source}</Badge>
+                        <div className='mt-2 text-sm text-muted-foreground'>
+                          {row.backend}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-44 align-top'>
+                        <div className='font-medium'>{row.owningService}</div>
+                        <div className='text-sm text-muted-foreground'>
+                          {row.workspace}
+                        </div>
+                      </TableCell>
+                      <TableCell className='align-top'>
+                        <Badge variant={stateVariant[row.presenceState]}>
+                          {row.presenceState}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className='min-w-48 align-top'>
+                        <div>{row.keyVersion}</div>
+                        <div className='text-sm text-muted-foreground'>
+                          {row.rotationStatus}
+                        </div>
+                        <div className='text-xs text-muted-foreground'>
+                          Expiry: {row.expiry}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-52 align-top text-sm'>
+                        <div>Updated: {row.lastUpdated}</div>
+                        <div className='text-muted-foreground'>
+                          Used: {row.lastUsed}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-48 align-top'>
+                        <div className='space-y-1 text-sm'>
+                          {row.providerConnectionUrl ? (
+                            <Link
+                              to={row.providerConnectionUrl}
+                              className='block text-primary underline-offset-4 hover:underline'
+                            >
+                              provider metadata
+                            </Link>
+                          ) : null}
+                          <Link
+                            to={row.refUsageUrl}
+                            className='block text-primary underline-offset-4 hover:underline'
+                          >
+                            ref usage
+                          </Link>
+                          <Link
+                            to={row.auditUrl}
+                            className='block text-primary underline-offset-4 hover:underline'
+                          >
+                            audit events
+                          </Link>
+                        </div>
+                        <div className='mt-2 text-xs text-muted-foreground'>
+                          Unavailable: {row.unavailableActions.join(', ')}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Safety boundaries</CardTitle>
+            <CardDescription>
+              Guardrails for keeping this inventory metadata-only and separate
+              from privileged reveal or mutation workflows.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+              {secretInventoryBoundaries.map((boundary) => (
+                <li key={boundary}>{boundary}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secret-inventory/secret-inventory.test.tsx
+++ b/src/features/secret-inventory/secret-inventory.test.tsx
@@ -1,0 +1,69 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  buildLargeSecretInventoryFixture,
+  countSecretInventoryByState,
+  secretInventoryHasPlaintextMaterial,
+  secretInventoryRows,
+} from './secret-inventory'
+
+describe('secret inventory metadata view', () => {
+  it('renders deterministic local fixture metadata without plaintext controls', async () => {
+    await renderRoute('/secret-inventory')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secret inventory$/i })
+    ).toBeVisible()
+    expect(screen.getAllByText(/Deterministic local fixture/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/No plaintext or privileged actions/i)
+    ).toBeVisible()
+    expect(screen.getByText(/not a password vault/i)).toBeVisible()
+    expect(screen.getByText(/metadata-first ref table/i)).toBeVisible()
+    expect(screen.getByText('local/serviceadmin')).toBeVisible()
+    expect(
+      screen.getByText('secret://local/serviceadmin/session-signing')
+    ).toBeVisible()
+    expect(screen.getAllByText('@serviceadmin')[0]).toBeVisible()
+    expect(screen.getAllByText(/provider metadata/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/ref usage/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/audit events/i)[0]).toBeVisible()
+  })
+
+  it('shows unavailable privileged actions as blocked text, not controls', async () => {
+    await renderRoute('/secret-inventory')
+
+    expect(screen.getAllByText(/show plaintext/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/copy value/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/bulk edit/i)[0]).toBeVisible()
+    expect(screen.getByText(/rotate from table/i)).toBeVisible()
+    expect(
+      screen.queryByRole('button', {
+        name: /show plaintext|copy value|rotate/i,
+      })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/unredacted value/i)).not.toBeInTheDocument()
+  })
+
+  it('counts states and keeps fixtures free of plaintext-like material', () => {
+    expect(countSecretInventoryByState()).toEqual({
+      present: 2,
+      missing: 1,
+      stale: 1,
+      'rotation-due': 1,
+    })
+    expect(secretInventoryRows).toHaveLength(5)
+    expect(secretInventoryHasPlaintextMaterial()).toBe(false)
+  })
+
+  it('builds large deterministic fixture sets for table behavior tests', () => {
+    const largeRows = buildLargeSecretInventoryFixture(125)
+
+    expect(largeRows).toHaveLength(125)
+    expect(largeRows[0].id).toBe('fixture-secret-ref-1')
+    expect(largeRows[124].refId).toBe('secret://fixture/workspace-5/ref-125')
+    expect(new Set(largeRows.map((row) => row.id)).size).toBe(125)
+    expect(secretInventoryHasPlaintextMaterial(largeRows)).toBe(false)
+  })
+})

--- a/src/features/secret-inventory/secret-inventory.ts
+++ b/src/features/secret-inventory/secret-inventory.ts
@@ -1,0 +1,181 @@
+export type SecretInventoryState =
+  | 'present'
+  | 'missing'
+  | 'stale'
+  | 'rotation-due'
+
+export type SecretInventorySource =
+  | 'local encrypted store'
+  | 'provider connection'
+  | 'file source'
+  | 'generated write-back'
+
+export interface SecretInventoryRow {
+  id: string
+  namespace: string
+  refId: string
+  source: SecretInventorySource
+  backend: string
+  owningService: string
+  workspace: string
+  presenceState: SecretInventoryState
+  keyVersion: string
+  lastUpdated: string
+  lastUsed: string
+  expiry: string
+  rotationStatus: string
+  providerConnectionUrl?: string
+  refUsageUrl: string
+  auditUrl: string
+  safeNotes: string
+  unavailableActions: string[]
+}
+
+export const secretInventoryBoundaries = [
+  'This is deterministic local fixture metadata only; it does not query a backend or resolve secret payloads.',
+  'Rows show refs, state, ownership, expiry, rotation, and links to adjacent metadata views only.',
+  'Plaintext values, raw reveal controls, clipboard actions, bulk edits, and rotation mutations are intentionally absent.',
+  'Any future raw reveal flow must remain a separate privileged workflow with identity, policy, audit reason, timeout, and no logging of values.',
+]
+
+export const secretInventoryRows: SecretInventoryRow[] = [
+  {
+    id: 'local-serviceadmin-session-signing',
+    namespace: 'local/serviceadmin',
+    refId: 'secret://local/serviceadmin/session-signing',
+    source: 'local encrypted store',
+    backend: '@secretsbroker/local/default',
+    owningService: '@serviceadmin',
+    workspace: 'local-dev',
+    presenceState: 'present',
+    keyVersion: 'v3',
+    lastUpdated: '2026-05-07T19:10:00Z',
+    lastUsed: '2026-05-08T09:45:00Z',
+    expiry: 'managed rotation window',
+    rotationStatus: 'healthy',
+    refUsageUrl: '/dependencies?ref=session-signing',
+    auditUrl: '/secrets-broker#audit',
+    safeNotes: 'Startup-critical ref; value hidden and never rendered.',
+    unavailableActions: ['show plaintext', 'copy value', 'bulk edit'],
+  },
+  {
+    id: 'provider-zitadel-client-credential',
+    namespace: 'provider/zitadel',
+    refId: 'secret://provider/zitadel/client-credential',
+    source: 'provider connection',
+    backend: 'ZITADEL provider connection',
+    owningService: '@serviceadmin',
+    workspace: 'identity',
+    presenceState: 'rotation-due',
+    keyVersion: 'v5',
+    lastUpdated: '2026-04-20T06:30:00Z',
+    lastUsed: '2026-05-08T08:20:00Z',
+    expiry: '2026-05-15T00:00:00Z',
+    rotationStatus: 'due within 7 days',
+    providerConnectionUrl: '/secrets-broker#provider-connections',
+    refUsageUrl: '/dependencies?ref=zitadel-client-credential',
+    auditUrl: '/secrets-broker#audit',
+    safeNotes: 'Connection metadata only; provider material remains hidden.',
+    unavailableActions: ['show plaintext', 'rotate from table', 'export value'],
+  },
+  {
+    id: 'file-source-node-registry-auth',
+    namespace: 'file/runtime',
+    refId: 'secret://file/runtime/node-registry-auth',
+    source: 'file source',
+    backend: 'runtime env file source',
+    owningService: '@node',
+    workspace: 'build',
+    presenceState: 'stale',
+    keyVersion: 'unknown',
+    lastUpdated: '2026-04-12T11:00:00Z',
+    lastUsed: '2026-05-01T12:05:00Z',
+    expiry: 'not declared',
+    rotationStatus: 'review source freshness',
+    refUsageUrl: '/dependencies?ref=node-registry-auth',
+    auditUrl: '/secrets-broker#audit',
+    safeNotes: 'File path grants should be narrowed before future mutation UI.',
+    unavailableActions: ['show plaintext', 'open source file', 'bulk rotate'],
+  },
+  {
+    id: 'generated-echoservice-webhook-signing',
+    namespace: 'generated/echoservice',
+    refId: 'secret://generated/echoservice/webhook-signing',
+    source: 'generated write-back',
+    backend: '@secretsbroker/generated/write-back',
+    owningService: 'echo-service',
+    workspace: 'demo',
+    presenceState: 'present',
+    keyVersion: 'v1',
+    lastUpdated: '2026-05-06T04:00:00Z',
+    lastUsed: '2026-05-07T22:14:00Z',
+    expiry: '2026-08-06T04:00:00Z',
+    rotationStatus: 'healthy',
+    refUsageUrl: '/dependencies?ref=webhook-signing',
+    auditUrl: '/secrets-broker#audit',
+    safeNotes: 'Generated value is write-only; table tracks metadata state.',
+    unavailableActions: ['show plaintext', 'regenerate here', 'copy value'],
+  },
+  {
+    id: 'provider-payments-signing-ref',
+    namespace: 'provider/payments',
+    refId: 'secret://provider/payments/signing-ref',
+    source: 'provider connection',
+    backend: 'payments provider connection',
+    owningService: 'payments-api',
+    workspace: 'future-prod-readonly',
+    presenceState: 'missing',
+    keyVersion: 'not available',
+    lastUpdated: 'not available',
+    lastUsed: 'not available',
+    expiry: 'not available',
+    rotationStatus: 'registration pending',
+    providerConnectionUrl: '/secrets-broker#provider-connections',
+    refUsageUrl: '/dependencies?ref=payments-signing-ref',
+    auditUrl: '/secrets-broker#audit',
+    safeNotes:
+      'Placeholder metadata; no production provider route is configured.',
+    unavailableActions: ['show plaintext', 'remote fetch', 'bulk operation'],
+  },
+]
+
+export function countSecretInventoryByState(rows = secretInventoryRows) {
+  return rows.reduce(
+    (counts, row) => ({
+      ...counts,
+      [row.presenceState]: counts[row.presenceState] + 1,
+    }),
+    {
+      present: 0,
+      missing: 0,
+      stale: 0,
+      'rotation-due': 0,
+    } satisfies Record<SecretInventoryState, number>
+  )
+}
+
+export function buildLargeSecretInventoryFixture(
+  count: number
+): SecretInventoryRow[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ...secretInventoryRows[index % secretInventoryRows.length],
+    id: `fixture-secret-ref-${index + 1}`,
+    namespace: `fixture/workspace-${(index % 8) + 1}`,
+    refId: `secret://fixture/workspace-${(index % 8) + 1}/ref-${index + 1}`,
+    owningService: `fixture-service-${(index % 12) + 1}`,
+    workspace: `fixture-${(index % 5) + 1}`,
+  }))
+}
+
+export function secretInventoryHasPlaintextMaterial(
+  rows = secretInventoryRows
+): boolean {
+  const serialized = JSON.stringify(rows)
+  return (
+    /\b(bearer|basic)\s+(?!auth\b)[a-z0-9._~+/=-]{8,}/i.test(serialized) ||
+    /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/i.test(
+      serialized
+    ) ||
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/i.test(serialized)
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authen
 import { Route as AuthenticatedServicesIndexRouteImport } from './routes/_authenticated/services/index'
 import { Route as AuthenticatedSecretsPolicySimulationIndexRouteImport } from './routes/_authenticated/secrets-policy-simulation/index'
 import { Route as AuthenticatedSecretsBrokerIndexRouteImport } from './routes/_authenticated/secrets-broker/index'
+import { Route as AuthenticatedSecretInventoryIndexRouteImport } from './routes/_authenticated/secret-inventory/index'
 import { Route as AuthenticatedRuntimeIndexRouteImport } from './routes/_authenticated/runtime/index'
 import { Route as AuthenticatedNetworkIndexRouteImport } from './routes/_authenticated/network/index'
 import { Route as AuthenticatedLogsIndexRouteImport } from './routes/_authenticated/logs/index'
@@ -176,6 +177,12 @@ const AuthenticatedSecretsBrokerIndexRoute =
   AuthenticatedSecretsBrokerIndexRouteImport.update({
     id: '/secrets-broker/',
     path: '/secrets-broker/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedSecretInventoryIndexRoute =
+  AuthenticatedSecretInventoryIndexRouteImport.update({
+    id: '/secret-inventory/',
+    path: '/secret-inventory/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedRuntimeIndexRoute =
@@ -328,6 +335,7 @@ export interface FileRoutesByFullPath {
   '/logs/': typeof AuthenticatedLogsIndexRoute
   '/network/': typeof AuthenticatedNetworkIndexRoute
   '/runtime/': typeof AuthenticatedRuntimeIndexRoute
+  '/secret-inventory/': typeof AuthenticatedSecretInventoryIndexRoute
   '/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/services/': typeof AuthenticatedServicesIndexRoute
@@ -370,6 +378,7 @@ export interface FileRoutesByTo {
   '/logs': typeof AuthenticatedLogsIndexRoute
   '/network': typeof AuthenticatedNetworkIndexRoute
   '/runtime': typeof AuthenticatedRuntimeIndexRoute
+  '/secret-inventory': typeof AuthenticatedSecretInventoryIndexRoute
   '/secrets-broker': typeof AuthenticatedSecretsBrokerIndexRoute
   '/secrets-policy-simulation': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/services': typeof AuthenticatedServicesIndexRoute
@@ -417,6 +426,7 @@ export interface FileRoutesById {
   '/_authenticated/logs/': typeof AuthenticatedLogsIndexRoute
   '/_authenticated/network/': typeof AuthenticatedNetworkIndexRoute
   '/_authenticated/runtime/': typeof AuthenticatedRuntimeIndexRoute
+  '/_authenticated/secret-inventory/': typeof AuthenticatedSecretInventoryIndexRoute
   '/_authenticated/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
   '/_authenticated/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/_authenticated/services/': typeof AuthenticatedServicesIndexRoute
@@ -462,6 +472,7 @@ export interface FileRouteTypes {
     | '/logs/'
     | '/network/'
     | '/runtime/'
+    | '/secret-inventory/'
     | '/secrets-broker/'
     | '/secrets-policy-simulation/'
     | '/services/'
@@ -504,6 +515,7 @@ export interface FileRouteTypes {
     | '/logs'
     | '/network'
     | '/runtime'
+    | '/secret-inventory'
     | '/secrets-broker'
     | '/secrets-policy-simulation'
     | '/services'
@@ -550,6 +562,7 @@ export interface FileRouteTypes {
     | '/_authenticated/logs/'
     | '/_authenticated/network/'
     | '/_authenticated/runtime/'
+    | '/_authenticated/secret-inventory/'
     | '/_authenticated/secrets-broker/'
     | '/_authenticated/secrets-policy-simulation/'
     | '/_authenticated/services/'
@@ -745,6 +758,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSecretsBrokerIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secret-inventory/': {
+      id: '/_authenticated/secret-inventory/'
+      path: '/secret-inventory'
+      fullPath: '/secret-inventory/'
+      preLoaderRoute: typeof AuthenticatedSecretInventoryIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/runtime/': {
       id: '/_authenticated/runtime/'
       path: '/runtime'
@@ -927,6 +947,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedLogsIndexRoute: typeof AuthenticatedLogsIndexRoute
   AuthenticatedNetworkIndexRoute: typeof AuthenticatedNetworkIndexRoute
   AuthenticatedRuntimeIndexRoute: typeof AuthenticatedRuntimeIndexRoute
+  AuthenticatedSecretInventoryIndexRoute: typeof AuthenticatedSecretInventoryIndexRoute
   AuthenticatedSecretsBrokerIndexRoute: typeof AuthenticatedSecretsBrokerIndexRoute
   AuthenticatedSecretsPolicySimulationIndexRoute: typeof AuthenticatedSecretsPolicySimulationIndexRoute
   AuthenticatedServicesIndexRoute: typeof AuthenticatedServicesIndexRoute
@@ -953,6 +974,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedLogsIndexRoute: AuthenticatedLogsIndexRoute,
   AuthenticatedNetworkIndexRoute: AuthenticatedNetworkIndexRoute,
   AuthenticatedRuntimeIndexRoute: AuthenticatedRuntimeIndexRoute,
+  AuthenticatedSecretInventoryIndexRoute:
+    AuthenticatedSecretInventoryIndexRoute,
   AuthenticatedSecretsBrokerIndexRoute: AuthenticatedSecretsBrokerIndexRoute,
   AuthenticatedSecretsPolicySimulationIndexRoute:
     AuthenticatedSecretsPolicySimulationIndexRoute,

--- a/src/routes/_authenticated/secret-inventory/index.tsx
+++ b/src/routes/_authenticated/secret-inventory/index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretInventoryPage } from '@/features/secret-inventory'
+
+export const Route = createFileRoute('/_authenticated/secret-inventory/')({
+  component: SecretInventoryPage,
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -59,6 +59,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Setup',
   },
   {
+    path: '/secret-inventory',
+    heading: /^Secret inventory$/i,
+    title: 'Service Admin - Secret Inventory',
+  },
+  {
     path: '/secrets-policy-simulation',
     heading: /^Secrets Broker policy simulation$/i,
     title: 'Service Admin - Secrets Policy Simulation',


### PR DESCRIPTION
## Summary

Implements the bounded metadata-first inventory/table view for service-lasso/lasso-serviceadmin#39.

- Adds `/secret-inventory` as a deterministic local fixture/stub Secrets Broker inventory surface.
- Renders namespace/ref id, source/backend, owner/service/workspace, secret presence state, key version, last updated/used, expiry/rotation status, and adjacent metadata links.
- Documents the metadata-only boundary in `docs/secret-inventory.md`.
- Adds nav and route/app-screen coverage.
- Adds tests for local fixture rendering, no plaintext/privileged controls, state counts, fixture secret-safety scanning, and large-list fixture behavior.

## Safety boundaries

This PR does not implement plaintext rendering, raw reveal controls, clipboard value actions, backend secret reads/writes, bulk edit, bulk rotation, provider credential access, arbitrary password-vault behavior, or backend enforcement claims.

## Validation

- `npm test -- --run src/features/secret-inventory/secret-inventory.test.tsx src/test/app-screens.test.tsx` — PASS, 28 tests
- `npx prettier --write docs/secret-inventory.md src/features/secret-inventory/index.tsx src/features/secret-inventory/secret-inventory.ts src/features/secret-inventory/secret-inventory.test.tsx src/routes/_authenticated/secret-inventory/index.tsx src/components/layout/data/sidebar-data.ts src/test/app-screens.test.tsx src/routeTree.gen.ts` — PASS
- `npm run format:check` — PASS
- `npm run lint` — PASS with existing warnings only; no errors
- `npm test` — PASS, 95 tests
- `npm run build` — PASS
- `git diff --check` — PASS

## Merge status

Holding merge pending independent validation/review approval.
