### PR TITLE
ISS-88 consume trusted SSO identity context

### DIFF
--- a/src/features/auth-session/index.tsx
+++ b/src/features/auth-session/index.tsx
@@ -22,30 +22,34 @@ import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
-  zitadelSessionScenarios,
-  type ZitadelPermissionDecision,
-  type ZitadelSessionState,
+  trustedIdentityScenarios,
+  type TrustedIdentityDecision,
+  type TrustedIdentityState,
 } from './zitadel-session'
 
-const stateCopy: Record<ZitadelSessionState, string> = {
-  'signed-in': 'Signed in',
-  'signed-out': 'Login required',
-  'setup-needed': 'Setup needed',
-  'permission-denied': 'Permission denied',
+const stateCopy: Record<TrustedIdentityState, string> = {
+  authenticated: 'Authenticated',
+  unauthenticated: 'Login required',
+  expired: 'Expired',
+  forbidden: 'Forbidden',
+  'workspace-mismatch': 'Workspace mismatch',
+  invalid: 'Invalid context',
 }
 
 const stateVariant: Record<
-  ZitadelSessionState,
+  TrustedIdentityState,
   'default' | 'secondary' | 'destructive' | 'outline'
 > = {
-  'signed-in': 'default',
-  'signed-out': 'secondary',
-  'setup-needed': 'outline',
-  'permission-denied': 'destructive',
+  authenticated: 'default',
+  unauthenticated: 'secondary',
+  expired: 'outline',
+  forbidden: 'destructive',
+  'workspace-mismatch': 'destructive',
+  invalid: 'destructive',
 }
 
 const permissionVariant: Record<
-  ZitadelPermissionDecision,
+  TrustedIdentityDecision,
   'default' | 'secondary' | 'destructive' | 'outline'
 > = {
   allowed: 'default',
@@ -53,21 +57,23 @@ const permissionVariant: Record<
   review: 'secondary',
 }
 
-function StateIcon({ state }: { state: ZitadelSessionState }) {
-  if (state === 'signed-in') return <UserCheck className='size-4' />
-  if (state === 'permission-denied') return <LockKeyhole className='size-4' />
+function StateIcon({ state }: { state: TrustedIdentityState }) {
+  if (state === 'authenticated') return <UserCheck className='size-4' />
+  if (state === 'forbidden' || state === 'workspace-mismatch') {
+    return <LockKeyhole className='size-4' />
+  }
   return <AlertTriangle className='size-4' />
 }
 
 export function AuthSessionPage() {
   const [selectedScenarioId, setSelectedScenarioId] = useState(
-    zitadelSessionScenarios[0].id
+    trustedIdentityScenarios[0].id
   )
   const selectedScenario = useMemo(
     () =>
-      zitadelSessionScenarios.find(
+      trustedIdentityScenarios.find(
         (scenario) => scenario.id === selectedScenarioId
-      ) ?? zitadelSessionScenarios[0],
+      ) ?? trustedIdentityScenarios[0],
     [selectedScenarioId]
   )
 
@@ -76,9 +82,9 @@ export function AuthSessionPage() {
   ).length
 
   usePageMetadata({
-    title: 'Service Admin - ZITADEL Session',
+    title: 'Service Admin - Trusted SSO Identity',
     description:
-      'Metadata-only ZITADEL login, session, role, and permission integration surface.',
+      'Metadata-only trusted SSO identity, workspace, role, and audit actor surface.',
   })
 
   return (
@@ -96,13 +102,13 @@ export function AuthSessionPage() {
         <div className='flex flex-wrap items-start justify-between gap-4'>
           <div>
             <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
-              <ShieldCheck className='size-5' /> ZITADEL session and roles
+              <ShieldCheck className='size-5' /> Trusted SSO identity context
             </h1>
             <p className='mt-1 text-muted-foreground'>
-              Service Admin auth integration preview for consumer apps that opt
-              into ZITADEL-backed sessions. This page renders facade metadata,
-              roles, and permission decisions only; provider credentials and
-              session secrets are never displayed.
+              Service Admin protected-route identity preview. This page renders
+              trusted route-boundary metadata, roles, workspace context, audit
+              actor metadata, and permission decisions only; provider
+              credentials and session secrets are never displayed.
             </p>
           </div>
           <Badge variant='secondary'>Metadata only</Badge>
@@ -110,27 +116,28 @@ export function AuthSessionPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Session state preview</CardTitle>
+            <CardTitle>Identity state preview</CardTitle>
             <CardDescription>
-              Choose the facade-reported state to inspect signed-in,
-              login-required, setup-needed, and permission-denied behaviour.
+              Choose the trusted identity state to inspect authenticated,
+              login-required, expired, forbidden, workspace-mismatch, and
+              invalid behaviour.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4'>
             <div>
               <label
-                htmlFor='zitadel-session-scenario'
+                htmlFor='trusted-identity-scenario'
                 className='mb-1 block text-xs text-muted-foreground'
               >
-                Auth scenario
+                Identity scenario
               </label>
               <select
-                id='zitadel-session-scenario'
+                id='trusted-identity-scenario'
                 className='h-9 w-full rounded-md border bg-background px-3 text-sm md:w-[24rem]'
                 value={selectedScenarioId}
                 onChange={(event) => setSelectedScenarioId(event.target.value)}
               >
-                {zitadelSessionScenarios.map((scenario) => (
+                {trustedIdentityScenarios.map((scenario) => (
                   <option key={scenario.id} value={scenario.id}>
                     {scenario.label}
                   </option>
@@ -147,9 +154,9 @@ export function AuthSessionPage() {
                 </Badge>
               </div>
               <div className='rounded-lg border p-3'>
-                <div className='text-xs text-muted-foreground'>Provider</div>
+                <div className='text-xs text-muted-foreground'>Boundary</div>
                 <div className='font-medium'>
-                  {selectedScenario.facade.authProvider}
+                  {selectedScenario.identityContext.deliveryBoundary}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
@@ -182,35 +189,41 @@ export function AuthSessionPage() {
         <div className='grid gap-4 lg:grid-cols-2'>
           <Card>
             <CardHeader>
-              <CardTitle>Facade session metadata</CardTitle>
+              <CardTitle>Trusted identity metadata</CardTitle>
               <CardDescription>
-                Consumer app/facade integration fields. These are identifiers
-                and status metadata, not credential material.
+                Protected route-boundary fields. These are identifiers and
+                status metadata, not credential material.
               </CardDescription>
             </CardHeader>
             <CardContent className='grid gap-3 text-sm md:grid-cols-2'>
               <div className='rounded-lg border p-3'>
                 <div className='text-muted-foreground'>Workspace</div>
                 <div className='font-medium break-all'>
-                  {selectedScenario.facade.workspaceId}
+                  {selectedScenario.identityContext.workspaceId}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
                 <div className='text-muted-foreground'>App</div>
                 <div className='font-medium'>
-                  {selectedScenario.facade.appId}
+                  {selectedScenario.identityContext.appId}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
-                <div className='text-muted-foreground'>Session mode</div>
+                <div className='text-muted-foreground'>Trust mode</div>
                 <div className='font-medium'>
-                  {selectedScenario.facade.sessionMode}
+                  {selectedScenario.identityContext.sessionMode}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
+                <div className='text-muted-foreground'>Trust status</div>
+                <div className='font-medium'>
+                  {selectedScenario.identityContext.trustStatus}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3 md:col-span-2'>
                 <div className='text-muted-foreground'>Metadata updated</div>
                 <div className='font-medium'>
-                  {selectedScenario.facade.metadataUpdatedAt}
+                  {selectedScenario.identityContext.metadataUpdatedAt}
                 </div>
               </div>
             </CardContent>
@@ -262,7 +275,7 @@ export function AuthSessionPage() {
                 </div>
               ) : (
                 <div className='rounded-lg border border-dashed p-4 text-muted-foreground'>
-                  No signed-in user metadata is available for this scenario.
+                  No trusted user metadata is available for this scenario.
                 </div>
               )}
 
@@ -285,6 +298,42 @@ export function AuthSessionPage() {
             </CardContent>
           </Card>
         </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Audit actor metadata</CardTitle>
+            <CardDescription>
+              Service Admin and Secrets Broker actions receive safe actor and
+              workspace references only.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 text-sm md:grid-cols-4'>
+            <div className='rounded-lg border p-3'>
+              <div className='text-muted-foreground'>Actor kind</div>
+              <div className='font-medium'>
+                {selectedScenario.auditActor.kind}
+              </div>
+            </div>
+            <div className='rounded-lg border p-3'>
+              <div className='text-muted-foreground'>Actor id</div>
+              <div className='font-medium break-all'>
+                {selectedScenario.auditActor.id}
+              </div>
+            </div>
+            <div className='rounded-lg border p-3'>
+              <div className='text-muted-foreground'>Actor label</div>
+              <div className='font-medium'>
+                {selectedScenario.auditActor.label}
+              </div>
+            </div>
+            <div className='rounded-lg border p-3'>
+              <div className='text-muted-foreground'>Source</div>
+              <div className='font-medium'>
+                {selectedScenario.auditActor.source}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         <Card>
           <CardHeader>
@@ -326,10 +375,11 @@ export function AuthSessionPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Optional ZITADEL integration guardrails</CardTitle>
+            <CardTitle>Trusted route-boundary guardrails</CardTitle>
             <CardDescription>
-              This UI depends on consumer app/facade integration. It should not
-              force authentication onto core local development by default.
+              This UI consumes trusted metadata from Traefik and
+              traefik-oidc-auth. It does not implement OIDC/session/token
+              mechanics.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-3'>

--- a/src/features/auth-session/zitadel-session.test.tsx
+++ b/src/features/auth-session/zitadel-session.test.tsx
@@ -3,23 +3,24 @@ import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
-  zitadelSessionHasSecretMaterial,
-  zitadelSessionScenarios,
+  trustedIdentityHasSecretMaterial,
+  trustedIdentityScenarios,
 } from './zitadel-session'
 
-describe('ZITADEL session and role surface', () => {
-  it('renders signed-in session metadata and role summaries without secret material', async () => {
+describe('Trusted SSO identity context surface', () => {
+  it('renders authenticated identity, workspace, roles, and audit actor without secret material', async () => {
     await renderRoute('/auth-session')
 
     expect(
       await screen.findByRole('heading', {
-        name: /ZITADEL session and roles/i,
+        name: /Trusted SSO identity context/i,
       })
     ).toBeVisible()
-    expect(screen.getAllByText(/Signed-in admin/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Signed in/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Authenticated admin/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Authenticated/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/traefik-oidc-auth/i)[0]).toBeVisible()
     expect(
-      screen.getByText(/workspace:service-lasso\/local-dev/i)
+      screen.getAllByText(/workspace:service-lasso\/local-dev/i)[0]
     ).toBeVisible()
     expect(
       screen.getByText(/zitadel-subject:\/\/service-lasso\/users\/max/i)
@@ -29,6 +30,8 @@ describe('ZITADEL session and role surface', () => {
       screen.getByText(/serviceadmin:secrets:values:reveal/i)
     ).toBeVisible()
     expect(screen.getByText(/raw secret reveal is not enabled/i)).toBeVisible()
+    expect(screen.getAllByText(/Audit actor metadata/i)[0]).toBeVisible()
+    expect(screen.getByText(/audit-actor:\/\/zitadel\/max/i)).toBeVisible()
     expect(screen.getByText(/Metadata only/i)).toBeVisible()
     expect(
       screen.queryByText(/access_token|refresh_token|id_token|session_secret/i)
@@ -38,37 +41,60 @@ describe('ZITADEL session and role surface', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('covers signed-out setup-needed and permission-denied states', async () => {
+  it('covers unauthenticated expired forbidden workspace-mismatch and invalid states', async () => {
     const user = userEvent.setup()
     await renderRoute('/auth-session')
 
     await user.selectOptions(
-      screen.getByLabelText(/Auth scenario/i),
-      'signed-out'
+      screen.getByLabelText(/Identity scenario/i),
+      'unauthenticated'
     )
     expect(screen.getAllByText(/Login required/i)[0]).toBeVisible()
-    expect(screen.getByText(/Start the ZITADEL login flow/i)).toBeVisible()
-    expect(screen.getByText(/No signed-in user metadata/i)).toBeVisible()
+    expect(screen.getByText(/No trusted user metadata/i)).toBeVisible()
     expect(screen.getByText(/none until login/i)).toBeVisible()
+    expect(screen.getByText(/no trusted identity metadata/i)).toBeVisible()
 
     await user.selectOptions(
-      screen.getByLabelText(/Auth scenario/i),
-      'setup-needed'
+      screen.getByLabelText(/Identity scenario/i),
+      'expired'
     )
-    expect(screen.getAllByText(/Setup needed/i)[0]).toBeVisible()
-    expect(screen.getByText(/not-configured/i)).toBeVisible()
-    expect(screen.getByText(/local-dev-open/i)).toBeVisible()
-    expect(screen.getByText(/Do not force ZITADEL/i)).toBeVisible()
+    expect(screen.getAllByText(/Expired/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/trusted identity context is expired/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Expired Operator \(expired\)/i)).toBeVisible()
 
     await user.selectOptions(
-      screen.getByLabelText(/Auth scenario/i),
-      'permission-denied'
+      screen.getByLabelText(/Identity scenario/i),
+      'forbidden'
     )
-    expect(screen.getAllByText(/Permission denied/i)[0]).toBeVisible()
-    expect(screen.getByText(/Readonly Operator/i)).toBeVisible()
+    expect(screen.getAllByText(/Forbidden/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Readonly Operator/i)[0]).toBeVisible()
     expect(screen.getByText(/workspace-viewer/i)).toBeVisible()
     expect(screen.getByText(/operator role is required/i)).toBeVisible()
     expect(screen.getByText(/least-privilege role/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Identity scenario/i),
+      'workspace-mismatch'
+    )
+    expect(screen.getAllByText(/Workspace mismatch/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/workspace:service-lasso\/other-dev/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/does not match the active route workspace/i)
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Identity scenario/i),
+      'invalid'
+    )
+    expect(screen.getAllByText(/Invalid context/i)[0]).toBeVisible()
+    expect(screen.getByText(/contract is incomplete/i)).toBeVisible()
+    expect(
+      screen.getByText(/Browser-supplied identity headers are not trusted/i)
+    ).toBeVisible()
   })
 
   it('renders permission decisions as metadata only', async () => {
@@ -82,12 +108,12 @@ describe('ZITADEL session and role surface', () => {
     expect(within(permissionTable).getAllByText(/denied/i)[0]).toBeVisible()
   })
 
-  it('keeps ZITADEL session fixtures free of secret material', () => {
-    expect(zitadelSessionHasSecretMaterial()).toBe(false)
-    expect(zitadelSessionScenarios).toHaveLength(4)
+  it('keeps trusted identity fixtures free of secret material', () => {
+    expect(trustedIdentityHasSecretMaterial()).toBe(false)
+    expect(trustedIdentityScenarios).toHaveLength(6)
     expect(
-      zitadelSessionScenarios.some(
-        (scenario) => scenario.state === 'permission-denied'
+      trustedIdentityScenarios.some(
+        (scenario) => scenario.state === 'workspace-mismatch'
       )
     ).toBe(true)
   })

--- a/src/features/auth-session/zitadel-session.ts
+++ b/src/features/auth-session/zitadel-session.ts
@@ -1,22 +1,32 @@
-export type ZitadelSessionState =
-  | 'signed-in'
-  | 'signed-out'
-  | 'setup-needed'
-  | 'permission-denied'
+export type TrustedIdentityState =
+  | 'authenticated'
+  | 'unauthenticated'
+  | 'expired'
+  | 'forbidden'
+  | 'workspace-mismatch'
+  | 'invalid'
 
-export type ZitadelPermissionDecision = 'allowed' | 'denied' | 'review'
+export type TrustedIdentityDecision = 'allowed' | 'denied' | 'review'
 
-export type ZitadelSessionScenario = {
+export type TrustedIdentityScenario = {
   id: string
   label: string
-  state: ZitadelSessionState
+  state: TrustedIdentityState
   summary: string
-  facade: {
+  identityContext: {
     workspaceId: string
     appId: string
     authProvider: 'zitadel' | 'not-configured'
+    deliveryBoundary: 'traefik-oidc-auth'
     sessionMode: string
     metadataUpdatedAt: string
+    trustStatus:
+      | 'trusted'
+      | 'missing'
+      | 'expired'
+      | 'denied'
+      | 'mismatch'
+      | 'invalid'
   }
   user?: {
     displayName: string
@@ -25,36 +35,52 @@ export type ZitadelSessionScenario = {
     organizationRef: string
     workspaceRole: string
   }
+  auditActor: {
+    kind: 'user' | 'anonymous' | 'denied-user'
+    id: string
+    label: string
+    workspaceId: string
+    source: 'trusted-route-boundary' | 'none'
+  }
   roles: string[]
   permissions: Array<{
     scope: string
-    decision: ZitadelPermissionDecision
+    decision: TrustedIdentityDecision
     reason: string
   }>
   requiredAction: string
   guardrails: string[]
 }
 
-export const zitadelSessionScenarios: ZitadelSessionScenario[] = [
+export const trustedIdentityScenarios: TrustedIdentityScenario[] = [
   {
-    id: 'signed-in-admin',
-    label: 'Signed-in admin',
-    state: 'signed-in',
+    id: 'authenticated-admin',
+    label: 'Authenticated admin',
+    state: 'authenticated',
     summary:
-      'Facade metadata reports an active ZITADEL-backed local session for this workspace.',
-    facade: {
+      'Trusted route-boundary metadata reports an active ZITADEL-backed user for this workspace.',
+    identityContext: {
       workspaceId: 'workspace:service-lasso/local-dev',
       appId: '@serviceadmin',
       authProvider: 'zitadel',
-      sessionMode: 'optional-auth-enabled',
-      metadataUpdatedAt: '2026-05-08T12:48:00Z',
+      deliveryBoundary: 'traefik-oidc-auth',
+      sessionMode: 'protected-route-authenticated',
+      metadataUpdatedAt: '2026-05-09T00:40:00Z',
+      trustStatus: 'trusted',
     },
     user: {
       displayName: 'Max Barrass',
-      email: 'max@service-lasso.local',
+      email: 'max@example.service-lasso.test',
       subjectRef: 'zitadel-subject://service-lasso/users/max',
       organizationRef: 'zitadel-org://service-lasso',
       workspaceRole: 'workspace-admin',
+    },
+    auditActor: {
+      kind: 'user',
+      id: 'audit-actor://zitadel/max',
+      label: 'Max Barrass via ZITADEL',
+      workspaceId: 'workspace:service-lasso/local-dev',
+      source: 'trusted-route-boundary',
     },
     roles: [
       'serviceadmin.viewer',
@@ -81,96 +107,125 @@ export const zitadelSessionScenarios: ZitadelSessionScenario[] = [
     requiredAction:
       'No login action required. Continue using metadata-only protected surfaces.',
     guardrails: [
-      'Session display is derived from facade metadata, not browser credential storage.',
+      'Identity display is derived from the protected route boundary, not browser credential storage.',
       'Subject and organization refs are stable identifiers, not bearer credentials.',
       'Denied sensitive permissions stay visible so operators know why an action is blocked.',
     ],
   },
   {
-    id: 'signed-out',
-    label: 'Signed out / login required',
-    state: 'signed-out',
+    id: 'unauthenticated',
+    label: 'Unauthenticated / login required',
+    state: 'unauthenticated',
     summary:
-      'ZITADEL is configured for this app, but no active local session metadata is available.',
-    facade: {
+      'The protected route did not provide trusted identity metadata for a signed-in user.',
+    identityContext: {
       workspaceId: 'workspace:service-lasso/local-dev',
       appId: '@serviceadmin',
       authProvider: 'zitadel',
+      deliveryBoundary: 'traefik-oidc-auth',
       sessionMode: 'login-required-for-protected-surfaces',
-      metadataUpdatedAt: '2026-05-08T12:49:00Z',
+      metadataUpdatedAt: '2026-05-09T00:41:00Z',
+      trustStatus: 'missing',
+    },
+    auditActor: {
+      kind: 'anonymous',
+      id: 'anonymous',
+      label: 'Unauthenticated request',
+      workspaceId: 'workspace:service-lasso/local-dev',
+      source: 'none',
     },
     roles: [],
     permissions: [
       {
         scope: 'serviceadmin:dashboard:read',
         decision: 'review',
-        reason: 'available after login handshake completes',
+        reason: 'available after the protected route login handshake completes',
       },
       {
         scope: 'serviceadmin:services:write',
         decision: 'denied',
-        reason: 'no active session metadata',
+        reason: 'no trusted identity metadata',
       },
     ],
     requiredAction:
-      'Start the ZITADEL login flow from the consumer app, then refresh session metadata.',
+      'Start the ZITADEL login flow through Traefik and traefik-oidc-auth, then retry the protected route.',
     guardrails: [
-      'Local development may continue without auth unless the app explicitly enables protected mode.',
-      'Login prompts should redirect through the consumer app facade, not store provider credentials in Service Admin.',
+      'Fail closed for protected surfaces when trusted identity metadata is absent.',
+      'Login prompts should redirect through the configured middleware and never collect provider credentials in Service Admin.',
     ],
   },
   {
-    id: 'setup-needed',
-    label: 'Setup needed',
-    state: 'setup-needed',
+    id: 'expired',
+    label: 'Expired session',
+    state: 'expired',
     summary:
-      'The consumer app has not enabled ZITADEL integration, so protected auth surfaces stay optional.',
-    facade: {
-      workspaceId: 'workspace:service-lasso/local-dev',
-      appId: '@serviceadmin',
-      authProvider: 'not-configured',
-      sessionMode: 'local-dev-open',
-      metadataUpdatedAt: '2026-05-08T12:50:00Z',
-    },
-    roles: ['local-dev-fallback'],
-    permissions: [
-      {
-        scope: 'serviceadmin:local-dev:read',
-        decision: 'allowed',
-        reason: 'auth integration is optional for local preview',
-      },
-      {
-        scope: 'serviceadmin:protected:write',
-        decision: 'review',
-        reason: 'requires consumer app/facade ZITADEL configuration',
-      },
-    ],
-    requiredAction:
-      'Configure the consumer app facade with ZITADEL issuer, client, and workspace mapping before enforcing auth.',
-    guardrails: [
-      'Do not force ZITADEL on existing local development flows without explicit app config.',
-      'Setup guidance references configuration metadata only and never asks operators to paste secrets into the UI.',
-    ],
-  },
-  {
-    id: 'permission-denied',
-    label: 'Permission denied',
-    state: 'permission-denied',
-    summary:
-      'The user is signed in, but the facade reports insufficient role grants for this protected surface.',
-    facade: {
+      'The route boundary reported identity metadata that is no longer valid for protected actions.',
+    identityContext: {
       workspaceId: 'workspace:service-lasso/local-dev',
       appId: '@serviceadmin',
       authProvider: 'zitadel',
+      deliveryBoundary: 'traefik-oidc-auth',
+      sessionMode: 'protected-route-expired',
+      metadataUpdatedAt: '2026-05-09T00:42:00Z',
+      trustStatus: 'expired',
+    },
+    user: {
+      displayName: 'Expired Operator',
+      email: 'expired@example.service-lasso.test',
+      subjectRef: 'zitadel-subject://service-lasso/users/expired-operator',
+      organizationRef: 'zitadel-org://service-lasso',
+      workspaceRole: 'workspace-operator',
+    },
+    auditActor: {
+      kind: 'denied-user',
+      id: 'audit-actor://zitadel/expired-operator',
+      label: 'Expired Operator (expired)',
+      workspaceId: 'workspace:service-lasso/local-dev',
+      source: 'trusted-route-boundary',
+    },
+    roles: ['serviceadmin.operator'],
+    permissions: [
+      {
+        scope: 'serviceadmin:services:read',
+        decision: 'denied',
+        reason: 'trusted identity context is expired',
+      },
+    ],
+    requiredAction:
+      'Re-authenticate through the protected route before continuing.',
+    guardrails: [
+      'Expired context is visible as state metadata only; session payloads are never rendered.',
+      'Protected actions remain blocked until fresh trusted metadata is supplied.',
+    ],
+  },
+  {
+    id: 'forbidden',
+    label: 'Forbidden role',
+    state: 'forbidden',
+    summary:
+      'The user is authenticated, but trusted route metadata does not grant this Service Admin surface.',
+    identityContext: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      deliveryBoundary: 'traefik-oidc-auth',
       sessionMode: 'protected-surface-denied',
-      metadataUpdatedAt: '2026-05-08T12:51:00Z',
+      metadataUpdatedAt: '2026-05-09T00:43:00Z',
+      trustStatus: 'denied',
     },
     user: {
       displayName: 'Readonly Operator',
-      email: 'readonly@service-lasso.local',
+      email: 'readonly@example.service-lasso.test',
       subjectRef: 'zitadel-subject://service-lasso/users/readonly-operator',
       organizationRef: 'zitadel-org://service-lasso',
       workspaceRole: 'workspace-viewer',
+    },
+    auditActor: {
+      kind: 'denied-user',
+      id: 'audit-actor://zitadel/readonly-operator',
+      label: 'Readonly Operator (denied)',
+      workspaceId: 'workspace:service-lasso/local-dev',
+      source: 'trusted-route-boundary',
     },
     roles: ['serviceadmin.viewer'],
     permissions: [
@@ -194,18 +249,105 @@ export const zitadelSessionScenarios: ZitadelSessionScenario[] = [
       'Ask a workspace admin to grant the least-privilege role required for this surface.',
     guardrails: [
       'Denied permissions are shown as policy metadata only.',
-      'Escalation guidance avoids displaying auth cookies, bearer material, or session secrets.',
+      'Escalation guidance avoids displaying cookies, bearer material, or session secrets.',
+    ],
+  },
+  {
+    id: 'workspace-mismatch',
+    label: 'Workspace mismatch',
+    state: 'workspace-mismatch',
+    summary:
+      'The trusted identity metadata points at a different workspace than the current Service Admin route.',
+    identityContext: {
+      workspaceId: 'workspace:service-lasso/other-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      deliveryBoundary: 'traefik-oidc-auth',
+      sessionMode: 'workspace-mismatch',
+      metadataUpdatedAt: '2026-05-09T00:44:00Z',
+      trustStatus: 'mismatch',
+    },
+    user: {
+      displayName: 'Workspace Visitor',
+      email: 'visitor@example.service-lasso.test',
+      subjectRef: 'zitadel-subject://service-lasso/users/workspace-visitor',
+      organizationRef: 'zitadel-org://service-lasso',
+      workspaceRole: 'workspace-viewer',
+    },
+    auditActor: {
+      kind: 'denied-user',
+      id: 'audit-actor://zitadel/workspace-visitor',
+      label: 'Workspace Visitor (workspace mismatch)',
+      workspaceId: 'workspace:service-lasso/other-dev',
+      source: 'trusted-route-boundary',
+    },
+    roles: ['serviceadmin.viewer'],
+    permissions: [
+      {
+        scope: 'serviceadmin:dashboard:read',
+        decision: 'denied',
+        reason: 'identity workspace does not match the active route workspace',
+      },
+    ],
+    requiredAction:
+      'Switch to the matching workspace route or sign in with an identity assigned to this workspace.',
+    guardrails: [
+      'Workspace mismatches fail closed before Service Admin actions run.',
+      'Audit metadata keeps only safe actor and workspace refs for investigation.',
+    ],
+  },
+  {
+    id: 'invalid',
+    label: 'Invalid identity context',
+    state: 'invalid',
+    summary:
+      'The protected route metadata is incomplete or fails the trusted context contract.',
+    identityContext: {
+      workspaceId: 'workspace:service-lasso/local-dev',
+      appId: '@serviceadmin',
+      authProvider: 'zitadel',
+      deliveryBoundary: 'traefik-oidc-auth',
+      sessionMode: 'invalid-context',
+      metadataUpdatedAt: '2026-05-09T00:45:00Z',
+      trustStatus: 'invalid',
+    },
+    auditActor: {
+      kind: 'anonymous',
+      id: 'invalid-context',
+      label: 'Invalid protected-route context',
+      workspaceId: 'workspace:service-lasso/local-dev',
+      source: 'none',
+    },
+    roles: [],
+    permissions: [
+      {
+        scope: 'serviceadmin:dashboard:read',
+        decision: 'denied',
+        reason: 'trusted identity context contract is incomplete',
+      },
+    ],
+    requiredAction:
+      'Check Traefik middleware and identity header mapping before retrying.',
+    guardrails: [
+      'Browser-supplied identity headers are not trusted by themselves.',
+      'Invalid context diagnostics stay metadata-only and do not echo raw headers.',
     ],
   },
 ]
 
-export function getZitadelSessionScenario(id: string) {
-  return zitadelSessionScenarios.find((scenario) => scenario.id === id)
+export function getTrustedIdentityScenario(id: string) {
+  return trustedIdentityScenarios.find((scenario) => scenario.id === id)
 }
 
-export function zitadelSessionHasSecretMaterial() {
-  const joined = JSON.stringify(zitadelSessionScenarios)
-  return /bearer\s+[a-z0-9_-]+\.[a-z0-9._-]+|id_token|access_token|refresh_token|session_secret|client_secret|password\s*=|token\s*=|secret\s*=/i.test(
+export function trustedIdentityHasSecretMaterial() {
+  const joined = JSON.stringify(trustedIdentityScenarios)
+  return /bearer\s+[a-z0-9_-]+\.[a-z0-9._-]+|id_token|access_token|refresh_token|session_secret|client_secret|password\s*=|token\s*=|secret\s*=|cookie\s*=/i.test(
     joined
   )
 }
+
+export const zitadelSessionScenarios = trustedIdentityScenarios
+export const zitadelSessionHasSecretMaterial = trustedIdentityHasSecretMaterial
+export type ZitadelSessionState = TrustedIdentityState
+export type ZitadelPermissionDecision = TrustedIdentityDecision
+export type ZitadelSessionScenario = TrustedIdentityScenario

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -70,8 +70,8 @@ const appScreens: ScreenCase[] = [
   },
   {
     path: '/auth-session',
-    heading: /^ZITADEL session and roles$/i,
-    title: 'Service Admin - ZITADEL Session',
+    heading: /^Trusted SSO identity context$/i,
+    title: 'Service Admin - Trusted SSO Identity',
   },
   {
     path: '/support-bundle',


### PR DESCRIPTION
## Summary
- replaces the legacy ZITADEL session preview with a trusted protected-route identity context model
- covers authenticated, unauthenticated, expired, forbidden, workspace mismatch, and invalid states
- renders safe user/workspace/role/audit-actor metadata without OIDC/session/token mechanics or secret material
- updates route smoke expectations for the Trusted SSO Identity page

## Validation
- npm test — 17 files / 115 tests passed
- npm run lint — passed with 7 pre-existing warnings in installed/logs/network/runtime/variables
- npm run build — passed
- git diff --check — passed
- forbidden wording guard: rg for auth-facade/custom-OIDC wording in auth-session and authenticated routes returned no matches

Closes #88