### PR TITLE
ISS-425 cover admin secret leak surfaces

### DIFF
--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -1,4 +1,9 @@
 import { renderRoute } from '@/test/render-route'
+import {
+  assertNoSecretMaterial,
+  collectBrowserLeakSurfaces,
+  serviceLassoSecretLeakSentinels,
+} from '@/test/secret-leak-harness'
 import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
@@ -57,6 +62,12 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getByText(/Raw output scrubbed/i)).toBeVisible()
     expect(screen.queryByText('supersecret')).not.toBeInTheDocument()
     expect(screen.queryByText('plaintext secret')).not.toBeInTheDocument()
+    assertNoSecretMaterial(collectBrowserLeakSurfaces())
+    expect(() =>
+      assertNoSecretMaterial({
+        fixture: serviceLassoSecretLeakSentinels[0].value,
+      })
+    ).toThrow(/Secret material leak detected/)
   })
 
   it('renders broker overview healthy degraded offline and unconfigured states', async () => {

--- a/src/test/secret-leak-harness.ts
+++ b/src/test/secret-leak-harness.ts
@@ -1,0 +1,127 @@
+export type SecretLeakSurface = unknown
+
+export interface SecretLeakFinding {
+  path: string
+  kind: 'sentinel' | 'credential-shape'
+  label: string
+  excerpt: string
+}
+
+export const serviceLassoSecretLeakSentinels = [
+  {
+    label: 'service-lasso-fake-token',
+    value: 'SERVICE_LASSO_FAKE_SECRET_SENTINEL_TOKEN_DO_NOT_USE',
+  },
+  {
+    label: 'service-lasso-fake-password',
+    value: 'SERVICE_LASSO_FAKE_SECRET_SENTINEL_PASSWORD_DO_NOT_USE',
+  },
+  {
+    label: 'service-lasso-fake-private-key',
+    value: '-----BEGIN SERVICE LASSO FAKE PRIVATE KEY-----',
+  },
+] as const
+
+const credentialShapePatterns: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'bearer-token', pattern: /Bearer\s+[A-Za-z0-9._~+/-]{24,}/g },
+  { label: 'basic-auth-url', pattern: /https?:\/\/[^\s/:]+:[^\s/@]{6,}@/g },
+  { label: 'github-token', pattern: /gh[pousr]_[A-Za-z0-9_]{30,}/g },
+  {
+    label: 'private-key-block',
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g,
+  },
+]
+
+function collectStrings(
+  input: unknown,
+  path: string,
+  output: Array<{ path: string; value: string }>
+): void {
+  if (typeof input === 'string') {
+    output.push({ path, value: input })
+    return
+  }
+  if (input === null || input === undefined) return
+  if (typeof input !== 'object') return
+  if (Array.isArray(input)) {
+    input.forEach((entry, index) =>
+      collectStrings(entry, `${path}[${index}]`, output)
+    )
+    return
+  }
+  for (const [key, value] of Object.entries(input)) {
+    collectStrings(value, `${path}.${key}`, output)
+  }
+}
+
+function excerpt(value: string, index: number, length: number): string {
+  return value.slice(
+    Math.max(0, index - 16),
+    Math.min(value.length, index + length + 16)
+  )
+}
+
+export function scanForSecretMaterial(
+  input: SecretLeakSurface
+): SecretLeakFinding[] {
+  const strings: Array<{ path: string; value: string }> = []
+  collectStrings(input, '$', strings)
+  const findings: SecretLeakFinding[] = []
+
+  for (const item of strings) {
+    for (const sentinel of serviceLassoSecretLeakSentinels) {
+      const index = item.value.indexOf(sentinel.value)
+      if (index >= 0) {
+        findings.push({
+          path: item.path,
+          kind: 'sentinel',
+          label: sentinel.label,
+          excerpt: excerpt(item.value, index, sentinel.value.length),
+        })
+      }
+    }
+    for (const { label, pattern } of credentialShapePatterns) {
+      pattern.lastIndex = 0
+      for (const match of item.value.matchAll(pattern)) {
+        findings.push({
+          path: item.path,
+          kind: 'credential-shape',
+          label,
+          excerpt: excerpt(item.value, match.index ?? 0, match[0].length),
+        })
+      }
+    }
+  }
+
+  return findings
+}
+
+export function assertNoSecretMaterial(input: SecretLeakSurface): void {
+  const findings = scanForSecretMaterial(input)
+  if (findings.length > 0) {
+    throw new Error(
+      `Secret material leak detected: ${findings
+        .map((finding) => `${finding.kind}:${finding.label}@${finding.path}`)
+        .join(', ')}`
+    )
+  }
+}
+
+export function collectBrowserLeakSurfaces() {
+  return {
+    title: document.title,
+    text: document.body.textContent ?? '',
+    localStorage: Object.fromEntries(
+      Array.from({ length: window.localStorage.length }, (_, index) => {
+        const key = window.localStorage.key(index) ?? ''
+        return [key, window.localStorage.getItem(key)]
+      })
+    ),
+    sessionStorage: Object.fromEntries(
+      Array.from({ length: window.sessionStorage.length }, (_, index) => {
+        const key = window.sessionStorage.key(index) ?? ''
+        return [key, window.sessionStorage.getItem(key)]
+      })
+    ),
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Service Admin test leak harness for rendered browser text plus local/session storage surfaces.
- Cover the Secrets Broker route with deterministic fake sentinel detection and a current rendered-surface scan.
- Keep sentinel material constrained to test-only inputs and verify visible/admin surfaces remain metadata-only.

## Validation
- `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` (28 pass)
- `npm run build`
- `npm test` (115 pass)
- `git diff --check`

Refs service-lasso/service-lasso#425
