### PR TITLE
ISS-95 add stub secrets update preview

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -35,12 +35,15 @@ import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
   buildManagedSecretActionPreview,
+  buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretRows,
   managedSecretSafetyBoundaries,
+  stubSecretMutationStates,
   valueSearchManagedSecrets,
   type ManagedSecretAction,
   type ManagedSecretState,
+  type StubSecretMutationState,
 } from './secrets-management'
 
 const stateVariant: Record<
@@ -63,6 +66,9 @@ export function SecretsManagementPage() {
   const [selectedRowId, setSelectedRowId] = useState(managedSecretRows[0].id)
   const [selectedAction, setSelectedAction] =
     useState<ManagedSecretAction>('metadata')
+  const [stubState, setStubState] = useState<StubSecretMutationState>('ready')
+  const [auditReason, setAuditReason] = useState('')
+  const [confirmed, setConfirmed] = useState(false)
 
   usePageMetadata({
     title: 'Service Admin - Secrets Broker Secrets',
@@ -89,6 +95,15 @@ export function SecretsManagementPage() {
   const actionPreview = buildManagedSecretActionPreview(
     selectedRow,
     selectedAction
+  )
+  const stubMutationPreview = buildStubSecretMutationPreview(
+    selectedRow,
+    selectedAction === 'metadata' || selectedAction === 'policy'
+      ? 'edit'
+      : selectedAction,
+    stubState,
+    auditReason,
+    confirmed
   )
 
   function chooseAction(rowId: string, action: ManagedSecretAction) {
@@ -119,7 +134,7 @@ export function SecretsManagementPage() {
               Rows never render raw secret values.
             </p>
           </div>
-          <Badge variant='secondary'>Metadata table · values hidden</Badge>
+          <Badge variant='secondary'>Stub preview · values hidden</Badge>
         </div>
 
         <Alert>
@@ -130,7 +145,8 @@ export function SecretsManagementPage() {
             Broker-backed value search, when supported, returns matching
             refs/metadata only. Reveal delegates to the audited #38 pattern;
             edit, reset, and policy changes require dry-run/preview before
-            apply.
+            apply. The mutation API on this page is stubbed preview behavior
+            until the production Secrets Broker contract lands.
           </AlertDescription>
         </Alert>
 
@@ -419,6 +435,150 @@ export function SecretsManagementPage() {
               <Badge variant='secondary'>Raw values hidden</Badge>
               <Badge variant='outline'>No copy/export</Badge>
               <Badge variant='outline'>No bulk mutation</Badge>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Stub update/reset/reveal API preview</CardTitle>
+            <CardDescription>
+              Deterministic non-production status model for a single selected
+              secret. This previews the operator flow only; no secret material
+              is read, written, copied, exported, logged, or displayed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4 text-sm'>
+            <div className='grid gap-4 lg:grid-cols-3'>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Selected ref
+                </div>
+                <div className='mt-1 font-medium break-all'>
+                  {selectedRow.ref}
+                </div>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <label
+                  htmlFor='stub-state'
+                  className='text-xs font-medium text-muted-foreground uppercase'
+                >
+                  Stub API state
+                </label>
+                <select
+                  id='stub-state'
+                  className='mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={stubState}
+                  onChange={(event) =>
+                    setStubState(event.target.value as StubSecretMutationState)
+                  }
+                >
+                  {stubSecretMutationStates.map((state) => (
+                    <option key={state.id} value={state.id}>
+                      {state.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Apply readiness
+                </div>
+                <Badge
+                  className='mt-2'
+                  variant={
+                    stubMutationPreview.canApply ? 'default' : 'secondary'
+                  }
+                >
+                  {stubMutationPreview.canApply
+                    ? 'Stub apply can be simulated'
+                    : 'Stub apply blocked'}
+                </Badge>
+              </div>
+            </div>
+
+            <div className='grid gap-4 lg:grid-cols-2'>
+              <div className='space-y-2'>
+                <label
+                  htmlFor='audit-reason'
+                  className='text-sm font-medium text-muted-foreground'
+                >
+                  Audit reason for stub preview
+                </label>
+                <Input
+                  id='audit-reason'
+                  value={auditReason}
+                  onChange={(event) => setAuditReason(event.target.value)}
+                  placeholder='Required before simulated apply; no secret values'
+                />
+                <label className='flex items-center gap-2 text-sm'>
+                  <input
+                    type='checkbox'
+                    checked={confirmed}
+                    onChange={(event) => setConfirmed(event.target.checked)}
+                  />
+                  I confirm this is a stub preview and no production mutation
+                  will be performed.
+                </label>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <div className='mb-2 flex flex-wrap items-center gap-2'>
+                  <Badge variant='outline'>{stubMutationPreview.badge}</Badge>
+                  <Badge variant='secondary'>Stub API · preview only</Badge>
+                </div>
+                <div className='font-medium'>{stubMutationPreview.title}</div>
+                <dl className='mt-3 grid gap-2 text-sm'>
+                  <div>
+                    <dt className='text-muted-foreground'>Dry-run status</dt>
+                    <dd>{stubMutationPreview.dryRunStatus}</dd>
+                  </div>
+                  <div>
+                    <dt className='text-muted-foreground'>Apply status</dt>
+                    <dd>{stubMutationPreview.applyStatus}</dd>
+                  </div>
+                  <div>
+                    <dt className='text-muted-foreground'>Policy decision</dt>
+                    <dd>{stubMutationPreview.policyDecision}</dd>
+                  </div>
+                  <div>
+                    <dt className='text-muted-foreground'>Audit requirement</dt>
+                    <dd>{stubMutationPreview.auditRequirement}</dd>
+                  </div>
+                </dl>
+              </div>
+            </div>
+
+            <div className='rounded-lg border p-3'>
+              <div className='text-xs font-medium text-muted-foreground uppercase'>
+                Metadata-only dry-run diff
+              </div>
+              <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                {stubMutationPreview.safeDiff.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+              <div className='mt-3 rounded-md border bg-muted/40 p-3'>
+                {stubMutationPreview.nextStep}
+              </div>
+            </div>
+
+            <div className='flex flex-wrap gap-2'>
+              <Button type='button' disabled={!stubMutationPreview.canApply}>
+                Simulate stub apply
+              </Button>
+              <Button
+                type='button'
+                variant='outline'
+                onClick={() => {
+                  setAuditReason('')
+                  setConfirmed(false)
+                  setStubState('cancelled')
+                }}
+              >
+                Cancel stub preview
+              </Button>
+              <Badge variant='outline'>No plaintext editing</Badge>
+              <Badge variant='outline'>Single-secret only</Badge>
             </div>
           </CardContent>
         </Card>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
+  buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
@@ -19,7 +20,11 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getByText(/Secrets Broker management table/i)).toBeVisible()
     expect(screen.getByText(/Visible values/i)).toBeVisible()
-    expect(screen.getByText(/Metadata table · values hidden/i)).toBeVisible()
+    expect(screen.getByText(/Stub preview · values hidden/i)).toBeVisible()
+    expect(
+      screen.getByText(/Stub update\/reset\/reveal API preview/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/Stub API · preview only/i)[0]).toBeVisible()
     expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
     expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
     expect(screen.getAllByText(/Controlled reveal/i)[0]).toBeVisible()
@@ -116,6 +121,74 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeDisabled()
   })
 
+  it('covers stub update reset reveal preview states and gated apply readiness', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    expect(
+      screen.getByText(/Stub update\/reset\/reveal API preview/i)
+    ).toBeVisible()
+    expect(screen.getByText(/audit reason required/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    ).toBeDisabled()
+
+    await user.type(
+      screen.getByLabelText(/Audit reason for stub preview/i),
+      'operator requested rotation preview'
+    )
+    await user.click(screen.getByLabelText(/I confirm this is a stub preview/i))
+    expect(screen.getByText(/Stub apply can be simulated/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    ).toBeEnabled()
+
+    await user.selectOptions(screen.getByLabelText(/Stub API state/i), 'denied')
+    expect(screen.getAllByText(/Policy denied/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/operator lacks single-secret mutation entitlement/i)
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    ).toBeDisabled()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Stub API state/i),
+      'auth-required'
+    )
+    expect(screen.getAllByText(/Auth required/i)[0]).toBeVisible()
+    expect(screen.getByText(/fresh operator authentication/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Stub API state/i),
+      'unavailable'
+    )
+    expect(screen.getAllByText(/Broker unavailable/i)[0]).toBeVisible()
+    expect(screen.getByText(/failed closed/i)).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Stub API state/i),
+      'success'
+    )
+    expect(screen.getAllByText(/Stub apply success/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/deterministic fake apply completed/i)
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Stub API state/i),
+      'failure'
+    )
+    expect(screen.getAllByText(/Stub apply failure/i)[0]).toBeVisible()
+    expect(screen.getByText(/deterministic fake apply failed/i)).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /Cancel stub preview/i })
+    )
+    expect(screen.getAllByText(/Cancelled/i)[0]).toBeVisible()
+    expect(screen.getByText(/cancelled by operator/i)).toBeVisible()
+  })
+
   it('keeps fixtures and modeled safe surfaces free of secret material', () => {
     expect(managedSecretsHaveSecretMaterial()).toBe(false)
     expect(managedSecretSafeSurfacesIncludeSecretMaterial()).toBe(false)
@@ -128,5 +201,23 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       valueSearchManagedSecrets(managedSecretRows, 'session', true)
     ).toHaveLength(1)
+    expect(
+      buildStubSecretMutationPreview(
+        managedSecretRows[0],
+        'edit',
+        'ready',
+        'operator requested safe preview',
+        true
+      ).canApply
+    ).toBe(true)
+    expect(
+      buildStubSecretMutationPreview(
+        managedSecretRows[0],
+        'edit',
+        'denied',
+        'operator requested safe preview',
+        true
+      ).canApply
+    ).toBe(false)
   })
 })

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -39,6 +39,30 @@ export type ManagedSecretActionPreview = {
   requiresConfirmation: boolean
 }
 
