### PR TITLE
ISS-38 add controlled single-secret reveal

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -121,6 +121,11 @@ export const sidebarData: SidebarData = {
               icon: KeyRound,
             },
             {
+              title: 'Single Reveal',
+              url: '/secrets-broker#privileged-secret-reveal',
+              icon: LockKeyhole,
+            },
+            {
               title: 'Backup / Keys',
               url: '/secrets-broker#backup-key-management',
               icon: FileKey2,

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -56,6 +56,11 @@ import {
   type SecretsBrokerProviderLifecycleStatus,
 } from './provider-connections'
 import {
+  singleSecretRevealReference,
+  singleSecretRevealScenarios,
+  type SingleSecretRevealState,
+} from './single-secret-reveal'
+import {
   countSourceBackendsByState,
   secretsBrokerSourceBackends,
   type SecretsBrokerSourceBackend,
@@ -1059,6 +1064,202 @@ function DiagnosticCard({
   )
 }
 
+function PrivilegedSecretRevealPanel({
+  scenarioId,
+  revealed,
+  onScenarioChange,
+  onReveal,
+  onHide,
+}: {
+  scenarioId: SingleSecretRevealState
+  revealed: boolean
+  onScenarioChange: (state: SingleSecretRevealState) => void
+  onReveal: () => void
+  onHide: (state: SingleSecretRevealState) => void
+}) {
+  const scenario =
+    singleSecretRevealScenarios.find((item) => item.id === scenarioId) ??
+    singleSecretRevealScenarios[0]
+  const ref = singleSecretRevealReference
+  const showValue = scenario.id === 'allowed' && revealed
+
+  return (
+    <Card id='privileged-secret-reveal'>
+      <CardHeader>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <div>
+            <CardTitle className='flex items-center gap-2'>
+              <LockKeyhole className='size-4' /> Privileged single-secret reveal
+            </CardTitle>
+            <CardDescription>
+              Controlled Service Admin to Secrets Broker reveal flow for one
+              selected ref. Default state is redacted; reveal is explicit,
+              short-lived, fail-closed, and auditable.
+            </CardDescription>
+          </div>
+          <Badge variant={scenario.canReveal ? 'default' : 'outline'}>
+            {scenario.badge}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <div className='max-w-xs'>
+          <label
+            htmlFor='single-secret-reveal-state'
+            className='mb-1 block text-xs text-muted-foreground'
+          >
+            Reveal workflow state
+          </label>
+          <select
+            id='single-secret-reveal-state'
+            className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+            value={scenarioId}
+            onChange={(event) =>
+              onScenarioChange(event.target.value as SingleSecretRevealState)
+            }
+          >
+            {singleSecretRevealScenarios.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className='grid gap-4 lg:grid-cols-[1.1fr_0.9fr]'>
+          <div className='rounded-lg border p-4 text-sm'>
+            <div className='mb-3 flex items-center gap-2 font-medium'>
+              <KeyRound className='size-4' /> Selected safe metadata
+            </div>
+            <div className='grid gap-3 sm:grid-cols-2'>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Ref
+                </div>
+                <div className='break-all'>{ref.ref}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Secret name
+                </div>
+                <div>{ref.name}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Owning service
+                </div>
+                <div>{ref.owningService}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Provider / source
+                </div>
+                <div>
+                  {ref.provider} � {ref.source}
+                </div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Last updated
+                </div>
+                <div>{ref.lastUpdatedAt}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Policy
+                </div>
+                <div className='break-all'>{ref.policy}</div>
+              </div>
+            </div>
+          </div>
+
+          <div className='rounded-lg border p-4 text-sm'>
+            <div className='mb-3 flex items-center gap-2 font-medium'>
+              <ShieldCheck className='size-4' /> Reveal control
+            </div>
+            <div className='space-y-3'>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Status
+                </div>
+                <div>{scenario.status}</div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Raw value
+                </div>
+                {showValue ? (
+                  <div
+                    className='mt-1 rounded-md border border-destructive/40 bg-destructive/10 p-2 font-mono text-sm'
+                    aria-live='polite'
+                  >
+                    {ref.fakeRawValue}
+                  </div>
+                ) : (
+                  <div className='mt-1 rounded-md border bg-muted/50 p-2 font-mono text-sm'>
+                    ������������
+                  </div>
+                )}
+              </div>
+              <p className='text-muted-foreground'>{scenario.reason}</p>
+              <div className='rounded-md bg-muted/40 p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Audit/status feedback
+                </div>
+                <div>
+                  {showValue
+                    ? `Audit event recorded: ${ref.auditEventId}`
+                    : scenario.auditStatus}
+                </div>
+              </div>
+              {showValue ? (
+                <div className='text-xs text-muted-foreground'>
+                  Reveal window expires in 60 seconds. The value re-hides on
+                  timeout, cancel, navigation away, or refresh. Copy/export is
+                  disabled for this story.
+                </div>
+              ) : (
+                <div className='text-xs text-muted-foreground'>
+                  {scenario.nextAction}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className='flex flex-wrap gap-2'>
+          <Button
+            type='button'
+            disabled={!scenario.canReveal || revealed}
+            onClick={onReveal}
+          >
+            Reveal secret value
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            disabled={!revealed}
+            onClick={() => onHide('cancelled')}
+          >
+            Cancel reveal
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            disabled={!revealed}
+            onClick={() => onHide('expired')}
+          >
+            Expire reveal window
+          </Button>
+          <Badge variant='secondary'>Bulk reveal disabled</Badge>
+          <Badge variant='outline'>Copy disabled</Badge>
+          <Badge variant='outline'>No route/query value material</Badge>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 export function SecretsBrokerSetupWizard() {
   usePageMetadata({
     title: 'Service Admin - Secrets Broker Setup',
@@ -1090,6 +1291,9 @@ export function SecretsBrokerSetupWizard() {
   const [connectionQueryFilter, setConnectionQueryFilter] = useState('')
   const [overviewScenarioId, setOverviewScenarioId] =
     useState<SecretsBrokerOverviewState>('healthy')
+  const [singleSecretRevealState, setSingleSecretRevealState] =
+    useState<SingleSecretRevealState>('hidden')
+  const [singleSecretRevealed, setSingleSecretRevealed] = useState(false)
   const [selectedWorkflowBoundaryId, setSelectedWorkflowBoundaryId] = useState(
     workflowAuthoringBoundaries[0].id
   )
@@ -1405,6 +1609,20 @@ export function SecretsBrokerSetupWizard() {
             </CardContent>
           </Card>
         </div>
+
+        <PrivilegedSecretRevealPanel
+          scenarioId={singleSecretRevealState}
+          revealed={singleSecretRevealed}
+          onScenarioChange={(state) => {
+            setSingleSecretRevealState(state)
+            setSingleSecretRevealed(false)
+          }}
+          onReveal={() => setSingleSecretRevealed(true)}
+          onHide={(state) => {
+            setSingleSecretRevealState(state)
+            setSingleSecretRevealed(false)
+          }}
+        />
 
         <BackupKeyManagementPanel />
 

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -16,6 +16,12 @@ import {
   secretsBrokerProviderConnections,
 } from './provider-connections'
 import {
+  revealFixtureLooksLikeProviderCredential,
+  revealSafeSurfacesIncludeRawValue,
+  singleSecretRevealReference,
+  singleSecretRevealScenarios,
+} from './single-secret-reveal'
+import {
   secretsBrokerSourceBackends,
   sourceBackendHasSecretValue,
 } from './source-backends'
@@ -125,6 +131,142 @@ describe('Secrets Broker setup wizard', () => {
     ).toBeVisible()
     expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
   }, 10000)
+
+  it('renders privileged single-secret reveal default and fail-closed states without raw material', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    expect(screen.getByText(/Privileged single-secret reveal/i)).toBeVisible()
+    expect(screen.getByText(/Selected safe metadata/i)).toBeVisible()
+    expect(screen.getByText(singleSecretRevealReference.ref)).toBeVisible()
+    expect(screen.getByText(singleSecretRevealReference.name)).toBeVisible()
+    expect(
+      screen.getAllByText(singleSecretRevealReference.owningService)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Value hidden by default/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Reveal secret value/i })
+    ).toBeDisabled()
+    expect(screen.getByText(/Bulk reveal disabled/i)).toBeVisible()
+    expect(screen.getByText(/Copy disabled/i)).toBeVisible()
+    expect(screen.getByText(/No route\/query value material/i)).toBeVisible()
+    expect(
+      screen.queryByText(singleSecretRevealReference.fakeRawValue)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Copy secret/i })
+    ).not.toBeInTheDocument()
+
+    const blockedStates = [
+      [
+        'auth-required',
+        /Reveal blocked until operator authorization completes/i,
+      ],
+      ['policy-denied', /Reveal denied by policy/i],
+      [
+        'broker-offline',
+        /Reveal unavailable because @secretsbroker is offline/i,
+      ],
+      [
+        'unconfigured',
+        /Reveal unavailable until a source\/backend is configured/i,
+      ],
+      [
+        'audit-unavailable',
+        /Reveal blocked because audit recording is unavailable/i,
+      ],
+    ] as const
+
+    for (const [state, status] of blockedStates) {
+      await user.selectOptions(
+        screen.getByLabelText(/Reveal workflow state/i),
+        state
+      )
+      expect(screen.getByText(status)).toBeVisible()
+      expect(
+        screen.getByRole('button', { name: /Reveal secret value/i })
+      ).toBeDisabled()
+      expect(
+        screen.queryByText(singleSecretRevealReference.fakeRawValue)
+      ).not.toBeInTheDocument()
+    }
+  }, 10000)
+
+  it('reveals deterministic fake material only after explicit action and re-hides on cancel or expiry', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Reveal workflow state/i),
+      'allowed'
+    )
+    expect(
+      screen.getByText(/Ready for explicit, time-limited reveal/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByText(singleSecretRevealReference.fakeRawValue)
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /Reveal secret value/i })
+    )
+    expect(
+      screen.getByText(singleSecretRevealReference.fakeRawValue)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Audit event recorded: audit-reveal-001/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Reveal window expires in 60 seconds/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: /Copy secret/i })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /Cancel reveal/i }))
+    expect(
+      screen.getByText(/Reveal cancelled; value remains hidden/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByText(singleSecretRevealReference.fakeRawValue)
+    ).not.toBeInTheDocument()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Reveal workflow state/i),
+      'allowed'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Reveal secret value/i })
+    )
+    expect(
+      screen.getByText(singleSecretRevealReference.fakeRawValue)
+    ).toBeVisible()
+    await user.click(
+      screen.getByRole('button', { name: /Expire reveal window/i })
+    )
+    expect(
+      screen.getByText(/Reveal window expired; value re-hidden/i)
+    ).toBeVisible()
+    expect(
+      screen.queryByText(singleSecretRevealReference.fakeRawValue)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps single-secret reveal safe surfaces free of raw material', () => {
+    expect(singleSecretRevealScenarios.map((scenario) => scenario.id)).toEqual([
+      'hidden',
+      'auth-required',
+      'policy-denied',
+      'broker-offline',
+      'unconfigured',
+      'audit-unavailable',
+      'allowed',
+      'cancelled',
+      'expired',
+    ])
+    expect(revealSafeSurfacesIncludeRawValue()).toBe(false)
+    expect(revealFixtureLooksLikeProviderCredential()).toBe(false)
+  })
 
   it('renders backup restore and key-management metadata without raw material', async () => {
     await renderRoute('/secrets-broker')
@@ -488,9 +630,7 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getAllByText(/refresh failure/i)[0]).toBeVisible()
     expect(screen.getAllByText(/session token revoked/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Event detail/i)[0]).toBeVisible()
-    expect(
-      screen.getByText(/policy\/openclaw\/service-lasso\/read/i)
-    ).toBeVisible()
+    expect(screen.getByText('policy/openclaw/service-lasso/read')).toBeVisible()
     expect(screen.getByText(/Resolver granted access/i)).toBeVisible()
 
     await user.selectOptions(screen.getByLabelText(/Outcome/i), 'denied')

--- a/src/features/secrets-broker/single-secret-reveal.ts
+++ b/src/features/secrets-broker/single-secret-reveal.ts
@@ -1,0 +1,181 @@
+export type SingleSecretRevealState =
+  | 'hidden'
+  | 'auth-required'
+  | 'policy-denied'
+  | 'broker-offline'
+  | 'unconfigured'
+  | 'audit-unavailable'
+  | 'allowed'
+  | 'cancelled'
+  | 'expired'
+
+export type SingleSecretRevealReference = {
+  id: string
+  ref: string
+  name: string
+  owningService: string
+  provider: string
+  source: string
+  lastUpdatedAt: string
+  policy: string
+  auditEventId: string
+  fakeRawValue: string
+}
+
+export type SingleSecretRevealScenario = {
+  id: SingleSecretRevealState
+  label: string
+  badge: string
+  canReveal: boolean
+  status: string
+  reason: string
+  auditStatus: string
+  nextAction: string
+}
+
+export const singleSecretRevealReference: SingleSecretRevealReference = {
+  id: 'serviceadmin-session-signing',
+  ref: 'secret://local/default/@serviceadmin/SESSION_SIGNING_KEY',
+  name: 'SESSION_SIGNING_KEY',
+  owningService: '@serviceadmin',
+  provider: 'local encrypted store',
+  source: 'local-default',
+  lastUpdatedAt: '2026-05-08T10:44:00Z',
+  policy: 'policy/openclaw/service-lasso/read-single-secret',
+  auditEventId: 'audit-reveal-001',
+  fakeRawValue: 'DEMO_REVEAL_VALUE_42',
+}
+
+export const singleSecretRevealScenarios: SingleSecretRevealScenario[] = [
+  {
+    id: 'hidden',
+    label: 'Hidden / default',
+    badge: 'Hidden',
+    canReveal: false,
+    status: 'Value hidden by default',
+    reason:
+      'Select a safe metadata ref, review the owner/provider/policy context, then request a privileged reveal.',
+    auditStatus: 'No reveal requested',
+    nextAction: 'Review metadata before requesting reveal authorization.',
+  },
+  {
+    id: 'auth-required',
+    label: 'Authorization required',
+    badge: 'Auth required',
+    canReveal: false,
+    status: 'Reveal blocked until operator authorization completes',
+    reason:
+      'The broker requires a fresh privileged operator authorization before resolving this ref.',
+    auditStatus: 'Authorization challenge pending',
+    nextAction:
+      'Complete privileged authorization and retry the reveal request.',
+  },
+  {
+    id: 'policy-denied',
+    label: 'Policy denied',
+    badge: 'Policy denied',
+    canReveal: false,
+    status: 'Reveal denied by policy',
+    reason:
+      'The active Service Admin identity is not allowed to reveal this ref under the current policy decision.',
+    auditStatus: 'Denied event recorded without value material',
+    nextAction:
+      'Escalate policy ownership; do not bypass through diagnostics or exports.',
+  },
+  {
+    id: 'broker-offline',
+    label: 'Broker offline',
+    badge: 'Broker offline',
+    canReveal: false,
+    status: 'Reveal unavailable because @secretsbroker is offline',
+    reason:
+      'Service Admin cannot reach the broker API, so it must fail closed and keep the value hidden.',
+    auditStatus: 'No reveal event emitted while broker is unreachable',
+    nextAction: 'Restore broker health before attempting a reveal.',
+  },
+  {
+    id: 'unconfigured',
+    label: 'Broker unconfigured',
+    badge: 'Setup needed',
+    canReveal: false,
+    status: 'Reveal unavailable until a source/backend is configured',
+    reason:
+      'The selected ref has metadata, but no configured source can resolve it safely.',
+    auditStatus: 'Setup-required status only',
+    nextAction:
+      'Configure a source/backend; raw values stay hidden during setup.',
+  },
+  {
+    id: 'audit-unavailable',
+    label: 'Audit unavailable / blocked',
+    badge: 'Audit blocked',
+    canReveal: false,
+    status: 'Reveal blocked because audit recording is unavailable',
+    reason:
+      'Privileged reveal requires a durable audit event before any value can be displayed.',
+    auditStatus: 'Audit sink unavailable; reveal refused',
+    nextAction: 'Restore audit recording before retrying.',
+  },
+  {
+    id: 'allowed',
+    label: 'Reveal allowed',
+    badge: 'Allowed',
+    canReveal: true,
+    status: 'Ready for explicit, time-limited reveal',
+    reason:
+      'Policy allowed the selected single ref, broker health is good, and audit recording is available.',
+    auditStatus: 'Reveal audit will be recorded before display',
+    nextAction: 'Click reveal only when the operator needs the value now.',
+  },
+  {
+    id: 'cancelled',
+    label: 'Cancelled reveal',
+    badge: 'Cancelled',
+    canReveal: false,
+    status: 'Reveal cancelled; value remains hidden',
+    reason:
+      'The operator cancelled before display. No raw material was fetched or rendered.',
+    auditStatus: 'Cancellation status recorded without value material',
+    nextAction: 'Start a new explicit reveal request if still required.',
+  },
+  {
+    id: 'expired',
+    label: 'Reveal expired / re-hidden',
+    badge: 'Expired',
+    canReveal: false,
+    status: 'Reveal window expired; value re-hidden',
+    reason:
+      'The short-lived display window has ended. Service Admin discards visible raw material.',
+    auditStatus: 'Expiry recorded; value no longer visible',
+    nextAction: 'Request a new reveal if the operator still has a valid need.',
+  },
+]
+
+export const singleSecretRevealSafeSurfaces = {
+  route: '/secrets-broker#privileged-secret-reveal',
+  pageTitle: 'Secrets Broker setup',
+  breadcrumb: 'Secrets Broker / privileged single-secret reveal',
+  diagnostics:
+    'reveal_status=redacted; selected_ref=metadata_only; raw_value=hidden',
+  supportBundle:
+    'single_secret_reveal: ref metadata, policy outcome, and audit status only; raw value omitted',
+  consoleEvents: [
+    'single-secret-reveal:selected-ref-metadata',
+    'single-secret-reveal:audit-status-updated',
+  ],
+  persistedStorage: 'none',
+}
+
+const providerCredentialPattern =
+  /(sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
+
+export function revealSafeSurfacesIncludeRawValue(): boolean {
+  const surfaceText = JSON.stringify(singleSecretRevealSafeSurfaces)
+  return surfaceText.includes(singleSecretRevealReference.fakeRawValue)
+}
+
+export function revealFixtureLooksLikeProviderCredential(): boolean {
+  return providerCredentialPattern.test(
+    singleSecretRevealReference.fakeRawValue
+  )
+}

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page, type TestInfo } from '@playwright/test'
 
+const fakeRevealValue = 'DEMO_REVEAL_VALUE_42'
+
 const forbiddenSecretMaterialPatterns = [
   /-----BEGIN (?:RSA |EC |OPENSSH |PGP )?PRIVATE KEY-----/i,
   /\bAKIA[0-9A-Z]{16}\b/,
@@ -47,6 +49,9 @@ test.describe('Secrets Broker browser coverage', () => {
         body: consoleErrors.join('\n') || '(none)',
         contentType: 'text/plain',
       })
+      if ((await page.locator('body').innerText()).includes(fakeRevealValue)) {
+        await page.goto('/secrets-broker')
+      }
       await testInfo.attach('failure-screenshot', {
         body: await page.screenshot({ fullPage: true }),
         contentType: 'image/png',
@@ -95,6 +100,7 @@ test.describe('Secrets Broker browser coverage', () => {
       ['Overview / Setup', /\/secrets-broker$/],
       ['Sources / Backends', /\/secrets-broker#secret-sources$/],
       ['Provider Connections', /\/secrets-broker#provider-connections$/],
+      ['Single Reveal', /\/secrets-broker#privileged-secret-reveal$/],
       ['Backup / Keys', /\/secrets-broker#backup-key-management$/],
       ['Workflow Boundaries', /\/secrets-broker#workflow-authoring-boundary$/],
       ['Topology', /\/secrets-broker#secrets-topology$/],
@@ -153,10 +159,68 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
+  test('reveals one broker secret only after explicit action and re-hides safely', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker#privileged-secret-reveal')
+    await expectNoBlankScreen(page)
+    await expect(
+      page.getByText(/Privileged single-secret reveal/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Value hidden by default/i)).toBeVisible()
+    await expect(
+      page.getByText('SESSION_SIGNING_KEY', { exact: true })
+    ).toBeVisible()
+    await expect(page.getByText(fakeRevealValue)).toHaveCount(0)
+    await expect(
+      page.getByRole('button', { name: /Reveal secret value/i })
+    ).toBeDisabled()
+
+    const revealState = page.locator('#single-secret-reveal-state')
+    for (const state of [
+      'auth-required',
+      'policy-denied',
+      'broker-offline',
+      'unconfigured',
+      'audit-unavailable',
+    ]) {
+      await revealState.selectOption(state)
+      await expect(
+        page.getByRole('button', { name: /Reveal secret value/i })
+      ).toBeDisabled()
+      await expect(page.getByText(fakeRevealValue)).toHaveCount(0)
+    }
+
+    await revealState.selectOption('allowed')
+    await expect(
+      page.getByRole('button', { name: /Reveal secret value/i })
+    ).toBeEnabled()
+    await page.getByRole('button', { name: /Reveal secret value/i }).click()
+    await expect(page.getByText(fakeRevealValue)).toBeVisible()
+    await expect(
+      page.getByText(/Audit event recorded: audit-reveal-001/i)
+    ).toBeVisible()
+    await expect(page).toHaveURL(/\/secrets-broker#privileged-secret-reveal$/)
+    expect(page.url()).not.toContain(fakeRevealValue)
+    expect(consoleErrors.join('\n')).not.toContain(fakeRevealValue)
+    await expect(
+      page.getByRole('button', { name: /Copy secret/i })
+    ).toHaveCount(0)
+
+    await page.getByRole('button', { name: /Expire reveal window/i }).click()
+    await expect(
+      page.getByText(/Reveal window expired; value re-hidden/i)
+    ).toBeVisible()
+    await expect(page.getByText(fakeRevealValue)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+    expect(consoleErrors).toEqual([])
+  })
+
   test('deep-links to broker surfaces and provider detail with safe metadata only', async ({
     page,
   }) => {
     const sections = [
+      ['privileged-secret-reveal', /Privileged single-secret reveal/i],
       ['secret-sources', /Secret Sources \/ Backends/i],
       ['provider-connections', /Provider Connections/i],
       ['backup-key-management', /Backup, restore, and key management/i],


### PR DESCRIPTION
## Summary
- Add a focused privileged single-secret reveal panel to the Secrets Broker setup surface.
- Show safe selected-ref metadata before reveal: ref, name, owning service, provider/source, last updated timestamp, and policy.
- Model fail-closed reveal states: hidden/default, authorization required, policy denied, broker offline, broker unconfigured, audit unavailable/blocked, cancelled, and expired/re-hidden.
- Add an allowed reveal path that displays deterministic fake material only after explicit operator action, then re-hides on cancel/expiry.
- Keep copy/export/bulk reveal disabled and model no-leak surfaces for route/title/breadcrumb/diagnostics/support bundle/console/persistent storage.
- Add Secrets Broker sidebar/deep-link coverage for the single reveal section.

## Validation
- `npm run format:check` ✅
- `npm run lint` ✅ (existing warnings only: TanStack Table React Compiler warnings and logs hook dependency warnings)
- `npm test` ✅ (98 passed)
- `npm run build` ✅
- `npm run test:ui` ✅ (8 passed)
- `git diff --check` ✅

## Safety notes
- Uses deterministic fake reveal material only: `DEMO_REVEAL_VALUE_42`.
- The fake value is asserted absent from default, denied, offline, unconfigured, audit-blocked, cancelled, expired, route, console, diagnostics/support-bundle modeled safe surfaces, and post-expiry rendering.
- Copy-to-clipboard, bulk reveal, mutation/edit/rotation, provider credential management, and backend enforcement claims remain out of scope.

Closes #38
