### PR TITLE
ISS-87 add Secrets Broker audit event viewer

### DIFF
--- a/src/features/secrets-broker/audit-events.test.tsx
+++ b/src/features/secrets-broker/audit-events.test.tsx
@@ -1,0 +1,103 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import {
+  auditEventsContainSecretMaterial,
+  filterSecretsBrokerAuditEvents,
+  secretsBrokerAuditEvents,
+} from './audit-events'
+
+describe('Secrets Broker audit event viewer', () => {
+  it('renders audit event metadata, detail, and tamper-evidence status safely', async () => {
+    await renderRoute('/secrets-broker')
+
+    expect(
+      await screen.findByRole('heading', { name: /Secrets Broker setup/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Audit and events/i)).toBeVisible()
+    expect(screen.getByText(/Values never rendered/i)).toBeVisible()
+    expect(screen.getByText(/Tamper evidence verified/i)).toBeVisible()
+    expect(screen.getByText(/chain: audit-chain\/openclaw/i)).toBeVisible()
+    expect(screen.getAllByText(/Policy decision/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Affected refs/i)[0]).toBeVisible()
+    expect(
+      screen.getAllByText(/Affected services\/workflows/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/startup dependency resolution/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Event details use safe identifiers/i)
+    ).toBeVisible()
+  })
+
+  it('filters by event type, outcome, provider, source, and tamper evidence', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Event type/i),
+      'migration_completed'
+    )
+    expect(screen.getAllByText(/migration completed/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/approved backend migration/i)[0]).toBeVisible()
+
+    await user.selectOptions(screen.getByLabelText(/Outcome/i), 'success')
+    await user.selectOptions(screen.getByLabelText(/Audit provider/i), 'vault')
+    expect(screen.getByText(/Local to Vault migration/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Tamper evidence/i),
+      'verified'
+    )
+    expect(
+      screen.getByText(/Migration summary and counts were verified/i)
+    ).toBeVisible()
+
+    await user.clear(screen.getByLabelText(/Source \/ actor/i))
+    await user.type(screen.getByLabelText(/Source \/ actor/i), 'billing-worker')
+    expect(screen.getByText(/billing-worker/i)).toBeVisible()
+  })
+
+  it('shows broken and unavailable tamper-evidence states without leaking payloads', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker')
+
+    await user.selectOptions(
+      screen.getByLabelText(/Tamper evidence/i),
+      'broken'
+    )
+    expect(screen.getByText(/Tamper evidence broken/i)).toBeVisible()
+    expect(screen.getByText(/investigation required/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Tamper evidence/i),
+      'unavailable'
+    )
+    expect(screen.getByText(/Tamper evidence unavailable/i)).toBeVisible()
+    expect(screen.getByText(/Provider is auth-required/i)).toBeVisible()
+    expect(screen.getByText(/sequence: unavailable/i)).toBeVisible()
+  })
+
+  it('keeps audit fixtures and rendered safe surface free of raw secret material', async () => {
+    expect(auditEventsContainSecretMaterial()).toBe(false)
+    expect(
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        tamperEvidence: 'verified',
+      })
+    ).toHaveLength(7)
+    expect(
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        query: 'STRIPE_API_TOKEN',
+      })
+    ).toHaveLength(1)
+
+    const { container } = await renderRoute('/secrets-broker')
+    expect(container).not.toHaveTextContent(/DEMO_REVEAL_VALUE_42/i)
+    expect(container).not.toHaveTextContent(/ACTUAL_SECRET/i)
+    expect(container).not.toHaveTextContent(/BEGIN PRIVATE KEY/i)
+    expect(container).not.toHaveTextContent(/CLIENT_SECRET=/i)
+    expect(container).not.toHaveTextContent(/REFRESH_TOKEN=/i)
+  })
+})

--- a/src/features/secrets-broker/audit-events.test.tsx
+++ b/src/features/secrets-broker/audit-events.test.tsx
@@ -1,6 +1,5 @@
 import { renderRoute } from '@/test/render-route'
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
   auditEventsContainSecretMaterial,
@@ -32,52 +31,41 @@ describe('Secrets Broker audit event viewer', () => {
     ).toBeVisible()
   })
 