+export type StubSecretMutationState =
+  | 'ready'
+  | 'denied'
+  | 'auth-required'
+  | 'unavailable'
+  | 'cancelled'
+  | 'success'
+  | 'failure'
+
+export type StubSecretMutationPreview = {
+  state: StubSecretMutationState
+  title: string
+  badge: string
+  dryRunStatus: string
+  applyStatus: string
+  policyDecision: string
+  auditRequirement: string
+  safeDiff: string[]
+  affectedRefs: string[]
+  nextStep: string
+  canApply: boolean
+  stubOnly: true
+}
+
 export const managedSecretRows: ManagedSecretRow[] = [
   {
     id: 'serviceadmin-session-signing',
@@ -120,6 +144,20 @@ export const managedSecretSafetyBoundaries = [
   'Broker-backed value search is represented as supported or unsupported and returns ref metadata only.',
   'Reveal delegates to the controlled #38 pattern: explicit action, audit status, timeout, and value hidden by default.',
   'Edit, reset, and policy actions require dry-run/preview before apply and never use spreadsheet-style plaintext editing.',
+  'The update/reset/reveal API shown here is a deterministic stub preview until the Secrets Broker production mutation contract lands.',
+]
+
+export const stubSecretMutationStates: Array<{
+  id: StubSecretMutationState
+  label: string
+}> = [
+  { id: 'ready', label: 'Ready dry-run preview' },
+  { id: 'denied', label: 'Policy denied' },
+  { id: 'auth-required', label: 'Auth required' },
+  { id: 'unavailable', label: 'Broker unavailable' },
+  { id: 'cancelled', label: 'Operator cancelled' },
+  { id: 'success', label: 'Stub apply success' },
+  { id: 'failure', label: 'Stub apply failure' },
 ]
 
 export const managedSecretSafeSurfaces = {
@@ -134,6 +172,8 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:metadata-search',
     'secrets-management:value-search-metadata-only',
     'secrets-management:action-preview',
+    'secrets-management:stub-mutation-preview',
+    'secrets-management:stub-mutation-apply-status',
   ],
   persistedStorage: 'none',
 }
@@ -179,6 +219,162 @@ export function valueSearchManagedSecrets(
         row.name.toLowerCase().includes(normalized) ||
         row.owningService.toLowerCase().includes(normalized))
   )
