### PR TITLE
ISS-81 add single-connection edit rotation workflow

### DIFF
--- a/src/features/secrets-broker/connection-detail.tsx
+++ b/src/features/secrets-broker/connection-detail.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import {
   AlertTriangle,
@@ -19,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
@@ -34,6 +36,11 @@ import {
   type SecretsBrokerProviderLifecycleStatus,
   type SecretsBrokerSecretMaterialState,
 } from './provider-connections'
+import {
+  buildSingleConnectionRotationPlan,
+  singleConnectionWorkflowStates,
+  type SingleConnectionWorkflowState,
+} from './single-connection-rotation'
 
 const connectionStateCopy: Record<
   SecretsBrokerProviderConnectionState,
@@ -156,6 +163,181 @@ function MetadataGrid({
         </div>
       ))}
     </div>
+  )
+}
+
+function SingleConnectionEditRotationWorkflow({
+  connection,
+}: {
+  connection: SecretsBrokerProviderConnectionDetail
+}) {
+  const [workflowState, setWorkflowState] =
+    useState<SingleConnectionWorkflowState>('dry-run-ready')
+  const [auditReason, setAuditReason] = useState('')
+  const [confirmedConnectionId, setConfirmedConnectionId] = useState('')
+  const [cancelled, setCancelled] = useState(false)
+
+  const plan = useMemo(
+    () =>
+      buildSingleConnectionRotationPlan(
+        connection,
+        cancelled ? 'cancelled' : workflowState
+      ),
+    [cancelled, connection, workflowState]
+  )
+  const applyReady =
+    plan.applyEnabled &&
+    auditReason.trim().length > 0 &&
+    confirmedConnectionId === connection.id
+
+  return (
+    <Card id='single-connection-edit-rotation'>
+      <CardHeader>
+        <CardTitle>Single-connection edit and rotation workflow</CardTitle>
+        <CardDescription>
+          Focused dry-run/preview/apply surface for one provider connection.
+          Bulk mutation is intentionally out of scope for #81.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <div className='grid gap-4 lg:grid-cols-3'>
+          <div className='space-y-2'>
+            <label
+              htmlFor='single-connection-workflow-state'
+              className='text-sm font-medium text-muted-foreground'
+            >
+              Workflow state
+            </label>
+            <select
+              id='single-connection-workflow-state'
+              className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+              value={workflowState}
+              onChange={(event) => {
+                setCancelled(false)
+                setWorkflowState(
+                  event.target.value as SingleConnectionWorkflowState
+                )
+              }}
+            >
+              {singleConnectionWorkflowStates.map((state) => (
+                <option key={state.value} value={state.value}>
+                  {state.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className='space-y-2'>
+            <label
+              htmlFor='single-connection-audit-reason'
+              className='text-sm font-medium text-muted-foreground'
+            >
+              Audit reason
+            </label>
+            <Input
+              id='single-connection-audit-reason'
+              value={auditReason}
+              onChange={(event) => setAuditReason(event.target.value)}
+              placeholder='Required before apply'
+            />
+          </div>
+          <div className='space-y-2'>
+            <label
+              htmlFor='single-connection-confirmation'
+              className='text-sm font-medium text-muted-foreground'
+            >
+              Confirm connection id
+            </label>
+            <Input
+              id='single-connection-confirmation'
+              value={confirmedConnectionId}
+              onChange={(event) => setConfirmedConnectionId(event.target.value)}
+              placeholder={connection.id}
+            />
+          </div>
+        </div>
+
+        <div className='rounded-lg border p-3 text-sm'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <Badge variant='secondary'>{plan.outcome}</Badge>
+            <Badge variant='outline'>Operation {plan.operationId}</Badge>
+            <Badge variant='outline'>Raw values hidden</Badge>
+          </div>
+          <div className='mt-3 font-medium'>{plan.title}</div>
+          <p className='mt-1 text-muted-foreground'>{plan.status}</p>
+          <div className='mt-3 grid gap-2 md:grid-cols-2'>
+            <div>
+              <span className='text-muted-foreground'>Connection:</span>{' '}
+              {plan.connectionId}
+            </div>
+            <div>
+              <span className='text-muted-foreground'>Ref:</span>{' '}
+              {plan.connectionRef}
+            </div>
+            <div>
+              <span className='text-muted-foreground'>Next action:</span>{' '}
+              {plan.nextAction}
+            </div>
+            <div>
+              <span className='text-muted-foreground'>Recovery:</span>{' '}
+              {plan.recovery}
+            </div>
+          </div>
+        </div>
+
+        <div className='space-y-2'>
+          {plan.changes.map((change) => (
+            <div
+              key={`${plan.state}-${change.field}`}
+              className='grid gap-2 rounded-lg border p-3 text-sm lg:grid-cols-[1fr_1fr_auto]'
+            >
+              <div>
+                <div className='font-medium'>{change.field}</div>
+                <div className='break-all text-muted-foreground'>
+                  Current: {change.current}
+                </div>
+                <div className='break-all text-muted-foreground'>
+                  Proposed: {change.proposed}
+                </div>
+              </div>
+              <div>
+                <div>Policy: {change.policy}</div>
+                <div>Risk: {change.risk}</div>
+                <div>Status: {change.status}</div>
+              </div>
+              <Badge
+                variant={
+                  change.status === 'blocked' || change.status === 'failed'
+                    ? 'destructive'
+                    : change.status === 'applied'
+                      ? 'default'
+                      : 'secondary'
+                }
+              >
+                {change.status}
+              </Badge>
+            </div>
+          ))}
+        </div>
+
+        <div className='flex flex-wrap gap-2'>
+          <Button type='button' disabled={!applyReady}>
+            {applyReady
+              ? 'Apply single-connection rotation'
+              : 'Apply blocked until dry-run, audit reason, and exact connection confirmation'}
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={() => setCancelled(true)}
+          >
+            Cancel operation
+          </Button>
+          <Badge variant='secondary'>Dry-run before apply</Badge>
+          <Badge variant='outline'>Audit required</Badge>
+          <Badge variant='outline'>No bulk mutation</Badge>
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -541,6 +723,8 @@ export function SecretsBrokerProviderConnectionDetailPage({
             ))}
           </CardContent>
         </Card>
+
+        <SingleConnectionEditRotationWorkflow connection={connection} />
 
         <Card>
           <CardHeader>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -16,6 +16,10 @@ import {
   secretsBrokerProviderConnections,
 } from './provider-connections'
 import {
+  buildSingleConnectionRotationPlan,
+  singleConnectionRotationPlanHasSecretValue,
+} from './single-connection-rotation'
+import {
   revealFixtureLooksLikeProviderCredential,
   revealSafeSurfacesIncludeRawValue,
   singleSecretRevealReference,
@@ -450,6 +454,15 @@ describe('Secrets Broker setup wizard', () => {
       screen.getByText(/Existing services may need restart/i)
     ).toBeVisible()
     expect(
+      screen.getByText(/Single-connection edit and rotation workflow/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/Dry-run preview ready/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/single-rotation-preview-2026-05-08-ready/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Dry-run before apply/i)).toBeVisible()
+    expect(screen.getByText(/No bulk mutation/i)).toBeVisible()
+    expect(
       screen.getByRole('button', { name: /Delete connection/i })
     ).toBeVisible()
     expect(screen.queryByText(/supersecret/i)).not.toBeInTheDocument()
@@ -465,6 +478,107 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.queryByRole('button', { name: /Copy secret/i })
     ).not.toBeInTheDocument()
+  })
+
+  it('covers single-connection edit rotation dry-run and apply states safely', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/local-default')
+
+    expect(screen.getAllByText(/Dry-run preview ready/i)[0]).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /Apply blocked until dry-run, audit reason, and exact connection confirmation/i,
+      })
+    ).toBeDisabled()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'dry-run-denied'
+    )
+    expect(screen.getByText(/Dry-run denied by policy/i)).toBeVisible()
+    expect(screen.getByText(/Policy denied the proposed/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'auth-required'
+    )
+    expect(screen.getByText(/Provider auth required/i)).toBeVisible()
+    expect(
+      screen.getByText(/Reconnect provider through a safe credential ref/i)
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'backend-unavailable'
+    )
+    expect(
+      screen.getByText(/Backend unavailable or unsupported/i)
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'audit-unavailable'
+    )
+    expect(
+      screen.getAllByText(/Audit unavailable \/ apply blocked/i)[0]
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'apply-ready'
+    )
+    await user.type(
+      screen.getByLabelText(/Audit reason/i),
+      'rotate after approval'
+    )
+    await user.type(
+      screen.getByLabelText(/Confirm connection id/i),
+      'local-default'
+    )
+    expect(
+      screen.getByRole('button', { name: /Apply single-connection rotation/i })
+    ).toBeEnabled()
+
+    await user.click(screen.getByRole('button', { name: /Cancel operation/i }))
+    expect(screen.getByText(/Operation cancelled/i)).toBeVisible()
+    expect(screen.getByText(/no provider metadata changed/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'apply-success'
+    )
+    expect(screen.getAllByText(/Apply success/i)[0]).toBeVisible()
+    await user.selectOptions(
+      screen.getByLabelText(/Workflow state/i),
+      'apply-failed'
+    )
+    expect(
+      screen.getAllByText(/Apply failure status feedback/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.queryByText(/DETERMINISTIC_FAKE_ROTATION_VALUE_81/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps single-connection rotation plans free of raw material', () => {
+    const connection = secretsBrokerProviderConnections[0]
+    for (const state of [
+      'dry-run-ready',
+      'dry-run-denied',
+      'auth-required',
+      'backend-unavailable',
+      'audit-unavailable',
+      'cancelled',
+      'apply-ready',
+      'apply-success',
+      'apply-failed',
+    ] as const) {
+      expect(
+        singleConnectionRotationPlanHasSecretValue(
+          buildSingleConnectionRotationPlan(connection, state)
+        )
+      ).toBe(false)
+    }
   })
 
   it('explains degraded and missing provider connection next actions', async () => {

--- a/src/features/secrets-broker/single-connection-rotation.ts
+++ b/src/features/secrets-broker/single-connection-rotation.ts
@@ -1,0 +1,247 @@
+import type { SecretsBrokerProviderConnectionDetail } from './provider-connections'
+
+export type SingleConnectionWorkflowState =
+  | 'dry-run-ready'
+  | 'dry-run-denied'
+  | 'auth-required'
+  | 'backend-unavailable'
+  | 'audit-unavailable'
+  | 'cancelled'
+  | 'apply-ready'
+  | 'apply-success'
+  | 'apply-failed'
+
+export type SingleConnectionRotationPlan = {
+  state: SingleConnectionWorkflowState
+  title: string
+  outcome: string
+  operationId: string
+  connectionId: string
+  connectionRef: string
+  action: 'edit' | 'rotate' | 'revoke'
+  dryRunRequired: boolean
+  applyEnabled: boolean
+  confirmationRequired: boolean
+  auditRequired: boolean
+  status: string
+  nextAction: string
+  recovery: string
+  changes: Array<{
+    field: string
+    current: string
+    proposed: string
+    policy: 'allowed' | 'denied' | 'review'
+    risk: 'low' | 'medium' | 'high'
+    status: 'planned' | 'blocked' | 'cancelled' | 'applied' | 'failed'
+  }>
+}
+
+const baseChanges: SingleConnectionRotationPlan['changes'] = [
+  {
+    field: 'credential handle',
+    current: 'ref:secret://local/provider/vault-ops/current-handle',
+    proposed: 'ref:secret://local/provider/vault-ops/rotated-handle',
+    policy: 'allowed',
+    risk: 'medium',
+    status: 'planned',
+  },
+  {
+    field: 'rotation window',
+    current: 'next maintenance window',
+    proposed: 'approved immediate rotation window',
+    policy: 'review',
+    risk: 'medium',
+    status: 'planned',
+  },
+]
+
+export function buildSingleConnectionRotationPlan(
+  connection: SecretsBrokerProviderConnectionDetail,
+  state: SingleConnectionWorkflowState
+): SingleConnectionRotationPlan {
+  const base = {
+    state,
+    connectionId: connection.id,
+    connectionRef: connection.connectionRef,
+    action: 'rotate' as const,
+    dryRunRequired: true,
+    confirmationRequired: true,
+    auditRequired: true,
+  }
+
+  if (state === 'dry-run-denied') {
+    return {
+      ...base,
+      title: 'Dry-run denied by policy',
+      outcome: 'denied',
+      operationId: 'single-rotation-preview-2026-05-08-denied',
+      applyEnabled: false,
+      status: 'Policy denied the proposed credential handle rotation.',
+      nextAction:
+        'Review workspace policy and rerun dry-run; apply remains blocked.',
+      recovery: 'No values changed; keep existing credential handle active.',
+      changes: baseChanges.map((change, index) => ({
+        ...change,
+        policy: index === 0 ? 'denied' : change.policy,
+        status: index === 0 ? 'blocked' : change.status,
+      })),
+    }
+  }
+
+  if (state === 'auth-required') {
+    return {
+      ...base,
+      title: 'Provider auth required',
+      outcome: 'auth_required',
+      operationId: 'single-rotation-preview-2026-05-08-auth',
+      applyEnabled: false,
+      status:
+        'Provider credential handle cannot be validated until reconnect completes.',
+      nextAction:
+        'Reconnect provider through a safe credential ref before dry-run/apply.',
+      recovery: 'Existing connection metadata remains unchanged.',
+      changes: baseChanges.map((change) => ({ ...change, status: 'blocked' })),
+    }
+  }
+
+  if (state === 'backend-unavailable') {
+    return {
+      ...base,
+      title: 'Backend unavailable or unsupported',
+      outcome: 'backend_unavailable',
+      operationId: 'single-rotation-preview-2026-05-08-backend',
+      applyEnabled: false,
+      status:
+        'Broker reports this backend cannot apply single-connection mutation now.',
+      nextAction:
+        'Wait for backend capability/health to recover, then rerun dry-run.',
+      recovery:
+        'No changes applied; dependents continue using current metadata.',
+      changes: baseChanges.map((change) => ({ ...change, status: 'blocked' })),
+    }
+  }
+
+  if (state === 'audit-unavailable') {
+    return {
+      ...base,
+      title: 'Audit unavailable / apply blocked',
+      outcome: 'audit_unavailable',
+      operationId: 'single-rotation-preview-2026-05-08-audit',
+      applyEnabled: false,
+      status: 'Audit recording is unavailable, so apply fails closed.',
+      nextAction:
+        'Restore audit writer before previewed edit or rotation can apply.',
+      recovery:
+        'No changes applied; operation must be repeated after audit repair.',
+      changes: baseChanges,
+    }
+  }
+
+  if (state === 'cancelled') {
+    return {
+      ...base,
+      title: 'Operation cancelled',
+      outcome: 'cancelled',
+      operationId: 'single-rotation-cancelled-2026-05-08',
+      applyEnabled: false,
+      status: 'Operator cancelled before apply; no provider metadata changed.',
+      nextAction: 'Rerun dry-run if rotation is still required.',
+      recovery: 'No rollback required because apply did not start.',
+      changes: baseChanges.map((change) => ({
+        ...change,
+        status: 'cancelled',
+      })),
+    }
+  }
+
+  if (state === 'apply-ready') {
+    return {
+      ...base,
+      title: 'Apply ready after explicit confirmation',
+      outcome: 'ready_for_apply',
+      operationId: 'single-rotation-apply-2026-05-08-ready',
+      applyEnabled: true,
+      status:
+        'Dry-run is clean; apply remains gated by confirmation and audit reason.',
+      nextAction:
+        'Record audit reason, confirm exact connection id, then apply once.',
+      recovery:
+        'Use previous credential handle metadata if dependent service checks fail.',
+      changes: baseChanges,
+    }
+  }
+
+  if (state === 'apply-success') {
+    return {
+      ...base,
+      title: 'Apply success',
+      outcome: 'applied',
+      operationId: 'single-rotation-apply-2026-05-08-success',
+      applyEnabled: false,
+      status:
+        'Rotation metadata applied; dependent services should refresh/test next.',
+      nextAction:
+        'Run refresh/test and monitor audit events for dependent failures.',
+      recovery:
+        'Previous handle remains available to broker rollback tooling by ref only.',
+      changes: baseChanges.map((change) => ({ ...change, status: 'applied' })),
+    }
+  }
+
+  if (state === 'apply-failed') {
+    return {
+      ...base,
+      title: 'Apply failure status feedback',
+      outcome: 'apply_failed',
+      operationId: 'single-rotation-apply-2026-05-08-failed',
+      applyEnabled: false,
+      status:
+        'Apply failed after audit start; current metadata remains authoritative.',
+      nextAction:
+        'Use recovery guidance, inspect safe diagnostics, then rerun dry-run.',
+      recovery:
+        'Partial work is recoverable by operation id; raw values are never exported.',
+      changes: baseChanges.map((change, index) => ({
+        ...change,
+        status: index === 0 ? 'failed' : 'blocked',
+      })),
+    }
+  }
+
+  return {
+    ...base,
+    title: 'Dry-run preview ready',
+    outcome: 'dry_run_ready',
+    operationId: 'single-rotation-preview-2026-05-08-ready',
+    applyEnabled: false,
+    status:
+      'Preview generated with refs and metadata only; raw values were not loaded.',
+    nextAction:
+      'Review plan, record audit reason, and confirm before enabling apply.',
+    recovery: 'No rollback required for dry-run; no provider state changed.',
+    changes: baseChanges,
+  }
+}
+
+export const singleConnectionWorkflowStates: Array<{
+  value: SingleConnectionWorkflowState
+  label: string
+}> = [
+  { value: 'dry-run-ready', label: 'Dry-run preview ready' },
+  { value: 'dry-run-denied', label: 'Denied by policy' },
+  { value: 'auth-required', label: 'Auth required' },
+  { value: 'backend-unavailable', label: 'Backend unavailable / unsupported' },
+  { value: 'audit-unavailable', label: 'Audit unavailable / apply blocked' },
+  { value: 'cancelled', label: 'Cancelled operation' },
+  { value: 'apply-ready', label: 'Apply ready after confirmation' },
+  { value: 'apply-success', label: 'Apply success' },
+  { value: 'apply-failed', label: 'Apply failure feedback' },
+]
+
+export function singleConnectionRotationPlanHasSecretValue(
+  plan: SingleConnectionRotationPlan
+) {
+  return /hunter2|correct-horse|plain\s*text\s*secret|supersecret|sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|AKIA[0-9A-Z]{16}|password\s*=|token\s*=|DETERMINISTIC_FAKE_ROTATION_VALUE_81/i.test(
+    JSON.stringify(plan)
+  )
+}

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -355,6 +355,36 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Secret material state/i)).toBeVisible()
     await expect(page.getByText(/Raw value: hidden/i)).toBeVisible()
     await expect(page.getByText(/Copy value: unavailable/i)).toBeVisible()
+    await expect(
+      page.getByText(/Single-connection edit and rotation workflow/i)
+    ).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('dry-run-denied')
+    await expect(page.getByText(/Dry-run denied by policy/i)).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('auth-required')
+    await expect(page.getByText(/Provider auth required/i)).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('backend-unavailable')
+    await expect(
+      page.getByText(/Backend unavailable or unsupported/i)
+    ).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('audit-unavailable')
+    await expect(
+      page.getByText(/Audit unavailable \/ apply blocked/i).last()
+    ).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('apply-ready')
+    await page.getByLabel(/Audit reason/i).fill('rotate after approval')
+    await page.getByLabel(/Confirm connection id/i).fill('local-default')
+    await expect(
+      page.getByRole('button', { name: /Apply single-connection rotation/i })
+    ).toBeEnabled()
+    await page.getByRole('button', { name: /Cancel operation/i }).click()
+    await expect(page.getByText(/Operation cancelled/i)).toBeVisible()
+    await page.getByLabel(/Workflow state/i).selectOption('apply-failed')
+    await expect(
+      page.getByText(/Apply failure status feedback/i).last()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/DETERMINISTIC_FAKE_ROTATION_VALUE_81/i)
+    ).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])
   })


### PR DESCRIPTION
## Summary

Implements the #81 prerequisite slice for a focused single-connection Secrets Broker edit/rotation workflow in Service Admin.

- adds a metadata-only dry-run/preview/apply workflow to the provider connection detail page
- covers dry-run ready, policy-denied, auth-required, backend unavailable, audit unavailable, cancelled, apply-ready, success, and failure states
- gates apply behind audit reason plus exact connection-id confirmation
- keeps bulk mutation, plaintext export/copy, and provider credential management out of scope
- adds reusable plan construction and secret-leak guard tests

## Safety / scope notes

- Raw values remain hidden; workflow uses connection refs/metadata only.
- No bulk spreadsheet/editor/apply path is added.
- Backend policy/audit enforcement is represented as required integration posture only; this UI does not claim live backend enforcement.

## Validation

- `npm test` — 16 files / 109 tests passed
- `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 26 tests passed
- `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — 7 Playwright tests passed
- `npm run lint` — passed with existing warnings in unrelated installed/logs/network/runtime/variables files
- `npm run build` — passed

Closes #81
