### PR TITLE
Add Secrets Broker Secrets management page

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -111,6 +111,11 @@ export const sidebarData: SidebarData = {
               icon: ShieldCheck,
             },
             {
+              title: 'Secrets',
+              url: '/secrets-broker/secrets',
+              icon: DatabaseZap,
+            },
+            {
               title: 'Sources / Backends',
               url: '/secrets-broker#secret-sources',
               icon: DatabaseZap,

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1,0 +1,445 @@
+import { useMemo, useState } from 'react'
+import {
+  DatabaseZap,
+  Eye,
+  RotateCcw,
+  SearchIcon,
+  ShieldCheck,
+  SlidersHorizontal,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  buildManagedSecretActionPreview,
+  filterManagedSecrets,
+  managedSecretRows,
+  managedSecretSafetyBoundaries,
+  valueSearchManagedSecrets,
+  type ManagedSecretAction,
+  type ManagedSecretState,
+} from './secrets-management'
+
+const stateVariant: Record<
+  ManagedSecretState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  present: 'default',
+  missing: 'destructive',
+  stale: 'secondary',
+  'rotation-due': 'outline',
+}
+
+export function SecretsManagementPage() {
+  const [metadataQuery, setMetadataQuery] = useState('')
+  const [stateFilter, setStateFilter] = useState<ManagedSecretState | 'all'>(
+    'all'
+  )
+  const [valueQuery, setValueQuery] = useState('')
+  const [valueSearchSupported, setValueSearchSupported] = useState(false)
+  const [selectedRowId, setSelectedRowId] = useState(managedSecretRows[0].id)
+  const [selectedAction, setSelectedAction] =
+    useState<ManagedSecretAction>('metadata')
+
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Secrets',
+    description:
+      'Searchable metadata-first Secrets Broker management table for controlled reveal, dry-run edit/reset, and policy preview actions.',
+  })
+
+  const filteredRows = useMemo(
+    () => filterManagedSecrets(managedSecretRows, metadataQuery, stateFilter),
+    [metadataQuery, stateFilter]
+  )
+  const valueSearchRows = useMemo(
+    () =>
+      valueSearchManagedSecrets(
+        managedSecretRows,
+        valueQuery,
+        valueSearchSupported
+      ),
+    [valueQuery, valueSearchSupported]
+  )
+  const selectedRow =
+    managedSecretRows.find((row) => row.id === selectedRowId) ??
+    managedSecretRows[0]
+  const actionPreview = buildManagedSecretActionPreview(
+    selectedRow,
+    selectedAction
+  )
+
+  function chooseAction(rowId: string, action: ManagedSecretAction) {
+    setSelectedRowId(rowId)
+    setSelectedAction(action)
+  }
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <DatabaseZap className='size-5' /> Secrets
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Secrets Broker management table for safe metadata search,
+              controlled reveal entry, and dry-run edit/reset/policy actions.
+              Rows never render raw secret values.
+            </p>
+          </div>
+          <Badge variant='secondary'>Metadata table · values hidden</Badge>
+        </div>
+
+        <Alert>
+          <ShieldCheck className='size-4' />
+          <AlertTitle>Controlled management surface</AlertTitle>
+          <AlertDescription>
+            Metadata search is local over safe refs and labels only.
+            Broker-backed value search, when supported, returns matching
+            refs/metadata only. Reveal delegates to the audited #38 pattern;
+            edit, reset, and policy changes require dry-run/preview before
+            apply.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-4'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Total refs</CardDescription>
+              <CardTitle className='text-3xl'>
+                {managedSecretRows.length}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Visible values</CardDescription>
+              <CardTitle className='text-3xl'>0</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Dry-run actions</CardDescription>
+              <CardTitle className='text-3xl'>3</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Bulk mutations</CardDescription>
+              <CardTitle className='text-3xl'>0</CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <SearchIcon className='size-4' /> Search and value-search posture
+            </CardTitle>
+            <CardDescription>
+              Metadata search never reads plaintext. Value search is explicitly
+              broker-backed and returns refs/metadata only when supported.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-4 lg:grid-cols-2'>
+            <div className='space-y-2'>
+              <label
+                htmlFor='metadata-search'
+                className='text-sm font-medium text-muted-foreground'
+              >
+                Metadata search
+              </label>
+              <Input
+                id='metadata-search'
+                value={metadataQuery}
+                onChange={(event) => setMetadataQuery(event.target.value)}
+                placeholder='Search ref, owner, provider, tag, workspace'
+              />
+              <div className='max-w-xs'>
+                <label
+                  htmlFor='state-filter'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  State filter
+                </label>
+                <select
+                  id='state-filter'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={stateFilter}
+                  onChange={(event) =>
+                    setStateFilter(
+                      event.target.value as ManagedSecretState | 'all'
+                    )
+                  }
+                >
+                  <option value='all'>All states</option>
+                  <option value='present'>Present</option>
+                  <option value='rotation-due'>Rotation due</option>
+                  <option value='stale'>Stale</option>
+                  <option value='missing'>Missing</option>
+                </select>
+              </div>
+              <div className='text-sm text-muted-foreground'>
+                Metadata matches: {filteredRows.length}
+              </div>
+            </div>
+
+            <div className='space-y-2'>
+              <label
+                htmlFor='value-search'
+                className='text-sm font-medium text-muted-foreground'
+              >
+                Broker-backed value search
+              </label>
+              <Input
+                id='value-search'
+                value={valueQuery}
+                onChange={(event) => setValueQuery(event.target.value)}
+                placeholder='Broker receives search request; UI receives refs only'
+              />
+              <div className='flex flex-wrap gap-2'>
+                <Button
+                  type='button'
+                  variant={valueSearchSupported ? 'default' : 'outline'}
+                  onClick={() => setValueSearchSupported(true)}
+                >
+                  Simulate supported value search
+                </Button>
+                <Button
+                  type='button'
+                  variant={!valueSearchSupported ? 'default' : 'outline'}
+                  onClick={() => setValueSearchSupported(false)}
+                >
+                  Simulate unsupported value search
+                </Button>
+              </div>
+              <div className='rounded-md border p-3 text-sm'>
+                {valueSearchSupported ? (
+                  <div>
+                    Value search supported: {valueSearchRows.length} safe ref
+                    metadata match
+                    {valueSearchRows.length === 1 ? '' : 'es'} returned; raw
+                    values are never returned to the table.
+                  </div>
+                ) : (
+                  <div>
+                    Value search unsupported by this broker/source; the table
+                    fails closed and keeps raw values hidden.
+                  </div>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Secrets management table</CardTitle>
+            <CardDescription>
+              Searchable safe metadata rows with controlled row actions. Apply
+              controls are represented as dry-run/preview states, not direct
+              mutation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className='overflow-x-auto rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Secret ref</TableHead>
+                    <TableHead>Owner / provider</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Policy / audit</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredRows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell className='min-w-80 align-top'>
+                        <div className='font-medium'>{row.name}</div>
+                        <div className='text-sm break-all text-muted-foreground'>
+                          {row.ref}
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {row.safeTags.map((tag) => (
+                            <Badge key={tag} variant='outline'>
+                              {tag}
+                            </Badge>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-56 align-top'>
+                        <div className='font-medium'>{row.owningService}</div>
+                        <div className='text-sm text-muted-foreground'>
+                          {row.provider} · {row.source}
+                        </div>
+                        <div className='text-xs text-muted-foreground'>
+                          {row.workspace}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-48 align-top'>
+                        <Badge variant={stateVariant[row.state]}>
+                          {row.state}
+                        </Badge>
+                        <div className='mt-2 text-sm'>{row.rotationStatus}</div>
+                        <div className='text-xs text-muted-foreground'>
+                          Updated: {row.lastUpdatedAt}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-64 align-top text-sm'>
+                        <div className='break-all'>{row.policy}</div>
+                        <div className='mt-2 text-muted-foreground'>
+                          {row.auditStatus}
+                        </div>
+                        <div className='text-xs text-muted-foreground'>
+                          Capability: {row.backendCapability}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-72 align-top'>
+                        <div className='flex flex-wrap gap-2'>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
+                            onClick={() => chooseAction(row.id, 'metadata')}
+                          >
+                            View metadata
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
+                            onClick={() => chooseAction(row.id, 'reveal')}
+                          >
+                            Controlled reveal
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
+                            onClick={() => chooseAction(row.id, 'edit')}
+                          >
+                            Edit/update dry-run
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
+                            onClick={() => chooseAction(row.id, 'reset')}
+                          >
+                            Reset/rotate dry-run
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
+                            onClick={() => chooseAction(row.id, 'policy')}
+                          >
+                            Apply policy preview
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              {actionPreview.action === 'reveal' ? (
+                <Eye className='size-4' />
+              ) : actionPreview.action === 'reset' ? (
+                <RotateCcw className='size-4' />
+              ) : (
+                <SlidersHorizontal className='size-4' />
+              )}
+              {actionPreview.title}
+            </CardTitle>
+            <CardDescription>
+              Selected row action preview. No apply occurs from this table
+              without dry-run, audit reason, and explicit confirmation.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-3 text-sm'>
+            <Badge
+              variant={
+                actionPreview.requiresConfirmation ? 'outline' : 'secondary'
+              }
+            >
+              {actionPreview.status}
+            </Badge>
+            <p>{actionPreview.preview}</p>
+            <div className='rounded-md border bg-muted/40 p-3'>
+              <div className='text-xs font-medium text-muted-foreground uppercase'>
+                Next step
+              </div>
+              <div>{actionPreview.nextStep}</div>
+            </div>
+            <div className='flex flex-wrap gap-2'>
+              <Button type='button' disabled>
+                Apply disabled until dry-run preview is accepted
+              </Button>
+              <Badge variant='secondary'>Raw values hidden</Badge>
+              <Badge variant='outline'>No copy/export</Badge>
+              <Badge variant='outline'>No bulk mutation</Badge>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Safety boundaries</CardTitle>
+            <CardDescription>
+              Guardrails for this Secrets sub-page while the backend API
+              contract and single-connection workflows mature.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+              {managedSecretSafetyBoundaries.map((boundary) => (
+                <li key={boundary}>{boundary}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1,0 +1,132 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  filterManagedSecrets,
+  managedSecretRows,
+  managedSecretSafeSurfacesIncludeSecretMaterial,
+  managedSecretsHaveSecretMaterial,
+  valueSearchManagedSecrets,
+} from './secrets-management'
+
+describe('Secrets Broker secrets management page', () => {
+  it('renders the Secrets sub-page table with metadata rows and no raw values', async () => {
+    await renderRoute('/secrets-broker/secrets')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Secrets Broker management table/i)).toBeVisible()
+    expect(screen.getByText(/Visible values/i)).toBeVisible()
+    expect(screen.getByText(/Metadata table · values hidden/i)).toBeVisible()
+    expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
+    expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
+    expect(screen.getAllByText(/Controlled reveal/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Edit\/update dry-run/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Reset\/rotate dry-run/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Apply policy preview/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Raw values hidden/i)[0]).toBeVisible()
+    expect(screen.getByText(/No bulk mutation/i)).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Copy secret/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('filters metadata locally without value search or plaintext indexing', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.type(screen.getByLabelText(/Metadata search/i), 'payments')
+    expect(screen.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
+    expect(screen.getByText(/Metadata matches: 1/i)).toBeVisible()
+
+    await user.selectOptions(screen.getByLabelText(/State filter/i), 'missing')
+    expect(screen.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
+    expect(screen.getAllByText(/missing/i)[0]).toBeVisible()
+  })
+
+  it('shows broker-backed value search supported and unsupported states without raw values', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.type(
+      screen.getByLabelText(/Broker-backed value search/i),
+      'session'
+    )
+    expect(screen.getByText(/Value search unsupported/i)).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', { name: /Simulate supported value search/i })
+    )
+    expect(
+      screen.getByText(/Value search supported: 1 safe ref metadata match/i)
+    ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('previews reveal edit reset and policy actions behind dry-run or confirmation gates', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Controlled reveal/i })[0]
+    )
+    expect(
+      screen.getByText(/Controlled reveal for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/ready for controlled reveal handoff/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Uses the #38 reveal pattern/i)).toBeVisible()
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Edit\/update dry-run/i })[0]
+    )
+    expect(
+      screen.getByText(/Edit\/update dry-run for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(screen.getByText(/dry-run required before apply/i)).toBeVisible()
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Reset\/rotate dry-run/i })[0]
+    )
+    expect(
+      screen.getByText(/Reset\/rotate dry-run for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/rotation preview required before apply/i)
+    ).toBeVisible()
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Apply policy preview/i })[0]
+    )
+    expect(
+      screen.getByText(/Policy preview for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/policy preview required before apply/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /Apply disabled until dry-run preview is accepted/i,
+      })
+    ).toBeDisabled()
+  })
+
+  it('keeps fixtures and modeled safe surfaces free of secret material', () => {
+    expect(managedSecretsHaveSecretMaterial()).toBe(false)
+    expect(managedSecretSafeSurfacesIncludeSecretMaterial()).toBe(false)
+    expect(
+      filterManagedSecrets(managedSecretRows, 'session', 'all')
+    ).toHaveLength(1)
+    expect(
+      valueSearchManagedSecrets(managedSecretRows, 'session', false)
+    ).toEqual([])
+    expect(
+      valueSearchManagedSecrets(managedSecretRows, 'session', true)
+    ).toHaveLength(1)
+  })
+})

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -1,0 +1,268 @@
+export type ManagedSecretState =
+  | 'present'
+  | 'rotation-due'
+  | 'stale'
+  | 'missing'
+
+export type ManagedSecretAction =
+  | 'metadata'
+  | 'reveal'
+  | 'edit'
+  | 'reset'
+  | 'policy'
+
+export type ManagedSecretRow = {
+  id: string
+  ref: string
+  name: string
+  owningService: string
+  provider: string
+  source: string
+  workspace: string
+  state: ManagedSecretState
+  lastUpdatedAt: string
+  lastUsedAt: string
+  rotationStatus: string
+  policy: string
+  auditStatus: string
+  backendCapability: string
+  valueSearch: 'supported' | 'unsupported'
+  safeTags: string[]
+}
+
+export type ManagedSecretActionPreview = {
+  action: ManagedSecretAction
+  title: string
+  status: string
+  preview: string
+  nextStep: string
+  requiresConfirmation: boolean
+}
+
+export const managedSecretRows: ManagedSecretRow[] = [
+  {
+    id: 'serviceadmin-session-signing',
+    ref: 'secret://local/default/@serviceadmin/SESSION_SIGNING_KEY',
+    name: 'SESSION_SIGNING_KEY',
+    owningService: '@serviceadmin',
+    provider: 'local encrypted store',
+    source: 'local-default',
+    workspace: 'local-dev',
+    state: 'present',
+    lastUpdatedAt: '2026-05-08T10:44:00Z',
+    lastUsedAt: '2026-05-08T15:10:00Z',
+    rotationStatus: 'healthy',
+    policy: 'policy/openclaw/service-lasso/read-single-secret',
+    auditStatus: 'audit available',
+    backendCapability: 'reveal, edit dry-run, reset dry-run, policy preview',
+    valueSearch: 'supported',
+    safeTags: ['startup', 'session', 'local'],
+  },
+  {
+    id: 'zitadel-client-credential',
+    ref: 'secret://provider/zitadel/client-credential',
+    name: 'ZITADEL_CLIENT_CREDENTIAL',
+    owningService: '@serviceadmin',
+    provider: 'provider connection',
+    source: 'zitadel-admin',
+    workspace: 'identity',
+    state: 'rotation-due',
+    lastUpdatedAt: '2026-04-20T06:30:00Z',
+    lastUsedAt: '2026-05-08T08:20:00Z',
+    rotationStatus: 'due within 7 days',
+    policy: 'policy/openclaw/service-lasso/provider-read',
+    auditStatus: 'audit available',
+    backendCapability: 'metadata, reveal challenge, reset dry-run',
+    valueSearch: 'supported',
+    safeTags: ['identity', 'provider', 'rotation'],
+  },
+  {
+    id: 'runtime-node-registry-auth',
+    ref: 'secret://file/runtime/node-registry-auth',
+    name: 'NODE_REGISTRY_AUTH',
+    owningService: '@node',
+    provider: 'file source',
+    source: 'runtime env file',
+    workspace: 'build',
+    state: 'stale',
+    lastUpdatedAt: '2026-04-12T11:00:00Z',
+    lastUsedAt: '2026-05-01T12:05:00Z',
+    rotationStatus: 'review source freshness',
+    policy: 'policy/openclaw/service-lasso/file-source-review',
+    auditStatus: 'audit available',
+    backendCapability: 'metadata, edit dry-run only',
+    valueSearch: 'unsupported',
+    safeTags: ['file-source', 'build'],
+  },
+  {
+    id: 'payments-signing-ref',
+    ref: 'secret://provider/payments/signing-ref',
+    name: 'PAYMENTS_SIGNING_REF',
+    owningService: 'payments-api',
+    provider: 'provider connection',
+    source: 'payments-provider',
+    workspace: 'future-prod-readonly',
+    state: 'missing',
+    lastUpdatedAt: 'not available',
+    lastUsedAt: 'not available',
+    rotationStatus: 'registration pending',
+    policy: 'policy/openclaw/service-lasso/payments-readonly',
+    auditStatus: 'audit required before reveal',
+    backendCapability: 'metadata only until provider is connected',
+    valueSearch: 'unsupported',
+    safeTags: ['payments', 'placeholder'],
+  },
+]
+
+export const managedSecretSafetyBoundaries = [
+  'Rows contain safe metadata only: refs, owner, provider/source, state, policy, audit status, and action readiness.',
+  'Metadata search filters refs/tags/provider/owner locally; it does not index raw secret values.',
+  'Broker-backed value search is represented as supported or unsupported and returns ref metadata only.',
+  'Reveal delegates to the controlled #38 pattern: explicit action, audit status, timeout, and value hidden by default.',
+  'Edit, reset, and policy actions require dry-run/preview before apply and never use spreadsheet-style plaintext editing.',
+]
+
+export const managedSecretSafeSurfaces = {
+  route: '/secrets-broker/secrets',
+  pageTitle: 'Service Admin - Secrets Broker Secrets',
+  breadcrumb: 'Secrets Broker / Secrets',
+  diagnostics:
+    'secrets_table=metadata_only; value_search=refs_only; raw_values=hidden',
+  supportBundle:
+    'secrets management table includes refs, state, policy, and audit metadata only; raw values omitted',
+  consoleEvents: [
+    'secrets-management:metadata-search',
+    'secrets-management:value-search-metadata-only',
+    'secrets-management:action-preview',
+  ],
+  persistedStorage: 'none',
+}
+
+export function filterManagedSecrets(
+  rows: ManagedSecretRow[],
+  query: string,
+  state: ManagedSecretState | 'all'
+): ManagedSecretRow[] {
+  const normalized = query.trim().toLowerCase()
+  return rows.filter((row) => {
+    const matchesState = state === 'all' || row.state === state
+    const matchesQuery =
+      normalized.length === 0 ||
+      [
+        row.ref,
+        row.name,
+        row.owningService,
+        row.provider,
+        row.source,
+        row.workspace,
+        row.rotationStatus,
+        ...row.safeTags,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(normalized)
+    return matchesState && matchesQuery
+  })
+}
+
+export function valueSearchManagedSecrets(
+  rows: ManagedSecretRow[],
+  query: string,
+  supported: boolean
+): ManagedSecretRow[] {
+  const normalized = query.trim().toLowerCase()
+  if (!supported || normalized.length === 0) return []
+  return rows.filter(
+    (row) =>
+      row.valueSearch === 'supported' &&
+      (row.safeTags.join(' ').toLowerCase().includes(normalized) ||
+        row.name.toLowerCase().includes(normalized) ||
+        row.owningService.toLowerCase().includes(normalized))
+  )
+}
+
+export function buildManagedSecretActionPreview(
+  row: ManagedSecretRow,
+  action: ManagedSecretAction
+): ManagedSecretActionPreview {
+  switch (action) {
+    case 'reveal':
+      return {
+        action,
+        title: `Controlled reveal for ${row.name}`,
+        status:
+          row.state === 'missing'
+            ? 'fail-closed: ref missing'
+            : 'ready for controlled reveal handoff',
+        preview:
+          'Uses the #38 reveal pattern: explicit operator action, policy/audit status, short-lived display, and value hidden until authorized.',
+        nextStep:
+          row.state === 'missing'
+            ? 'Connect the provider/source before reveal can be requested.'
+            : 'Open the controlled reveal flow with an audit reason; raw value is not shown in this table.',
+        requiresConfirmation: true,
+      }
+    case 'edit':
+      return {
+        action,
+        title: `Edit/update dry-run for ${row.name}`,
+        status:
+          row.state === 'missing'
+            ? 'blocked: ref unavailable'
+            : 'dry-run required before apply',
+        preview:
+          'Preview validates target ref, policy, backend capability, affected service metadata, and audit readiness without plaintext spreadsheet editing.',
+        nextStep:
+          'Run dry-run, review metadata-only diff, enter audit reason, then apply only after explicit confirmation.',
+        requiresConfirmation: true,
+      }
+    case 'reset':
+      return {
+        action,
+        title: `Reset/rotate dry-run for ${row.name}`,
+        status:
+          row.state === 'missing'
+            ? 'blocked: provider/source missing'
+            : 'rotation preview required before apply',
+        preview:
+          'Preview checks backend support, policy, affected service restart notes, and audit status without generating or displaying raw material in Service Admin.',
+        nextStep:
+          'Run reset/rotate preview first; apply remains disabled until preview and audit reason are accepted.',
+        requiresConfirmation: true,
+      }
+    case 'policy':
+      return {
+        action,
+        title: `Policy preview for ${row.name}`,
+        status: 'policy preview required before apply',
+        preview:
+          'Preview shows policy target, expected outcome, affected refs, and audit status. Applying policy is separate and confirmation-gated.',
+        nextStep:
+          'Review policy preview and audit impact before applying any change.',
+        requiresConfirmation: true,
+      }
+    case 'metadata':
+    default:
+      return {
+        action: 'metadata',
+        title: `Metadata view for ${row.name}`,
+        status: 'metadata only',
+        preview:
+          'Displays safe ref metadata, ownership, provider/source, rotation state, policy, audit posture, and action readiness only.',
+        nextStep:
+          'Choose a controlled row action when an operator task is needed.',
+        requiresConfirmation: false,
+      }
+  }
+}
+
+const forbiddenSecretPattern =
+  /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
+
+export function managedSecretsHaveSecretMaterial(rows = managedSecretRows) {
+  return forbiddenSecretPattern.test(JSON.stringify(rows))
+}
+
+export function managedSecretSafeSurfacesIncludeSecretMaterial() {
+  return forbiddenSecretPattern.test(JSON.stringify(managedSecretSafeSurfaces))
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -52,6 +52,7 @@ import { Route as AuthenticatedSettingsDisplayRouteImport } from './routes/_auth
 import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_authenticated/settings/appearance'
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
 import { Route as AuthenticatedServicesServiceIdRouteImport } from './routes/_authenticated/services.$serviceId'
+import { Route as AuthenticatedSecretsBrokerSecretsRouteImport } from './routes/_authenticated/secrets-broker/secrets'
 import { Route as AuthenticatedSecretsBrokerConnectionIdRouteImport } from './routes/_authenticated/secrets-broker.$connectionId'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
@@ -288,6 +289,12 @@ const AuthenticatedServicesServiceIdRoute =
     path: '/services/$serviceId',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedSecretsBrokerSecretsRoute =
+  AuthenticatedSecretsBrokerSecretsRouteImport.update({
+    id: '/secrets-broker/secrets',
+    path: '/secrets-broker/secrets',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSecretsBrokerConnectionIdRoute =
   AuthenticatedSecretsBrokerConnectionIdRouteImport.update({
     id: '/secrets-broker/$connectionId',
@@ -317,6 +324,7 @@ export interface FileRoutesByFullPath {
   '/503': typeof errors503Route
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -360,6 +368,7 @@ export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -408,6 +417,7 @@ export interface FileRoutesById {
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/_authenticated/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/_authenticated/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/_authenticated/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
   '/_authenticated/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
@@ -454,6 +464,7 @@ export interface FileRouteTypes {
     | '/503'
     | '/errors/$error'
     | '/secrets-broker/$connectionId'
+    | '/secrets-broker/secrets'
     | '/services/$serviceId'
     | '/settings/account'
     | '/settings/appearance'
@@ -497,6 +508,7 @@ export interface FileRouteTypes {
     | '/'
     | '/errors/$error'
     | '/secrets-broker/$connectionId'
+    | '/secrets-broker/secrets'
     | '/services/$serviceId'
     | '/settings/account'
     | '/settings/appearance'
@@ -544,6 +556,7 @@ export interface FileRouteTypes {
     | '/_authenticated/'
     | '/_authenticated/errors/$error'
     | '/_authenticated/secrets-broker/$connectionId'
+    | '/_authenticated/secrets-broker/secrets'
     | '/_authenticated/services/$serviceId'
     | '/_authenticated/settings/account'
     | '/_authenticated/settings/appearance'
@@ -891,6 +904,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedServicesServiceIdRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/secrets': {
+      id: '/_authenticated/secrets-broker/secrets'
+      path: '/secrets-broker/secrets'
+      fullPath: '/secrets-broker/secrets'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerSecretsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/secrets-broker/$connectionId': {
       id: '/_authenticated/secrets-broker/$connectionId'
       path: '/secrets-broker/$connectionId'
@@ -936,6 +956,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedErrorsErrorRoute: typeof AuthenticatedErrorsErrorRoute
   AuthenticatedSecretsBrokerConnectionIdRoute: typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  AuthenticatedSecretsBrokerSecretsRoute: typeof AuthenticatedSecretsBrokerSecretsRoute
   AuthenticatedServicesServiceIdRoute: typeof AuthenticatedServicesServiceIdRoute
   AuthenticatedAppsIndexRoute: typeof AuthenticatedAppsIndexRoute
   AuthenticatedAuthSessionIndexRoute: typeof AuthenticatedAuthSessionIndexRoute
@@ -963,6 +984,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedErrorsErrorRoute: AuthenticatedErrorsErrorRoute,
   AuthenticatedSecretsBrokerConnectionIdRoute:
     AuthenticatedSecretsBrokerConnectionIdRoute,
+  AuthenticatedSecretsBrokerSecretsRoute:
+    AuthenticatedSecretsBrokerSecretsRoute,
   AuthenticatedServicesServiceIdRoute: AuthenticatedServicesServiceIdRoute,
   AuthenticatedAppsIndexRoute: AuthenticatedAppsIndexRoute,
   AuthenticatedAuthSessionIndexRoute: AuthenticatedAuthSessionIndexRoute,

--- a/src/routes/_authenticated/secrets-broker/secrets.tsx
+++ b/src/routes/_authenticated/secrets-broker/secrets.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretsManagementPage } from '@/features/secrets-broker/secrets-management-page'
+
+export const Route = createFileRoute('/_authenticated/secrets-broker/secrets')({
+  component: SecretsManagementPage,
+})

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -98,6 +98,7 @@ test.describe('Secrets Broker browser coverage', () => {
 
     const navLinks = [
       ['Overview / Setup', /\/secrets-broker$/],
+      ['Secrets', /\/secrets-broker\/secrets$/],
       ['Sources / Backends', /\/secrets-broker#secret-sources$/],
       ['Provider Connections', /\/secrets-broker#provider-connections$/],
       ['Single Reveal', /\/secrets-broker#privileged-secret-reveal$/],
@@ -125,6 +126,53 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByRole('link', { name: 'Policy Simulation' })
     ).toBeVisible()
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('covers the Secrets sub-page table search and safe action previews', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker/secrets')
+    await expectNoBlankScreen(page)
+    await expect(page.getByRole('heading', { name: /^Secrets$/ })).toBeVisible()
+    await expect(
+      page.getByText(/Metadata table · values hidden/i)
+    ).toBeVisible()
+    await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
+    await expect(page.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
+
+    await page.getByLabel(/Metadata search/i).fill('payments')
+    await expect(page.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
+    await expect(page.getByText(/Metadata matches: 1/i)).toBeVisible()
+
+    await page.getByLabel(/Broker-backed value search/i).fill('session')
+    await expect(page.getByText(/Value search unsupported/i)).toBeVisible()
+    await page
+      .getByRole('button', { name: /Simulate supported value search/i })
+      .click()
+    await expect(
+      page.getByText(/Value search supported: 1 safe ref metadata match/i)
+    ).toBeVisible()
+
+    await page
+      .getByRole('button', { name: /Controlled reveal/i })
+      .first()
+      .click()
+    await expect(page.getByText(/Uses the #38 reveal pattern/i)).toBeVisible()
+    await page
+      .getByRole('button', { name: /Edit\/update dry-run/i })
+      .first()
+      .click()
+    await expect(
+      page.getByText(/dry-run required before apply|blocked: ref unavailable/i)
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', {
+        name: /Apply disabled until dry-run preview is accepted/i,
+      })
+    ).toBeDisabled()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])
   })
 


### PR DESCRIPTION
## Summary
- Add `Secrets Broker > Secrets` route and sidebar navigation for a searchable secrets management surface.
- Model fixture-backed metadata-only secret rows with local metadata search/filter and broker-backed value-search supported/unsupported states.
- Add controlled row action previews for metadata view, #38-style reveal handoff, edit/update dry-run, reset/rotate dry-run, and policy preview/apply gates.
- Add unit and Playwright coverage for route reachability, search/value-search states, no raw value rendering, controlled reveal entry point, dry-run gates, and no-leak assertions.

## Safety notes
- Raw values remain hidden; the page does not render copy/export controls.
- Metadata search is local over refs/tags/provider/owner only and does not index plaintext values.
- Broker-backed value search is represented as metadata-only refs when supported and fail-closed when unsupported.
- Edit/reset/policy actions are preview/dry-run gated; no bulk mutation is implemented.

## Validation
- `npm test -- src/features/secrets-broker/secrets-management.test.tsx` — 5 passed
- `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — 6 passed
- `npm run lint` — passed with 7 pre-existing warnings in unrelated files
- `npm run build` — passed

Closes #82
Related: service-lasso/lasso-secretsbroker#35, #81, #40