+}
+
+export function buildStubSecretMutationPreview(
+  row: ManagedSecretRow,
+  action: ManagedSecretAction,
+  state: StubSecretMutationState,
+  auditReason: string,
+  confirmed: boolean
+): StubSecretMutationPreview {
+  const actionLabel =
+    action === 'reset'
+      ? 'reset/rotate'
+      : action === 'reveal'
+        ? 'reveal'
+        : 'update'
+  const hasAuditReason = auditReason.trim().length >= 8
+  const base = {
+    state,
+    title: `Stub ${actionLabel} preview for ${row.name}`,
+    affectedRefs: [row.ref],
+    stubOnly: true as const,
+  }
+
+  if (state === 'denied') {
+    return {
+      ...base,
+      badge: 'Policy denied',
+      dryRunStatus: 'blocked before preview',
+      applyStatus: 'not applied',
+      policyDecision: 'deny: operator lacks single-secret mutation entitlement',
+      auditRequirement:
+        'audit reason retained as metadata only; no mutation attempted',
+      safeDiff: ['no value read', 'no value written', 'policy denial recorded'],
+      nextStep: 'Request least-privilege access or choose a different ref.',
+      canApply: false,
+    }
+  }
+
+  if (state === 'auth-required') {
+    return {
+      ...base,
+      badge: 'Auth required',
+      dryRunStatus: 'blocked before preview',
+      applyStatus: 'not applied',
+      policyDecision:
+        'challenge: broker requires fresh operator authentication',
+      auditRequirement: 'reauthenticate before preview or apply',
+      safeDiff: ['no value read', 'no value written', 'auth challenge emitted'],
+      nextStep:
+        'Complete broker auth challenge, then rerun the dry-run preview.',
+      canApply: false,
+    }
+  }
+
+  if (state === 'unavailable') {
+    return {
+      ...base,
+      badge: 'Broker unavailable',
+      dryRunStatus: 'failed closed',
+      applyStatus: 'not applied',
+      policyDecision:
+        'unavailable: stub broker endpoint did not accept mutation preview',
+      auditRequirement: 'retry when broker health is restored',
+      safeDiff: [
+        'no value read',
+        'no value written',
+        'unavailable status rendered',
+      ],
+      nextStep: 'Check Secrets Broker health and retry the preview.',
+      canApply: false,
+    }
+  }
+
+  if (state === 'cancelled') {
+    return {
+      ...base,
+      badge: 'Cancelled',
+      dryRunStatus: 'preview discarded',
+      applyStatus: 'cancelled by operator',
+      policyDecision: 'allow preview only; apply cancelled',
+      auditRequirement: 'audit reason discarded with the cancelled operation',
+      safeDiff: [
+        'preview generated',
+        'no value written',
+        'operator cancellation recorded',
+      ],
+      nextStep: 'Choose another action or rerun preview with a fresh reason.',
+      canApply: false,
+    }
+  }
+
+  if (state === 'success') {
+    return {
+      ...base,
+      badge: 'Stub apply success',
+      dryRunStatus: 'preview accepted',
+      applyStatus: 'deterministic fake apply completed',
+      policyDecision: 'allow: single-secret mutation permitted by stub policy',
+      auditRequirement: 'audit reason captured as safe metadata',
+      safeDiff: [
+        'metadata version increments by 1',
+        'dependent service restart note added',
+        'raw value remains hidden',
+      ],
+      nextStep:
+        'Production broker API will replace this fake status when contract lands.',
+      canApply: false,
+    }
+  }
+
+  if (state === 'failure') {
+    return {
+      ...base,
+      badge: 'Stub apply failure',
+      dryRunStatus: 'preview accepted',
+      applyStatus: 'deterministic fake apply failed',
+      policyDecision: 'allow preview; apply returned safe failure metadata',
+      auditRequirement: 'audit reason retained for failed attempt',
+      safeDiff: [
+        'metadata unchanged',
+        'failure category rendered',
+        'raw value remains hidden',
+      ],
+      nextStep:
+        'Review safe failure category and retry after broker contract issue is resolved.',
+      canApply: false,
+    }
+  }
+
+  return {
+    ...base,
+    badge: 'Ready dry-run preview',
+    dryRunStatus: hasAuditReason
+      ? 'metadata-only dry-run ready'
+      : 'audit reason required',
+    applyStatus: 'not applied',
+    policyDecision:
+      row.state === 'missing'
+        ? 'deny until ref/source exists'
+        : 'allow preview; apply remains confirmation gated',
+    auditRequirement: hasAuditReason
+      ? 'audit reason present; confirmation still required'
+      : 'enter at least 8 characters of audit reason',
+    safeDiff: [
+      `${actionLabel} target ref selected`,
+      'affected service metadata reviewed',
+      'raw value placeholder is never displayed',
+    ],
+    nextStep:
+      row.state === 'missing'
+        ? 'Connect the provider/source before mutation preview can apply.'
+        : confirmed && hasAuditReason
+          ? 'Use the stub state selector to simulate apply success or failure.'
+          : 'Enter audit reason and explicit confirmation before apply can be simulated.',
+    canApply: row.state !== 'missing' && confirmed && hasAuditReason,
+  }
 }
 
 export function buildManagedSecretActionPreview(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -136,9 +136,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await page.goto('/secrets-broker/secrets')
     await expectNoBlankScreen(page)
     await expect(page.getByRole('heading', { name: /^Secrets$/ })).toBeVisible()
-    await expect(
-      page.getByText(/Metadata table · values hidden/i)
-    ).toBeVisible()
+    await expect(page.getByText(/Stub preview · values hidden/i)).toBeVisible()
     await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
     await expect(page.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
 
@@ -154,6 +152,9 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/Value search supported: 1 safe ref metadata match/i)
     ).toBeVisible()
