### PR TITLE
ISS-71 add Secrets Broker navigation section

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -1,14 +1,18 @@
 import {
   Boxes,
   Building2,
+  ClipboardCheck,
   Command,
   DatabaseZap,
+  FileKey2,
   GitBranch,
   Globe,
   KeyRound,
   LifeBuoy,
   LockKeyhole,
+  Network,
   Scale,
+  ShieldCheck,
   SlidersHorizontal,
   HardDrive,
   HelpCircle,
@@ -78,21 +82,6 @@ export const sidebarData: SidebarData = {
           icon: SlidersHorizontal,
         },
         {
-          title: 'Secrets Broker',
-          url: '/secrets-broker',
-          icon: KeyRound,
-        },
-        {
-          title: 'Secret Inventory',
-          url: '/secret-inventory',
-          icon: DatabaseZap,
-        },
-        {
-          title: 'Policy Simulation',
-          url: '/secrets-policy-simulation',
-          icon: Scale,
-        },
-        {
           title: 'ZITADEL Session',
           url: '/auth-session',
           icon: LockKeyhole,
@@ -106,6 +95,67 @@ export const sidebarData: SidebarData = {
           title: 'Network',
           url: '/network',
           icon: Globe,
+        },
+      ],
+    },
+    {
+      title: 'Secrets Broker',
+      items: [
+        {
+          title: 'Secrets Broker',
+          icon: KeyRound,
+          items: [
+            {
+              title: 'Overview / Setup',
+              url: '/secrets-broker',
+              icon: ShieldCheck,
+            },
+            {
+              title: 'Sources / Backends',
+              url: '/secrets-broker#secret-sources',
+              icon: DatabaseZap,
+            },
+            {
+              title: 'Provider Connections',
+              url: '/secrets-broker#provider-connections',
+              icon: KeyRound,
+            },
+            {
+              title: 'Backup / Keys',
+              url: '/secrets-broker#backup-key-management',
+              icon: FileKey2,
+            },
+            {
+              title: 'Workflow Boundaries',
+              url: '/secrets-broker#workflow-authoring-boundary',
+              icon: ClipboardCheck,
+            },
+            {
+              title: 'Topology',
+              url: '/secrets-broker#secrets-topology',
+              icon: Network,
+            },
+            {
+              title: 'Audit / Events',
+              url: '/secrets-broker#audit-events',
+              icon: GitBranch,
+            },
+            {
+              title: 'Diagnostics',
+              url: '/secrets-broker#diagnostics',
+              icon: LifeBuoy,
+            },
+          ],
+        },
+        {
+          title: 'Secret Inventory',
+          url: '/secret-inventory',
+          icon: DatabaseZap,
+        },
+        {
+          title: 'Policy Simulation',
+          url: '/secrets-policy-simulation',
+          icon: Scale,
         },
       ],
     },

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -58,7 +58,8 @@ test.describe('Secrets Broker browser coverage', () => {
     page,
   }) => {
     await page.goto('/')
-    await page.getByRole('link', { name: /^Secrets Broker$/ }).click()
+    await page.getByRole('button', { name: /^Secrets Broker$/ }).click()
+    await page.getByRole('link', { name: 'Overview / Setup' }).click()
 
     await expect(page).toHaveURL(/\/secrets-broker$/)
     await expectNoBlankScreen(page)
@@ -70,7 +71,7 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText('Secret Sources / Backends', { exact: true })
     ).toBeVisible()
     await expect(
-      page.getByText('Provider Connections', { exact: true })
+      page.locator('main').getByText('Provider Connections', { exact: true })
     ).toBeVisible()
     await expect(
       page.getByText('Audit and events', { exact: true })
@@ -81,6 +82,43 @@ test.describe('Secrets Broker browser coverage', () => {
     await expectNoSecretMaterial(page)
     await expect(page.getByText(/values hidden/i).first()).toBeVisible()
     await expect(page.getByText(/raw output scrubbed/i).first()).toBeVisible()
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('dedicated Secrets Broker navigation reaches each broker sub-page', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: /^Secrets Broker$/ }).click()
+
+    const navLinks = [
+      ['Overview / Setup', /\/secrets-broker$/],
+      ['Sources / Backends', /\/secrets-broker#secret-sources$/],
+      ['Provider Connections', /\/secrets-broker#provider-connections$/],
+      ['Backup / Keys', /\/secrets-broker#backup-key-management$/],
+      ['Workflow Boundaries', /\/secrets-broker#workflow-authoring-boundary$/],
+      ['Topology', /\/secrets-broker#secrets-topology$/],
+      ['Audit / Events', /\/secrets-broker#audit-events$/],
+      ['Diagnostics', /\/secrets-broker#diagnostics$/],
+    ] as const
+
+    for (const [name, urlPattern] of navLinks) {
+      await page
+        .locator('[data-sidebar="menu-sub-button"]')
+        .filter({ hasText: name })
+        .first()
+        .click()
+      await expect(page).toHaveURL(urlPattern)
+      await expectNoBlankScreen(page)
+      await expectNoSecretMaterial(page)
+    }
+
+    await expect(
+      page.getByRole('link', { name: 'Secret Inventory' })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: 'Policy Simulation' })
+    ).toBeVisible()
     expect(consoleErrors).toEqual([])
   })
 
@@ -121,6 +159,9 @@ test.describe('Secrets Broker browser coverage', () => {
     const sections = [
       ['secret-sources', /Secret Sources \/ Backends/i],
       ['provider-connections', /Provider Connections/i],
+      ['backup-key-management', /Backup, restore, and key management/i],
+      ['workflow-authoring-boundary', /Workflow authoring boundary/i],
+      ['secrets-topology', /Secrets Broker topology/i],
       ['audit-events', /Audit and events/i],
       ['diagnostics', /Diagnostics and troubleshooting/i],
     ] as const

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -134,7 +134,9 @@ test('runtime, network, installed, and variables tables render', async ({
 
   await page.goto('/installed')
   await expect(page.getByRole('heading', { name: 'Installed' })).toBeVisible()
-  await expect(page.getByText('Installed services')).toBeVisible()
+  await expect(
+    page.getByText('Installed services', { exact: true })
+  ).toBeVisible()
   await expect(
     page.getByRole('cell', { name: 'lasso-@serviceadmin', exact: true })
   ).toBeVisible()


### PR DESCRIPTION
## Summary
- Add a dedicated `Secrets Broker` sidebar section with stable links for overview/setup, sources/backends, provider connections, backup/keys, workflow boundaries, topology, audit/events, and diagnostics.
- Move broker-adjacent `Secret Inventory` and `Policy Simulation` links into the same dedicated section for discoverability.
- Extend Playwright UI coverage for the dedicated navigation section, nav-driven reachability, and representative deep links across broker surfaces.
- Preserve metadata-only/secret-safe assertions in the browser coverage.

## Validation
- `npm run format:check` ✅
- `npm run lint` ✅ (existing warnings only: TanStack Table React Compiler warnings and logs hook dependency warnings)
- `npm test` ✅ (95 passed)
- `npm run build` ✅
- `npm run test:ui` ✅ (7 passed)
- `git diff --check` ✅

Closes #71
