### PR TITLE
Add Secrets Broker configuration migration page

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -116,6 +116,11 @@ export const sidebarData: SidebarData = {
               icon: DatabaseZap,
             },
             {
+              title: 'Configuration',
+              url: '/secrets-broker/configuration',
+              icon: Settings,
+            },
+            {
               title: 'Sources / Backends',
               url: '/secrets-broker#secret-sources',
               icon: DatabaseZap,

--- a/src/features/secrets-broker/provider-configuration-page.tsx
+++ b/src/features/secrets-broker/provider-configuration-page.tsx
@@ -1,0 +1,402 @@
+import { useMemo, useState } from 'react'
+import {
+  DatabaseZap,
+  GitBranch,
+  KeyRound,
+  ShieldCheck,
+  Wrench,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  configurationSafetyBoundaries,
+  migrationPlans,
+  providerConfigurations,
+  type MigrationState,
+  type ProviderState,
+} from './provider-configuration'
+
+const providerStateLabels: Record<ProviderState, string> = {
+  'local-default': 'No provider configured / local default',
+  healthy: 'Provider configured and healthy',
+  'auth-required': 'Provider auth required',
+  unsupported: 'Provider capability unsupported',
+  'validation-failed': 'Validation failed',
+}
+
+const migrationStateLabels: Record<MigrationState, string> = {
+  'dry-run-ready': 'Migration dry-run ready',
+  'dry-run-partial': 'Migration dry-run denied/partial',
+  'apply-ready': 'Migration apply ready after confirmation',
+  'apply-success': 'Migration success',
+  'apply-partial': 'Migration partial failure',
+}
+
+export function ProviderConfigurationPage() {
+  const [providerState, setProviderState] =
+    useState<ProviderState>('local-default')
+  const [migrationState, setMigrationState] =
+    useState<MigrationState>('dry-run-ready')
+  const [auditReason, setAuditReason] = useState('')
+  const [confirmed, setConfirmed] = useState(false)
+
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Configuration',
+    description:
+      'Safe provider configuration and migration workflow for Secrets Broker using refs, handles, dry-run previews, and audit-gated apply.',
+  })
+
+  const provider = providerConfigurations[providerState]
+  const migration = migrationPlans[migrationState]
+  const applyAllowed = useMemo(
+    () => migration.applyEnabled && confirmed && auditReason.trim().length > 0,
+    [auditReason, confirmed, migration.applyEnabled]
+  )
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <Wrench className='size-5' /> Configuration
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Configure a Secrets Broker provider and migrate existing refs with
+              safe handles, metadata-only dry-runs, and explicit audit-gated
+              apply. Provider credentials and raw secret values are never
+              rendered.
+            </p>
+          </div>
+          <Badge variant='secondary'>Handles only · dry-run first</Badge>
+        </div>
+
+        <Alert>
+          <ShieldCheck className='size-4' />
+          <AlertTitle>Provider setup stays secret-safe</AlertTitle>
+          <AlertDescription>
+            This screen models the #36 backend contract: provider capabilities,
+            config status, validation, migration dry-run, and apply responses
+            use safe metadata only. Apply remains disabled until confirmation,
+            operation id, and audit reason are present.
+          </AlertDescription>
+        </Alert>
+
+        <div className='grid gap-4 md:grid-cols-4'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Current provider</CardDescription>
+              <CardTitle className='text-xl'>{provider.name}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Credential values shown</CardDescription>
+              <CardTitle className='text-3xl'>0</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Migration items</CardDescription>
+              <CardTitle className='text-3xl'>
+                {migration.items.length}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Apply gate</CardDescription>
+              <CardTitle className='text-xl'>
+                {applyAllowed ? 'ready' : 'locked'}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <KeyRound className='size-4' /> Provider configuration
+            </CardTitle>
+            <CardDescription>
+              Select safe provider states and validate configuration without
+              showing or persisting provider credential values.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-4 lg:grid-cols-3'>
+            <div className='space-y-2'>
+              <label
+                htmlFor='provider-state'
+                className='text-sm font-medium text-muted-foreground'
+              >
+                Provider state scenario
+              </label>
+              <select
+                id='provider-state'
+                className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                value={providerState}
+                onChange={(event) =>
+                  setProviderState(event.target.value as ProviderState)
+                }
+              >
+                {Object.entries(providerStateLabels).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <div className='rounded-md border p-3 text-sm'>
+                <div className='font-medium'>{provider.status}</div>
+                <div className='mt-2 text-muted-foreground'>
+                  Next action: {provider.nextAction}
+                </div>
+              </div>
+            </div>
+
+            <div className='space-y-2 text-sm'>
+              <div className='font-medium'>
+                Current provider/backend summary
+              </div>
+              <div className='rounded-md border p-3'>
+                <div>Provider id: {provider.id}</div>
+                <div>Kind: {provider.kind}</div>
+                <div>Address/status handle: {provider.address}</div>
+                <div>Credential handle: {provider.credentialHandle}</div>
+                <div>Namespaces: {provider.namespaces.join(', ')}</div>
+                <div>Audit: {provider.auditStatus}</div>
+              </div>
+            </div>
+
+            <div className='space-y-2 text-sm'>
+              <div className='font-medium'>Validation/test connection</div>
+              <div className='rounded-md border p-3'>
+                <Badge
+                  variant={
+                    provider.state === 'healthy' ||
+                    provider.state === 'local-default'
+                      ? 'default'
+                      : 'outline'
+                  }
+                >
+                  {provider.state}
+                </Badge>
+                <p className='mt-3 text-muted-foreground'>
+                  Validation sends provider id, kind, address, namespaces, and a
+                  credential handle/ref. Plaintext provider credentials are not
+                  accepted by this UI.
+                </p>
+                <Button type='button' className='mt-3' disabled>
+                  Test connection preview only
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <DatabaseZap className='size-4' /> Capability summary
+            </CardTitle>
+            <CardDescription>
+              Safe capability metadata from the provider configuration contract.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className='flex flex-wrap gap-2'>
+              {provider.capabilities.map((capability) => (
+                <Badge
+                  key={capability.id}
+                  variant={capability.supported ? 'default' : 'secondary'}
+                >
+                  {capability.label}: {capability.supported ? 'yes' : 'no'}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <GitBranch className='size-4' /> Migration dry-run / apply
+            </CardTitle>
+            <CardDescription>
+              Migration plans show refs, source/target provider ids, policy,
+              risk, expected action, audit requirement, and recovery guidance —
+              never raw secret values.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-4 lg:grid-cols-3'>
+              <div className='space-y-2'>
+                <label
+                  htmlFor='migration-state'
+                  className='text-sm font-medium text-muted-foreground'
+                >
+                  Migration state scenario
+                </label>
+                <select
+                  id='migration-state'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={migrationState}
+                  onChange={(event) =>
+                    setMigrationState(event.target.value as MigrationState)
+                  }
+                >
+                  {Object.entries(migrationStateLabels).map(
+                    ([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    )
+                  )}
+                </select>
+              </div>
+              <div className='space-y-2'>
+                <label
+                  htmlFor='audit-reason'
+                  className='text-sm font-medium text-muted-foreground'
+                >
+                  Audit reason
+                </label>
+                <Input
+                  id='audit-reason'
+                  value={auditReason}
+                  onChange={(event) => setAuditReason(event.target.value)}
+                  placeholder='Required before migration apply'
+                />
+              </div>
+              <div className='space-y-2 text-sm'>
+                <div className='font-medium text-muted-foreground'>
+                  Explicit confirmation
+                </div>
+                <Button
+                  type='button'
+                  variant={confirmed ? 'default' : 'outline'}
+                  onClick={() => setConfirmed((value) => !value)}
+                >
+                  {confirmed ? 'Confirmation recorded' : 'Record confirmation'}
+                </Button>
+              </div>
+            </div>
+
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>{migration.title}</div>
+              <div className='text-muted-foreground'>
+                Outcome: {migration.outcome} · Operation id:{' '}
+                {migration.operationId} · Source: {migration.sourceProvider} ·
+                Target: {migration.targetProvider}
+              </div>
+              <div className='mt-2'>Next action: {migration.nextAction}</div>
+              <div>Rollback/recovery: {migration.rollback}</div>
+            </div>
+
+            <div className='overflow-x-auto rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Secret ref</TableHead>
+                    <TableHead>Source → target</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Policy / risk</TableHead>
+                    <TableHead>Recovery</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {migration.items.map((item) => (
+                    <TableRow key={`${migration.state}-${item.ref}`}>
+                      <TableCell className='min-w-80 align-top'>
+                        <div className='font-medium'>{item.owner}</div>
+                        <div className='break-all text-muted-foreground'>
+                          {item.ref}
+                        </div>
+                      </TableCell>
+                      <TableCell className='align-top'>
+                        {item.source} → {item.target}
+                      </TableCell>
+                      <TableCell className='align-top'>
+                        <Badge variant='outline'>{item.state}</Badge>
+                        <div className='mt-2 text-sm text-muted-foreground'>
+                          {item.expectedAction}
+                        </div>
+                      </TableCell>
+                      <TableCell className='align-top'>
+                        <div>Policy: {item.policyResult}</div>
+                        <div>Risk: {item.risk}</div>
+                        <div>Audit: {item.auditRequirement}</div>
+                      </TableCell>
+                      <TableCell className='min-w-64 align-top text-sm text-muted-foreground'>
+                        {item.recovery}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className='flex flex-wrap gap-2'>
+              <Button type='button' disabled={!applyAllowed}>
+                {applyAllowed
+                  ? 'Migration apply ready'
+                  : 'Migration apply disabled until confirmation and audit reason'}
+              </Button>
+              <Badge variant='secondary'>Raw values hidden</Badge>
+              <Badge variant='outline'>Provider credentials hidden</Badge>
+              <Badge variant='outline'>No spreadsheet plaintext editing</Badge>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Safety boundaries</CardTitle>
+            <CardDescription>
+              Guardrails for provider configuration and migration.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
+              {configurationSafetyBoundaries.map((boundary) => (
+                <li key={boundary}>{boundary}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/provider-configuration.test.tsx
+++ b/src/features/secrets-broker/provider-configuration.test.tsx
@@ -1,0 +1,124 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  configurationFixturesHaveSecretMaterial,
+  migrationPlans,
+  providerConfigurations,
+} from './provider-configuration'
+
+describe('Secrets Broker provider configuration page', () => {
+  it('renders provider configuration and migration screen without credential or raw value leakage', async () => {
+    await renderRoute('/secrets-broker/configuration')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Configuration$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Handles only · dry-run first/i)).toBeVisible()
+    expect(screen.getByText(/Current provider\/backend summary/i)).toBeVisible()
+    expect(screen.getByText(/Credential values shown/i)).toBeVisible()
+    expect(screen.getByText(/Migration dry-run \/ apply/i)).toBeVisible()
+    expect(screen.getByText(/Provider credentials hidden/i)).toBeVisible()
+    expect(
+      screen.queryByText(/fixture-provider-credential-value/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/fixture-managed-secret-value/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('covers provider validation states safely', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/configuration')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Provider state scenario/i),
+      'healthy'
+    )
+    expect(screen.getByText(/Provider configuration validated/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        /ref:secret:\/\/local\/provider\/vault-prod\/credential-handle/i
+      )
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Provider state scenario/i),
+      'auth-required'
+    )
+    expect(
+      screen.getByText(/Provider requires credential ref refresh/i)
+    ).toBeVisible()
+    expect(screen.getByText(/do not paste provider credentials/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Provider state scenario/i),
+      'unsupported'
+    )
+    expect(screen.getByText(/cannot be a migration target/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Provider state scenario/i),
+      'validation-failed'
+    )
+    expect(screen.getByText(/Validation failed closed/i)).toBeVisible()
+    expect(
+      screen.queryByText(/fixture-provider-credential-value/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('covers migration dry-run apply gating and partial failure states', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/configuration')
+
+    expect(
+      screen.getByText(
+        /Migration apply disabled until confirmation and audit reason/i
+      )
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Migration state scenario/i),
+      'dry-run-partial'
+    )
+    expect(screen.getByText(/Migration dry-run partial denial/i)).toBeVisible()
+    expect(screen.getByText(/partial_failure/i)).toBeVisible()
+    expect(screen.getByText(/review policy and rerun dry-run/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Migration state scenario/i),
+      'apply-ready'
+    )
+    await user.type(
+      screen.getByLabelText(/Audit reason/i),
+      'approved migration'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Record confirmation/i })
+    )
+    expect(
+      screen.getByRole('button', { name: /Migration apply ready/i })
+    ).toBeEnabled()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Migration state scenario/i),
+      'apply-partial'
+    )
+    expect(screen.getAllByText(/Migration partial failure/i)[0]).toBeVisible()
+    expect(screen.getByText(/Unmigrated refs remain on source/i)).toBeVisible()
+    expect(
+      screen.queryByText(/fixture-managed-secret-value/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps provider and migration fixtures free of secret material', () => {
+    expect(configurationFixturesHaveSecretMaterial()).toBe(false)
+    expect(providerConfigurations.healthy.credentialHandle).toContain('ref:')
+    expect(migrationPlans['dry-run-partial'].items).toHaveLength(3)
+    expect(
+      migrationPlans['apply-ready'].applyEnabled,
+      'apply-ready requires UI confirmation and audit reason before button enables'
+    ).toBe(true)
+  })
+})

--- a/src/features/secrets-broker/provider-configuration.ts
+++ b/src/features/secrets-broker/provider-configuration.ts
@@ -1,0 +1,316 @@
+export type ProviderState =
+  | 'local-default'
+  | 'healthy'
+  | 'auth-required'
+  | 'unsupported'
+  | 'validation-failed'
+
+export type MigrationState =
+  | 'dry-run-ready'
+  | 'dry-run-partial'
+  | 'apply-ready'
+  | 'apply-success'
+  | 'apply-partial'
+
+export type ProviderCapability = {
+  id: string
+  label: string
+  supported: boolean
+}
+
+export type ProviderConfiguration = {
+  id: string
+  name: string
+  kind: string
+  state: ProviderState
+  status: string
+  credentialHandle: string
+  address: string
+  namespaces: string[]
+  capabilities: ProviderCapability[]
+  nextAction: string
+  auditStatus: string
+  recovery: string
+}
+
+export type MigrationItem = {
+  ref: string
+  source: string
+  target: string
+  owner: string
+  state: 'planned' | 'skipped' | 'denied' | 'failed' | 'migrated'
+  policyResult: 'allowed' | 'denied' | 'review'
+  risk: 'low' | 'medium' | 'high'
+  expectedAction: string
+  auditRequirement: string
+  recovery: string
+}
+
+export type MigrationPlan = {
+  state: MigrationState
+  title: string
+  outcome: string
+  operationId: string
+  sourceProvider: string
+  targetProvider: string
+  items: MigrationItem[]
+  nextAction: string
+  rollback: string
+  applyEnabled: boolean
+}
+
+export const providerCapabilities: ProviderCapability[] = [
+  { id: 'read', label: 'Read', supported: true },
+  { id: 'reveal', label: 'Reveal', supported: true },
+  { id: 'write', label: 'Write/update', supported: true },
+  { id: 'rotate', label: 'Rotate/reset', supported: true },
+  { id: 'policy', label: 'Policy', supported: true },
+  { id: 'value_search', label: 'Value search', supported: true },
+  { id: 'audit', label: 'Audit', supported: true },
+]
+
+export const providerConfigurations: Record<
+  ProviderState,
+  ProviderConfiguration
+> = {
+  'local-default': {
+    id: 'local',
+    name: 'Local encrypted store',
+    kind: 'local-encrypted-store',
+    state: 'local-default',
+    status:
+      'No external provider configured; local-first encrypted store is active.',
+    credentialHandle: 'local-master-key-handle',
+    address: 'loopback/local',
+    namespaces: ['services/*', 'workspaces/*'],
+    capabilities: providerCapabilities,
+    nextAction:
+      'Select a target provider and validate safe credential references before migration.',
+    auditStatus: 'audit available',
+    recovery: 'Encrypted backup restore is available before migration apply.',
+  },
+  healthy: {
+    id: 'vault-prod',
+    name: 'Vault production',
+    kind: 'vault',
+    state: 'healthy',
+    status:
+      'Provider configuration validated; broker reports read/reveal and migration-source readiness.',
+    credentialHandle:
+      'ref:secret://local/provider/vault-prod/credential-handle',
+    address: 'https://vault.example.invalid',
+    namespaces: ['services/*'],
+    capabilities: providerCapabilities.map((capability) =>
+      capability.id === 'write' || capability.id === 'rotate'
+        ? { ...capability, supported: false }
+        : capability
+    ),
+    nextAction: 'Run migration dry-run before applying any provider migration.',
+    auditStatus: 'audit available',
+    recovery:
+      'Rerun migration for denied/failed refs after fixing provider state.',
+  },
+  'auth-required': {
+    id: 'vault-auth-required',
+    name: 'Vault auth required',
+    kind: 'vault',
+    state: 'auth-required',
+    status:
+      'Provider requires credential ref refresh before validation or migration can proceed.',
+    credentialHandle: 'missing credential reference',
+    address: 'https://vault.example.invalid',
+    namespaces: ['services/*'],
+    capabilities: providerCapabilities.map((capability) => ({
+      ...capability,
+      supported: capability.id === 'audit',
+    })),
+    nextAction:
+      'Reconnect provider with a safe credential reference; do not paste provider credentials into Service Admin.',
+    auditStatus: 'audit available',
+    recovery: 'No migration apply until provider auth is restored.',
+  },
+  unsupported: {
+    id: 'env-readonly',
+    name: 'Environment source',
+    kind: 'env',
+    state: 'unsupported',
+    status:
+      'Read-only source can be a migration source but cannot be a migration target.',
+    credentialHandle: 'not required',
+    address: 'process environment',
+    namespaces: ['services/*'],
+    capabilities: providerCapabilities.map((capability) => ({
+      ...capability,
+      supported: ['read', 'audit'].includes(capability.id),
+    })),
+    nextAction: 'Select a provider with migration_target support.',
+    auditStatus: 'audit available',
+    recovery:
+      'Choose local encrypted store or a write-capable provider target.',
+  },
+  'validation-failed': {
+    id: 'vault-invalid',
+    name: 'Vault validation failed',
+    kind: 'vault',
+    state: 'validation-failed',
+    status:
+      'Validation failed closed because provider address or credential handle is invalid.',
+    credentialHandle: 'ref rejected by broker validation',
+    address: 'https://vault.invalid',
+    namespaces: ['services/*'],
+    capabilities: providerCapabilities.map((capability) => ({
+      ...capability,
+      supported: capability.id === 'audit',
+    })),
+    nextAction: 'Fix provider address/credential handle and rerun validation.',
+    auditStatus: 'audit recorded',
+    recovery: 'Keep local provider active until validation passes.',
+  },
+}
+
+const baseMigrationItems: MigrationItem[] = [
+  {
+    ref: 'secret://local/default/@serviceadmin/SESSION_SIGNING_KEY',
+    source: 'local',
+    target: 'vault-prod',
+    owner: '@serviceadmin',
+    state: 'planned',
+    policyResult: 'allowed',
+    risk: 'low',
+    expectedAction: 'copy inside broker with metadata-only result',
+    auditRequirement: 'required',
+    recovery: 'retry idempotent operation id if interrupted',
+  },
+  {
+    ref: 'secret://local/default/@node/NODE_REGISTRY_AUTH',
+    source: 'local',
+    target: 'vault-prod',
+    owner: '@node',
+    state: 'denied',
+    policyResult: 'denied',
+    risk: 'medium',
+    expectedAction: 'skipped until policy grants target namespace',
+    auditRequirement: 'required',
+    recovery: 'review policy and rerun dry-run for this ref',
+  },
+  {
+    ref: 'secret://provider/payments/PAYMENTS_SIGNING_REF',
+    source: 'provider',
+    target: 'vault-prod',
+    owner: 'payments-api',
+    state: 'skipped',
+    policyResult: 'review',
+    risk: 'high',
+    expectedAction: 'requires provider auth before migration',
+    auditRequirement: 'required',
+    recovery: 'reconnect source provider and retry',
+  },
+]
+
+export const migrationPlans: Record<MigrationState, MigrationPlan> = {
+  'dry-run-ready': {
+    state: 'dry-run-ready',
+    title: 'Migration dry-run ready',
+    outcome: 'dry_run_ready',
+    operationId: 'migration-preview-2026-05-08-a',
+    sourceProvider: 'local',
+    targetProvider: 'vault-prod',
+    items: baseMigrationItems.slice(0, 1),
+    nextAction:
+      'Review metadata-only plan, enter audit reason, then enable confirmation.',
+    rollback: 'No rollback required for dry-run; no values moved.',
+    applyEnabled: false,
+  },
+  'dry-run-partial': {
+    state: 'dry-run-partial',
+    title: 'Migration dry-run partial denial',
+    outcome: 'partial_failure',
+    operationId: 'migration-preview-2026-05-08-b',
+    sourceProvider: 'local',
+    targetProvider: 'vault-prod',
+    items: baseMigrationItems,
+    nextAction:
+      'Resolve denied/skipped refs or proceed only when acceptable policy allows partial migration.',
+    rollback: 'No rollback required for dry-run; denied refs remain unchanged.',
+    applyEnabled: false,
+  },
+  'apply-ready': {
+    state: 'apply-ready',
+    title: 'Migration apply ready after confirmation',
+    outcome: 'ready_for_apply',
+    operationId: 'migration-apply-2026-05-08-a',
+    sourceProvider: 'local',
+    targetProvider: 'vault-prod',
+    items: baseMigrationItems.slice(0, 1),
+    nextAction:
+      'Apply remains gated by explicit confirmation and audit reason.',
+    rollback: 'Encrypted backup restore available before apply.',
+    applyEnabled: true,
+  },
+  'apply-success': {
+    state: 'apply-success',
+    title: 'Migration success',
+    outcome: 'applied',
+    operationId: 'migration-apply-2026-05-08-b',
+    sourceProvider: 'local',
+    targetProvider: 'vault-prod',
+    items: baseMigrationItems.slice(0, 1).map((item) => ({
+      ...item,
+      state: 'migrated',
+      expectedAction: 'completed inside broker',
+    })),
+    nextAction:
+      'Verify provider status and keep recovery notes attached to audit record.',
+    rollback:
+      'Rerun using previous provider as source if rollback is supported.',
+    applyEnabled: false,
+  },
+  'apply-partial': {
+    state: 'apply-partial',
+    title: 'Migration partial failure',
+    outcome: 'partial_failure',
+    operationId: 'migration-apply-2026-05-08-c',
+    sourceProvider: 'local',
+    targetProvider: 'vault-prod',
+    items: baseMigrationItems.map((item, index) =>
+      index === 0 ? { ...item, state: 'migrated' } : item
+    ),
+    nextAction:
+      'Review denied/failed refs, fix provider or policy, and retry by operation id.',
+    rollback:
+      'Unmigrated refs remain on source; migrated refs can be retried idempotently.',
+    applyEnabled: false,
+  },
+}
+
+export const configurationSafetyBoundaries = [
+  'Provider credentials are represented as safe refs/handles only; the UI never asks operators to paste credential values.',
+  'Configuration status and validation results show provider metadata, capabilities, audit state, and next actions only.',
+  'Migration dry-run is metadata-only: refs, source/target provider ids, policy result, risk, expected action, audit requirement, and recovery guidance.',
+  'Migration apply requires explicit confirmation, operation id, and audit reason before apply becomes available.',
+  'Denied, unsupported, auth-required, validation failed, and partial failure states fail closed without exposing raw values.',
+]
+
+export const configurationSafeSurfaces = {
+  route: '/secrets-broker/configuration',
+  pageTitle: 'Service Admin - Secrets Broker Configuration',
+  breadcrumb: 'Secrets Broker / Configuration',
+  diagnostics:
+    'provider_config=handles_only; migration=dry_run_first; raw_values=hidden',
+  supportBundle:
+    'provider configuration and migration include provider ids, refs, status, and audit metadata only; credentials and raw values omitted',
+  persistedStorage: 'none',
+}
+
+const forbiddenSecretPattern =
+  /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9]|fixture-provider-credential-value|credential-value)/i
+
+export function configurationFixturesHaveSecretMaterial() {
+  return forbiddenSecretPattern.test(
+    JSON.stringify({
+      providerConfigurations,
+      migrationPlans,
+      configurationSafeSurfaces,
+    })
+  )
+}

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -250,7 +250,7 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.queryByText(singleSecretRevealReference.fakeRawValue)
     ).not.toBeInTheDocument()
-  })
+  }, 10000)
 
   it('keeps single-secret reveal safe surfaces free of raw material', () => {
     expect(singleSecretRevealScenarios.map((scenario) => scenario.id)).toEqual([

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -53,6 +53,7 @@ import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_a
 import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_authenticated/settings/account'
 import { Route as AuthenticatedServicesServiceIdRouteImport } from './routes/_authenticated/services.$serviceId'
 import { Route as AuthenticatedSecretsBrokerSecretsRouteImport } from './routes/_authenticated/secrets-broker/secrets'
+import { Route as AuthenticatedSecretsBrokerConfigurationRouteImport } from './routes/_authenticated/secrets-broker/configuration'
 import { Route as AuthenticatedSecretsBrokerConnectionIdRouteImport } from './routes/_authenticated/secrets-broker.$connectionId'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
@@ -295,6 +296,12 @@ const AuthenticatedSecretsBrokerSecretsRoute =
     path: '/secrets-broker/secrets',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedSecretsBrokerConfigurationRoute =
+  AuthenticatedSecretsBrokerConfigurationRouteImport.update({
+    id: '/secrets-broker/configuration',
+    path: '/secrets-broker/configuration',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSecretsBrokerConnectionIdRoute =
   AuthenticatedSecretsBrokerConnectionIdRouteImport.update({
     id: '/secrets-broker/$connectionId',
@@ -324,6 +331,7 @@ export interface FileRoutesByFullPath {
   '/503': typeof errors503Route
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -368,6 +376,7 @@ export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -417,6 +426,7 @@ export interface FileRoutesById {
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/errors/$error': typeof AuthenticatedErrorsErrorRoute
   '/_authenticated/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  '/_authenticated/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/_authenticated/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/_authenticated/services/$serviceId': typeof AuthenticatedServicesServiceIdRoute
   '/_authenticated/settings/account': typeof AuthenticatedSettingsAccountRoute
@@ -464,6 +474,7 @@ export interface FileRouteTypes {
     | '/503'
     | '/errors/$error'
     | '/secrets-broker/$connectionId'
+    | '/secrets-broker/configuration'
     | '/secrets-broker/secrets'
     | '/services/$serviceId'
     | '/settings/account'
@@ -508,6 +519,7 @@ export interface FileRouteTypes {
     | '/'
     | '/errors/$error'
     | '/secrets-broker/$connectionId'
+    | '/secrets-broker/configuration'
     | '/secrets-broker/secrets'
     | '/services/$serviceId'
     | '/settings/account'
@@ -556,6 +568,7 @@ export interface FileRouteTypes {
     | '/_authenticated/'
     | '/_authenticated/errors/$error'
     | '/_authenticated/secrets-broker/$connectionId'
+    | '/_authenticated/secrets-broker/configuration'
     | '/_authenticated/secrets-broker/secrets'
     | '/_authenticated/services/$serviceId'
     | '/_authenticated/settings/account'
@@ -911,6 +924,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSecretsBrokerSecretsRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/configuration': {
+      id: '/_authenticated/secrets-broker/configuration'
+      path: '/secrets-broker/configuration'
+      fullPath: '/secrets-broker/configuration'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerConfigurationRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/secrets-broker/$connectionId': {
       id: '/_authenticated/secrets-broker/$connectionId'
       path: '/secrets-broker/$connectionId'
@@ -956,6 +976,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedErrorsErrorRoute: typeof AuthenticatedErrorsErrorRoute
   AuthenticatedSecretsBrokerConnectionIdRoute: typeof AuthenticatedSecretsBrokerConnectionIdRoute
+  AuthenticatedSecretsBrokerConfigurationRoute: typeof AuthenticatedSecretsBrokerConfigurationRoute
   AuthenticatedSecretsBrokerSecretsRoute: typeof AuthenticatedSecretsBrokerSecretsRoute
   AuthenticatedServicesServiceIdRoute: typeof AuthenticatedServicesServiceIdRoute
   AuthenticatedAppsIndexRoute: typeof AuthenticatedAppsIndexRoute
@@ -984,6 +1005,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedErrorsErrorRoute: AuthenticatedErrorsErrorRoute,
   AuthenticatedSecretsBrokerConnectionIdRoute:
     AuthenticatedSecretsBrokerConnectionIdRoute,
+  AuthenticatedSecretsBrokerConfigurationRoute:
+    AuthenticatedSecretsBrokerConfigurationRoute,
   AuthenticatedSecretsBrokerSecretsRoute:
     AuthenticatedSecretsBrokerSecretsRoute,
   AuthenticatedServicesServiceIdRoute: AuthenticatedServicesServiceIdRoute,

--- a/src/routes/_authenticated/secrets-broker/configuration.tsx
+++ b/src/routes/_authenticated/secrets-broker/configuration.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { ProviderConfigurationPage } from '@/features/secrets-broker/provider-configuration-page'
+
+export const Route = createFileRoute(
+  '/_authenticated/secrets-broker/configuration'
+)({
+  component: ProviderConfigurationPage,
+})

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -99,6 +99,7 @@ test.describe('Secrets Broker browser coverage', () => {
     const navLinks = [
       ['Overview / Setup', /\/secrets-broker$/],
       ['Secrets', /\/secrets-broker\/secrets$/],
+      ['Configuration', /\/secrets-broker\/configuration$/],
       ['Sources / Backends', /\/secrets-broker#secret-sources$/],
       ['Provider Connections', /\/secrets-broker#provider-connections$/],
       ['Single Reveal', /\/secrets-broker#privileged-secret-reveal$/],
@@ -172,6 +173,66 @@ test.describe('Secrets Broker browser coverage', () => {
       })
     ).toBeDisabled()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('covers the Configuration sub-page provider and migration states', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker/configuration')
+    await expectNoBlankScreen(page)
+    await expect(
+      page.getByRole('heading', { name: /^Configuration$/ })
+    ).toBeVisible()
+    await expect(page.getByText(/Handles only · dry-run first/i)).toBeVisible()
+    await expect(page.getByText(/Credential values shown/i)).toBeVisible()
+
+    await page.getByLabel(/Provider state scenario/i).selectOption('healthy')
+    await expect(
+      page.getByText(/Provider configuration validated/i)
+    ).toBeVisible()
+    await page
+      .getByLabel(/Provider state scenario/i)
+      .selectOption('auth-required')
+    await expect(
+      page.getByText(/Provider requires credential ref refresh/i)
+    ).toBeVisible()
+    await page
+      .getByLabel(/Provider state scenario/i)
+      .selectOption('unsupported')
+    await expect(page.getByText(/cannot be a migration target/i)).toBeVisible()
+    await page
+      .getByLabel(/Provider state scenario/i)
+      .selectOption('validation-failed')
+    await expect(page.getByText(/Validation failed closed/i)).toBeVisible()
+
+    await page
+      .getByLabel(/Migration state scenario/i)
+      .selectOption('dry-run-partial')
+    await expect(
+      page.getByText(/Migration dry-run partial denial/i)
+    ).toBeVisible()
+    await expect(page.getByText(/partial_failure/i)).toBeVisible()
+    await page
+      .getByLabel(/Migration state scenario/i)
+      .selectOption('apply-ready')
+    await page.getByLabel(/Audit reason/i).fill('approved migration')
+    await page.getByRole('button', { name: /Record confirmation/i }).click()
+    await expect(
+      page.getByRole('button', { name: /Migration apply ready/i })
+    ).toBeEnabled()
+    await page
+      .getByLabel(/Migration state scenario/i)
+      .selectOption('apply-partial')
+    await expect(
+      page.getByText(/Migration partial failure/i).last()
+    ).toBeVisible()
+    await expect(page.getByText(/Provider credentials hidden/i)).toBeVisible()
+    await expect(
+      page.getByText(/fixture-provider-credential-value/i)
+    ).toHaveCount(0)
+    await expect(page.getByText(/fixture-managed-secret-value/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])
   })


### PR DESCRIPTION
## Summary
- Add `Secrets Broker > Configuration` route and sidebar navigation.
- Add a safe provider configuration screen with current provider/backend summary, provider state scenarios, validation/test-connection preview, and capability summary.
- Add migration dry-run/apply workflow states with metadata-only per-ref status, partial failure reporting, rollback/recovery guidance, audit reason, operation id, and explicit confirmation gating.
- Add unit and Playwright coverage for provider states, validation, dry-run/apply gating, partial failures, route/nav reachability, and no-leak assertions.

## Safety notes
- Provider credentials are modeled as safe refs/handles only; plaintext credential values are not rendered or persisted.
- Raw secret values are not rendered in provider status, validation, migration list, dry-run, or apply previews.
- Migration apply remains disabled until the apply-ready state, audit reason, and explicit confirmation are present.
- This does not implement #40 bulk edit/rotation campaigns; it is the #84 provider configuration/migration screen.

## Validation
- `npm test -- src/features/secrets-broker/provider-configuration.test.tsx` — 4 passed
- `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — 7 passed
- `npm run lint` — passed with 7 pre-existing unrelated warnings
- `npm run build` — passed

Closes #84
Related: service-lasso/lasso-secretsbroker#36, service-lasso/lasso-serviceadmin#40, service-lasso/lasso-serviceadmin#81