+
+    await page.getByLabel(/Metadata search/i).fill('')
+    await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
 
     await page
       .getByRole('button', { name: /Controlled reveal/i })
@@ -172,6 +173,29 @@ test.describe('Secrets Broker browser coverage', () => {
         name: /Apply disabled until dry-run preview is accepted/i,
       })
     ).toBeDisabled()
+
+    await expect(
+      page.getByText(/Stub update\/reset\/reveal API preview/i)
+    ).toBeVisible()
+    await expect(page.getByText(/audit reason required/i)).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /Simulate stub apply/i })
+    ).toBeDisabled()
+    await page
+      .getByLabel(/Audit reason for stub preview/i)
+      .fill('operator requested preview')
+    await page.getByLabel(/I confirm this is a stub preview/i).check()
+    await expect(page.getByText(/Stub apply can be simulated/i)).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /Simulate stub apply/i })
+    ).toBeEnabled()
+    await page.getByLabel(/Stub API state/i).selectOption('success')
+    await expect(page.getByText(/Stub apply success/i).last()).toBeVisible()
+    await page.getByLabel(/Stub API state/i).selectOption('failure')
+    await expect(page.getByText(/Stub apply failure/i).last()).toBeVisible()
+    await page.getByRole('button', { name: /Cancel stub preview/i }).click()
+    await expect(page.getByText(/cancelled by operator/i)).toBeVisible()
+
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Summary

Implements the focused #95 stub-backed Secrets update UI preview inside the existing Secrets Broker Secrets page.

- adds deterministic stub mutation states for single-secret update/reset/reveal preview
- adds audit reason + explicit confirmation gating before simulated apply can enable
- renders metadata-only dry-run diff, policy/audit status, fake apply status, and affected ref
- covers ready, denied, auth-required, unavailable, cancelled, success, and failure states
- keeps #40 bulk campaign behavior out of scope and labels the flow as stub/non-production
- updates browser UI coverage for the changed Secrets page copy and stub-state flow

## Safety boundary

No real secret values, provider credentials, tokens, cookies, private keys, recovery material, raw env values, wrapper plaintext, session material, or raw secrets are added to UI/fixtures/tests/docs/PR content. The preview is metadata-only and deterministic.

## Validation

- `npm test -- src/features/secrets-broker/secrets-management.test.tsx` ✅ 6 tests
- `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table search"` ✅ 1 browser test
- `npm run lint` ✅ 0 errors; 7 existing warnings outside changed files
- `npm run build` ✅
- `git diff --check HEAD^..HEAD` ✅
- changed-file leak scan ✅ only expected deny-list/test assertions and safety text

Closes #95