-  it('filters by event type, outcome, provider, source, and tamper evidence', async () => {
-    const user = userEvent.setup()
-    await renderRoute('/secrets-broker')
+  it('filters by event type, outcome, provider, source, and tamper evidence', () => {
+    const filtered = filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+      type: 'migration_completed',
+      outcome: 'success',
+      provider: 'vault',
+      tamperEvidence: 'verified',
+      query: 'billing-worker',
+      since: '2026-05-07T18:00:00Z',
+      until: '2026-05-07T18:30:00Z',
+    })
 
-    await user.selectOptions(
-      screen.getByLabelText(/Event type/i),
-      'migration_completed'
-    )
-    expect(screen.getAllByText(/migration completed/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/approved backend migration/i)[0]).toBeVisible()
-
-    await user.selectOptions(screen.getByLabelText(/Outcome/i), 'success')
-    await user.selectOptions(screen.getByLabelText(/Audit provider/i), 'vault')
-    expect(screen.getByText(/Local to Vault migration/i)).toBeVisible()
-
-    await user.selectOptions(
-      screen.getByLabelText(/Tamper evidence/i),
-      'verified'
-    )
-    expect(
-      screen.getByText(/Migration summary and counts were verified/i)
-    ).toBeVisible()
-
-    await user.clear(screen.getByLabelText(/Source \/ actor/i))
-    await user.type(screen.getByLabelText(/Source \/ actor/i), 'billing-worker')
-    expect(screen.getByText(/billing-worker/i)).toBeVisible()
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toMatchObject({
+      type: 'migration_completed',
+      outcome: 'success',
+      provider: 'vault',
+      auditReason: 'approved backend migration',
+    })
   })
 
-  it('shows broken and unavailable tamper-evidence states without leaking payloads', async () => {
-    const user = userEvent.setup()
-    await renderRoute('/secrets-broker')
+  it('models broken and unavailable tamper-evidence states without payloads', () => {
+    expect(
+      filterSecretsBrokerAuditEvents(secretsBrokerAuditEvents, {
+        tamperEvidence: 'broken',
+      })[0].tamperEvidence.note
+    ).toMatch(/investigation required/i)
 
-    await user.selectOptions(
-      screen.getByLabelText(/Tamper evidence/i),
-      'broken'
-    )
-    expect(screen.getByText(/Tamper evidence broken/i)).toBeVisible()
-    expect(screen.getByText(/investigation required/i)).toBeVisible()
-
-    await user.selectOptions(
-      screen.getByLabelText(/Tamper evidence/i),
-      'unavailable'
-    )
-    expect(screen.getByText(/Tamper evidence unavailable/i)).toBeVisible()
-    expect(screen.getByText(/Provider is auth-required/i)).toBeVisible()
-    expect(screen.getByText(/sequence: unavailable/i)).toBeVisible()
+    const unavailable = filterSecretsBrokerAuditEvents(
+      secretsBrokerAuditEvents,
+      {
+        tamperEvidence: 'unavailable',
+      }
+    )[0]
+    expect(unavailable.tamperEvidence.sequence).toBeNull()
+    expect(unavailable.tamperEvidence.note).toMatch(/auth-required/i)
   })
 
   it('keeps audit fixtures and rendered safe surface free of raw secret material', async () => {

--- a/src/features/secrets-broker/audit-events.ts
+++ b/src/features/secrets-broker/audit-events.ts
@@ -1,11 +1,17 @@
 export type SecretsBrokerAuditEventType =
   | 'resolve_granted'
   | 'resolve_denied'
+  | 'reveal_granted'
+  | 'reveal_denied'
   | 'external_provider_read'
   | 'refresh_failure'
   | 'reconnect_required'
   | 'session_token_revoked'
   | 'write_back_denied'
+  | 'write_back_committed'
+  | 'migration_started'
+  | 'migration_completed'
+  | 'policy_changed'
   | 'secret_rotated'
 
 export type SecretsBrokerAuditOutcome =
@@ -14,6 +20,11 @@ export type SecretsBrokerAuditOutcome =
   | 'failure'
   | 'revoked'
   | 'success'
+
+export type SecretsBrokerAuditTamperEvidenceStatus =
+  | 'verified'
+  | 'broken'
+  | 'unavailable'
 
 export type SecretsBrokerAuditEvent = {
   id: string
@@ -27,15 +38,28 @@ export type SecretsBrokerAuditEvent = {
   actorType: 'service' | 'workflow' | 'operator' | 'cli-session'
   actorId: string
   ref: string
+  affectedRefs: string[]
+  affectedServices: string[]
   policyId: string
   policyDecision: string
   normalizedReason: string
+  auditReason: string
+  tamperEvidence: {
+    status: SecretsBrokerAuditTamperEvidenceStatus
+    chainId: string
+    sequence: number | null
+    previousHashRef: string | null
+    entryHashRef: string | null
+    checkedAt: string | null
+    note: string
+  }
 }
 
 export type SecretsBrokerAuditFilters = {
   type?: SecretsBrokerAuditEventType | 'all'
   outcome?: SecretsBrokerAuditOutcome | 'all'
   provider?: SecretsBrokerAuditEvent['provider'] | 'all'
+  tamperEvidence?: SecretsBrokerAuditTamperEvidenceStatus | 'all'
   query?: string
   since?: string
   until?: string
@@ -54,9 +78,21 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'service',
     actorId: '@serviceadmin',
     ref: 'openclaw/anthropic/api_key',
+    affectedRefs: ['openclaw/anthropic/api_key'],
+    affectedServices: ['@serviceadmin'],
     policyId: 'policy/openclaw/service-lasso/read',
     policyDecision: 'allow: namespace and service identity matched',
     normalizedReason: 'Resolver granted access to the requested SecretRef.',
+    auditReason: 'startup dependency resolution',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/openclaw/service-lasso/2026-05-07',
+      sequence: 1842,
+      previousHashRef: 'sha256:prev-openclaw-1841',
+      entryHashRef: 'sha256:event-openclaw-1842',
+      checkedAt: '2026-05-07T18:20:05Z',
+      note: 'Hash chain verified by broker metadata endpoint.',
+    },
   },
   {
     id: 'evt-20260507-002',
@@ -70,10 +106,22 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'service',
     actorId: 'postgres',
     ref: 'postgres.ADMIN_PASSWORD',
+    affectedRefs: ['postgres.ADMIN_PASSWORD'],
+    affectedServices: ['postgres'],
     policyId: 'policy/local/default/read',
     policyDecision: 'deny: service identity missing ref grant',
     normalizedReason:
       'Policy denied the read request before any value was resolved.',
+    auditReason: 'service startup preflight',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/local/default/2026-05-07',
+      sequence: 778,
+      previousHashRef: 'sha256:prev-local-777',
+      entryHashRef: 'sha256:event-local-778',
+      checkedAt: '2026-05-07T18:19:20Z',
+      note: 'Denial event is present in the verified local chain.',
+    },
   },
   {
     id: 'evt-20260507-003',
@@ -87,10 +135,22 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'operator',
     actorId: 'operator:max',
     ref: 'telegram.bot_token',
+    affectedRefs: ['telegram.bot_token'],
+    affectedServices: ['telegram-alerts', '@serviceadmin'],
     policyId: 'policy/external/ops/refresh',
     policyDecision: 'allow: refresh attempted',
     normalizedReason:
       'External provider refresh failed because source authentication is required.',
+    auditReason: 'provider reconnect check',
+    tamperEvidence: {
+      status: 'unavailable',
+      chainId: 'audit-chain/vault/ops/2026-05-07',
+      sequence: null,
+      previousHashRef: null,
+      entryHashRef: null,
+      checkedAt: null,
+      note: 'Provider is auth-required, so chain proof cannot be fetched yet.',
+    },
   },
   {
     id: 'evt-20260507-004',
@@ -104,9 +164,21 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'cli-session',
     actorId: 'session:rotated',
     ref: 'openclaw/session_token',
+    affectedRefs: ['openclaw/session_token'],
+    affectedServices: ['cli:service-lasso'],
     policyId: 'policy/openclaw/session/lifecycle',
     policyDecision: 'revoke: token replaced by newer session',
     normalizedReason: 'Session credential was revoked after rotation.',
+    auditReason: 'session rotation',
+    tamperEvidence: {
+      status: 'broken',
+      chainId: 'audit-chain/openclaw/session/2026-05-07',
+      sequence: 91,
+      previousHashRef: 'sha256:prev-session-090',
+      entryHashRef: 'sha256:event-session-091',
+      checkedAt: '2026-05-07T18:17:30Z',
+      note: 'Broker reported a previous-entry mismatch; treat as investigation required.',
+    },
   },
   {
     id: 'evt-20260507-005',
@@ -120,10 +192,22 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'workflow',
     actorId: 'dagu:daily-ai-summary/run/20260507',
     ref: 'openclaw/anthropic/api_key',
+    affectedRefs: ['openclaw/anthropic/api_key'],
+    affectedServices: ['dagu:daily-ai-summary'],
     policyId: 'policy/workflows/ai-summary/read',
     policyDecision: 'allow: workflow run identity matched',
     normalizedReason:
       'External provider returned metadata for a successful read.',
+    auditReason: 'workflow SecretRef resolution',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/onepassword/ops/2026-05-07',
+      sequence: 122,
+      previousHashRef: 'sha256:prev-1password-121',
+      entryHashRef: 'sha256:event-1password-122',
+      checkedAt: '2026-05-07T18:16:10Z',
+      note: 'Provider read event was appended and verified by broker metadata.',
+    },
   },
   {
     id: 'evt-20260507-006',
@@ -137,11 +221,123 @@ export const secretsBrokerAuditEvents: SecretsBrokerAuditEvent[] = [
     actorType: 'service',
     actorId: '@serviceadmin',
     ref: '@serviceadmin/SESSION_SECRET',
+    affectedRefs: ['@serviceadmin/SESSION_SECRET'],
+    affectedServices: ['@serviceadmin'],
     policyId: 'policy/local/default/write-back',
     policyDecision: 'deny: write-back requires operator audit reason',
     normalizedReason:
       'Generated secret write-back was denied before storing a value.',
+    auditReason: 'generated secret dry-run',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/local/default/2026-05-07',
+      sequence: 777,
+      previousHashRef: 'sha256:prev-local-776',
+      entryHashRef: 'sha256:event-local-777',
+      checkedAt: '2026-05-07T18:15:25Z',
+      note: 'Denied write-back event was verified; no generated value was stored.',
+    },
   },
+  {
+    id: 'evt-20260507-007',
+    timestamp: '2026-05-07T18:14:10Z',
+    type: 'reveal_granted',
+    outcome: 'granted',
+    provider: 'local',
+    source: '@secretsbroker/local/default',
+    connection: 'Controlled reveal session',
+    serviceOrWorkflow: '@serviceadmin',
+    actorType: 'operator',
+    actorId: 'operator:max',
+    ref: '@serviceadmin/SESSION_SECRET',
+    affectedRefs: ['@serviceadmin/SESSION_SECRET'],
+    affectedServices: ['@serviceadmin'],
+    policyId: 'policy/local/default/reveal',
+    policyDecision: 'allow: privileged reveal with recorded reason',
+    normalizedReason:
+      'A privileged reveal was approved; this viewer stores only the reveal metadata.',
+    auditReason: 'operator break-glass verification',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/local/default/2026-05-07',
+      sequence: 776,
+      previousHashRef: 'sha256:prev-local-775',
+      entryHashRef: 'sha256:event-local-776',
+      checkedAt: '2026-05-07T18:14:15Z',
+      note: 'Reveal event metadata verified; raw value is not retained in audit detail.',
+    },
+  },
+  {
+    id: 'evt-20260507-008',
+    timestamp: '2026-05-07T18:13:02Z',
+    type: 'migration_completed',
+    outcome: 'success',
+    provider: 'vault',
+    source: '@secretsbroker/migration/local-to-vault',
+    connection: 'Local to Vault migration',
+    serviceOrWorkflow: 'migration:ops-vault-cutover',
+    actorType: 'operator',
+    actorId: 'operator:max',
+    ref: 'payments/*',
+    affectedRefs: ['payments/STRIPE_API_TOKEN', 'payments/WEBHOOK_SIGNING_REF'],
+    affectedServices: ['payments-api', 'billing-worker'],
+    policyId: 'policy/migration/local-to-vault',
+    policyDecision: 'allow: migration plan approved',
+    normalizedReason:
+      'Migration completed with counts and ref identifiers only; payload values were not exported.',
+    auditReason: 'approved backend migration',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/migration/local-to-vault/2026-05-07',
+      sequence: 44,
+      previousHashRef: 'sha256:prev-migration-043',
+      entryHashRef: 'sha256:event-migration-044',
+      checkedAt: '2026-05-07T18:13:08Z',
+      note: 'Migration summary and counts were verified without value payloads.',
+    },
+  },
+  {
+    id: 'evt-20260507-009',
+    timestamp: '2026-05-07T18:12:31Z',
+    type: 'policy_changed',
+    outcome: 'success',
+    provider: 'local',
+    source: '@secretsbroker/policy/default',
+    connection: 'Policy engine',
+    serviceOrWorkflow: '@secretsbroker',
+    actorType: 'operator',
+    actorId: 'operator:max',
+    ref: 'policy/local/default/read',
+    affectedRefs: ['postgres.ADMIN_PASSWORD', '@serviceadmin/SESSION_SECRET'],
+    affectedServices: ['postgres', '@serviceadmin'],
+    policyId: 'policy/local/default/read',
+    policyDecision: 'change: grant narrowed to explicit service identities',
+    normalizedReason:
+      'Policy metadata changed; the event includes affected refs and services only.',
+    auditReason: 'least-privilege policy maintenance',
+    tamperEvidence: {
+      status: 'verified',
+      chainId: 'audit-chain/policy/default/2026-05-07',
+      sequence: 19,
+      previousHashRef: 'sha256:prev-policy-018',
+      entryHashRef: 'sha256:event-policy-019',
+      checkedAt: '2026-05-07T18:12:36Z',
+      note: 'Policy change event is verified; no policy secret material is present.',
+    },
+  },
+]
+
+export const secretMaterialSentinels = [
+  'DEMO_REVEAL_VALUE_42',
+  'ACTUAL_SECRET',
+  'RAW_SECRET',
+  'BEGIN PRIVATE KEY',
+  'AWS_SECRET_ACCESS_KEY=',
+  'PASSWORD=',
+  'CLIENT_SECRET=',
+  'SESSION_COOKIE=',
+  'REFRESH_TOKEN=',
+  'BOT_TOKEN=',
 ]
 
 export function filterSecretsBrokerAuditEvents(
@@ -169,6 +365,13 @@ export function filterSecretsBrokerAuditEvents(
     ) {
       return false
     }
+    if (
+      filters.tamperEvidence &&
+      filters.tamperEvidence !== 'all' &&
+      event.tamperEvidence.status !== filters.tamperEvidence
+    ) {
+      return false
+    }
     const query = filters.query?.trim().toLowerCase()
     if (query) {
       const searchable = [
@@ -178,6 +381,14 @@ export function filterSecretsBrokerAuditEvents(
         event.actorType,
         event.actorId,
         event.ref,
+        event.policyId,
+        event.policyDecision,
+        event.normalizedReason,
+        event.auditReason,
+        event.tamperEvidence.status,
+        event.tamperEvidence.chainId,
+        ...event.affectedRefs,
+        ...event.affectedServices,
       ]
         .join(' ')
         .toLowerCase()
@@ -198,4 +409,14 @@ export function filterSecretsBrokerAuditEvents(
 
 export function auditEventTypeLabel(type: SecretsBrokerAuditEventType) {
   return type.replace(/_/g, ' ')
+}
+
+export function auditEventsContainSecretMaterial(
+  events: SecretsBrokerAuditEvent[] = secretsBrokerAuditEvents
+) {
+  const serialized = JSON.stringify(events).toUpperCase()
+
+  return secretMaterialSentinels.some((sentinel) =>
+    serialized.includes(sentinel.toUpperCase())
+  )
 }

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -36,6 +36,7 @@ import {
   type SecretsBrokerAuditEvent,
   type SecretsBrokerAuditEventType,
   type SecretsBrokerAuditOutcome,
+  type SecretsBrokerAuditTamperEvidenceStatus,
 } from './audit-events'
 import {
   secretsBrokerBackupKeyStatus,
@@ -409,6 +410,24 @@ const auditOutcomeVariant: Record<
   revoked: 'outline',
 }
 
+const auditTamperEvidenceCopy: Record<
+  SecretsBrokerAuditTamperEvidenceStatus,
+  string
+> = {
+  verified: 'Tamper evidence verified',
+  broken: 'Tamper evidence broken',
+  unavailable: 'Tamper evidence unavailable',
+}
+
+const auditTamperEvidenceVariant: Record<
+  SecretsBrokerAuditTamperEvidenceStatus,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  verified: 'default',
+  broken: 'destructive',
+  unavailable: 'outline',
+}
+
 const sourceStateCopy: Record<SecretsBrokerSourceState, string> = {
   configured: 'Configured',
   'not-configured': 'Not configured',
@@ -568,6 +587,9 @@ const auditOutcomes = Array.from(
 )
 const auditProviders = Array.from(
   new Set(secretsBrokerAuditEvents.map((event) => event.provider))
+)
+const auditTamperEvidenceStates = Array.from(
+  new Set(secretsBrokerAuditEvents.map((event) => event.tamperEvidence.status))
 )
 
 function BackupKeyActionButton({
@@ -916,9 +938,16 @@ function AuditEventDetail({ event }: { event: SecretsBrokerAuditEvent }) {
             <CardTitle className='text-base'>Event detail</CardTitle>
             <CardDescription>{event.id}</CardDescription>
           </div>
-          <Badge variant={auditOutcomeVariant[event.outcome]}>
-            {event.outcome}
-          </Badge>
+          <div className='flex flex-wrap gap-2'>
+            <Badge variant={auditOutcomeVariant[event.outcome]}>
+              {event.outcome}
+            </Badge>
+            <Badge
+              variant={auditTamperEvidenceVariant[event.tamperEvidence.status]}
+            >
+              {event.tamperEvidence.status}
+            </Badge>
+          </div>
         </div>
       </CardHeader>
       <CardContent className='space-y-4 text-sm'>
@@ -970,6 +999,32 @@ function AuditEventDetail({ event }: { event: SecretsBrokerAuditEvent }) {
           </div>
           <div className='font-mono break-all'>{event.ref}</div>
         </div>
+        <div className='grid gap-3 md:grid-cols-2'>
+          <div className='rounded-md bg-muted/40 p-2'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Affected refs
+            </div>
+            <div className='mt-1 flex flex-wrap gap-1'>
+              {event.affectedRefs.map((ref) => (
+                <Badge key={ref} variant='outline'>
+                  {ref}
+                </Badge>
+              ))}
+            </div>
+          </div>
+          <div className='rounded-md bg-muted/40 p-2'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Affected services/workflows
+            </div>
+            <div className='mt-1 flex flex-wrap gap-1'>
+              {event.affectedServices.map((service) => (
+                <Badge key={service} variant='outline'>
+                  {service}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </div>
         <div className='rounded-md bg-muted/40 p-2'>
           <div className='text-xs font-medium text-muted-foreground uppercase'>
             Policy decision
@@ -979,9 +1034,49 @@ function AuditEventDetail({ event }: { event: SecretsBrokerAuditEvent }) {
         </div>
         <div>
           <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Audit reason
+          </div>
+          <p className='text-muted-foreground'>{event.auditReason}</p>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
             Normalized reason
           </div>
           <p className='text-muted-foreground'>{event.normalizedReason}</p>
+        </div>
+        <div className='rounded-md bg-muted/40 p-2'>
+          <div className='mb-2 flex flex-wrap items-center justify-between gap-2'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Tamper-evidence status
+            </div>
+            <Badge
+              variant={auditTamperEvidenceVariant[event.tamperEvidence.status]}
+            >
+              {auditTamperEvidenceCopy[event.tamperEvidence.status]}
+            </Badge>
+          </div>
+          <div className='grid gap-2 text-xs md:grid-cols-2'>
+            <span>chain: {event.tamperEvidence.chainId}</span>
+            <span>
+              sequence:{' '}
+              {event.tamperEvidence.sequence === null
+                ? 'unavailable'
+                : event.tamperEvidence.sequence}
+            </span>
+            <span>
+              previous hash:{' '}
+              {event.tamperEvidence.previousHashRef ?? 'unavailable'}
+            </span>
+            <span>
+              entry hash: {event.tamperEvidence.entryHashRef ?? 'unavailable'}
+            </span>
+            <span>
+              checked: {event.tamperEvidence.checkedAt ?? 'not checked'}
+            </span>
+          </div>
+          <p className='mt-2 text-xs text-muted-foreground'>
+            {event.tamperEvidence.note}
+          </p>
         </div>
         <div className='flex gap-3 rounded-lg border p-3'>
           <ShieldCheck className='mt-0.5 size-4 shrink-0' />
@@ -1279,6 +1374,9 @@ export function SecretsBrokerSetupWizard() {
   const [auditProviderFilter, setAuditProviderFilter] = useState<
     SecretsBrokerAuditEvent['provider'] | 'all'
   >('all')
+  const [auditTamperEvidenceFilter, setAuditTamperEvidenceFilter] = useState<
+    SecretsBrokerAuditTamperEvidenceStatus | 'all'
+  >('all')
   const [auditQueryFilter, setAuditQueryFilter] = useState('')
   const [auditSinceFilter, setAuditSinceFilter] = useState('')
   const [auditUntilFilter, setAuditUntilFilter] = useState('')
@@ -1350,6 +1448,7 @@ export function SecretsBrokerSetupWizard() {
         type: auditTypeFilter,
         outcome: auditOutcomeFilter,
         provider: auditProviderFilter,
+        tamperEvidence: auditTamperEvidenceFilter,
         query: auditQueryFilter,
         since: auditSinceFilter,
         until: auditUntilFilter,
@@ -1358,6 +1457,7 @@ export function SecretsBrokerSetupWizard() {
       auditOutcomeFilter,
       auditProviderFilter,
       auditQueryFilter,
+      auditTamperEvidenceFilter,
       auditSinceFilter,
       auditTypeFilter,
       auditUntilFilter,
@@ -2317,7 +2417,7 @@ export function SecretsBrokerSetupWizard() {
             </div>
           </CardHeader>
           <CardContent className='space-y-4'>
-            <div className='grid gap-3 md:grid-cols-6'>
+            <div className='grid gap-3 md:grid-cols-7'>
               <div>
                 <label
                   htmlFor='secret-audit-type'
@@ -2397,6 +2497,33 @@ export function SecretsBrokerSetupWizard() {
               </div>
               <div>
                 <label
+                  htmlFor='secret-audit-tamper-evidence'
+                  className='mb-1 block text-xs text-muted-foreground'
+                >
+                  Tamper evidence
+                </label>
+                <select
+                  id='secret-audit-tamper-evidence'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={auditTamperEvidenceFilter}
+                  onChange={(event) =>
+                    setAuditTamperEvidenceFilter(
+                      event.target.value as
+                        | SecretsBrokerAuditTamperEvidenceStatus
+                        | 'all'
+                    )
+                  }
+                >
+                  <option value='all'>all</option>
+                  {auditTamperEvidenceStates.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
                   htmlFor='secret-audit-query'
                   className='mb-1 block text-xs text-muted-foreground'
                 >
@@ -2463,14 +2590,26 @@ export function SecretsBrokerSetupWizard() {
                             {event.source}
                           </div>
                         </div>
-                        <Badge variant={auditOutcomeVariant[event.outcome]}>
-                          {event.outcome}
-                        </Badge>
+                        <div className='flex flex-wrap gap-2'>
+                          <Badge variant={auditOutcomeVariant[event.outcome]}>
+                            {event.outcome}
+                          </Badge>
+                          <Badge
+                            variant={
+                              auditTamperEvidenceVariant[
+                                event.tamperEvidence.status
+                              ]
+                            }
+                          >
+                            {event.tamperEvidence.status}
+                          </Badge>
+                        </div>
                       </div>
                       <div className='grid gap-2 text-xs text-muted-foreground md:grid-cols-3'>
                         <span>ref: {event.ref}</span>
                         <span>actor: {event.actorId}</span>
                         <span>target: {event.serviceOrWorkflow}</span>
+                        <span>audit reason: {event.auditReason}</span>
                       </div>
                     </button>
                   ))

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -197,7 +197,7 @@ describe('Secrets Broker setup wizard', () => {
         screen.queryByText(singleSecretRevealReference.fakeRawValue)
       ).not.toBeInTheDocument()
     }
-  }, 10000)
+  }, 20000)
 
   it('reveals deterministic fake material only after explicit action and re-hides on cancel or expiry', async () => {
     const user = userEvent.setup()


### PR DESCRIPTION
## Summary
- extend the Secrets Broker audit/event model with reveal, migration, policy, affected ref/service, audit reason, and tamper-evidence metadata
- add tamper-evidence OK/broken/unavailable rendering and filtering to the existing Secrets Broker audit/events section
- add audit viewer tests for filter states, event details, tamper-evidence states, and no-leak assertions

## Validation
- `npm run lint` ✅ (existing warnings only: TanStack Table incompatible-library and logs hook deps in unrelated files)
- `npm test -- src/features/secrets-broker/audit-events.test.tsx src/features/secrets-broker/secrets-management.test.tsx` ✅
- `npm run build` ✅
- `git diff --check` ✅

## Safety notes
- fixture/model data contains refs, metadata, policy/audit reason text, and redaction/no-value statements only
- tests assert audit fixture and rendered safe surface do not contain raw secret sentinel material
- viewer represents backend tamper-evidence status without claiming enforcement beyond supplied metadata

Closes #87