### PR TITLE
fix: prevent prod Service Admin stub fallback

### DIFF
--- a/runtime/server.js
+++ b/runtime/server.js
@@ -9,6 +9,11 @@ const root = path.resolve(__dirname, '..')
 const distDir = path.resolve(root, process.env.SERVICE_DIST_DIR || 'dist')
 const host = process.env.SERVICE_HOST || '127.0.0.1'
 const port = Number(process.env.SERVICE_PORT || '17700')
+const runtimeApiBaseUrl = (
+  process.env.SERVICE_LASSO_API_BASE_URL ||
+  process.env.SERVICE_LASSO_RUNTIME_API_BASE_URL ||
+  ''
+).replace(/\/$/, '')
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],
@@ -51,8 +56,65 @@ function resolveRequestPath(urlPath) {
   return path.join(distDir, 'index.html')
 }
 
+function readRequestBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    request.on('data', (chunk) => chunks.push(chunk))
+    request.on('end', () => resolve(Buffer.concat(chunks)))
+    request.on('error', reject)
+  })
+}
+
+async function proxyRuntimeApi(request, response) {
+  if (!runtimeApiBaseUrl) {
+    response.writeHead(503, { 'Content-Type': 'application/json; charset=utf-8' })
+    response.end(JSON.stringify({
+      error: 'service_lasso_runtime_api_unconfigured',
+      message: 'Service Admin is running in production mode but SERVICE_LASSO_API_BASE_URL / SERVICE_LASSO_RUNTIME_API_BASE_URL is not configured.',
+    }))
+    return
+  }
+
+  const method = request.method || 'GET'
+  const targetUrl = new URL(request.url || '/', runtimeApiBaseUrl)
+  const headers = new Headers()
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined || key.toLowerCase() === 'host') continue
+    if (Array.isArray(value)) {
+      for (const entry of value) headers.append(key, entry)
+    } else {
+      headers.set(key, value)
+    }
+  }
+
+  try {
+    const body = ['GET', 'HEAD'].includes(method) ? undefined : await readRequestBody(request)
+    const upstream = await fetch(targetUrl, { method, headers, body })
+    response.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()))
+    if (method === 'HEAD') {
+      response.end()
+      return
+    }
+    const arrayBuffer = await upstream.arrayBuffer()
+    response.end(Buffer.from(arrayBuffer))
+  } catch (error) {
+    response.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' })
+    response.end(JSON.stringify({
+      error: 'service_lasso_runtime_api_unreachable',
+      message: error instanceof Error ? error.message : String(error),
+    }))
+  }
+}
+
 const server = http.createServer((request, response) => {
   const method = request.method || 'GET'
+  const requestPath = new URL(request.url || '/', 'http://127.0.0.1').pathname
+
+  if (requestPath.startsWith('/api/')) {
+    void proxyRuntimeApi(request, response)
+    return
+  }
+
   if (method !== 'GET' && method !== 'HEAD') {
     response.writeHead(405, { 'Content-Type': 'text/plain; charset=utf-8' })
     response.end('Method Not Allowed')

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -5,6 +5,7 @@ import {
   fetchServices as fetchStubServices,
   runDashboardAction as runStubDashboardAction,
   serviceLassoApiBaseUrl,
+  stubDashboardDataEnabled,
 } from './stub'
 import type {
   DashboardAction,
@@ -29,7 +30,7 @@ function encodeServiceId(serviceId: string) {
 }
 
 function buildApiUrl(pathname: string) {
-  if (!serviceLassoApiBaseUrl) {
+  if (serviceLassoApiBaseUrl === null) {
     throw new Error('Service Lasso API base URL is not configured.')
   }
 
@@ -49,10 +50,6 @@ async function fetchRuntimeJson<T>(pathname: string, init?: RequestInit) {
   }
 
   return (await response.json()) as T
-}
-
-function hasRuntimeApi() {
-  return Boolean(serviceLassoApiBaseUrl)
 }
 
 async function fetchRuntimeDashboardSummary() {
@@ -126,7 +123,7 @@ async function runRuntimeDashboardAction(action: DashboardAction) {
 }
 
 export async function fetchDashboardSummary() {
-  if (!hasRuntimeApi()) {
+  if (stubDashboardDataEnabled) {
     return fetchStubDashboardSummary()
   }
 
@@ -134,7 +131,7 @@ export async function fetchDashboardSummary() {
 }
 
 export async function fetchServices() {
-  if (!hasRuntimeApi()) {
+  if (stubDashboardDataEnabled) {
     return fetchStubServices()
   }
 
@@ -142,7 +139,7 @@ export async function fetchServices() {
 }
 
 export async function fetchDashboardService(serviceId: string) {
-  if (!hasRuntimeApi()) {
+  if (stubDashboardDataEnabled) {
     return fetchStubDashboardService(serviceId)
   }
 
@@ -155,7 +152,7 @@ export function buildServiceLogUrl(
     type?: 'default' | 'access' | 'error'
   }
 ) {
-  if (!hasRuntimeApi()) {
+  if (stubDashboardDataEnabled) {
     return buildStubServiceLogUrl(serviceId, options)
   }
 
@@ -168,7 +165,7 @@ export function buildServiceLogUrl(
 }
 
 export async function runDashboardAction(action: DashboardAction) {
-  if (!hasRuntimeApi()) {
+  if (stubDashboardDataEnabled) {
     return runStubDashboardAction(action)
   }
 

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -8,7 +8,10 @@ import type {
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 export const serviceLassoApiBaseUrl =
-  import.meta.env.VITE_SERVICE_LASSO_API_BASE_URL?.replace(/\/$/, '') || null
+  import.meta.env.VITE_SERVICE_LASSO_API_BASE_URL?.replace(/\/$/, '') ??
+  (import.meta.env.PROD ? '' : null)
+
+export const stubDashboardDataEnabled = serviceLassoApiBaseUrl === null
 
 export const favoritesFeatureEnabled =
   import.meta.env.VITE_SERVICE_LASSO_FAVORITES_ENABLED === 'true'
@@ -24,7 +27,7 @@ type RemoteServiceMeta = {
 }
 
 async function fetchRemoteServiceMeta(): Promise<RemoteServiceMeta[] | null> {
-  if (!serviceLassoApiBaseUrl) return null
+  if (serviceLassoApiBaseUrl === null) return null
 
   try {
     const response = await fetch(`${serviceLassoApiBaseUrl}/api/services/meta`)


### PR DESCRIPTION
## Summary
- make production Service Admin builds use same-origin runtime API routes when no explicit API base is compiled
- keep stub dashboard data available only for local dev/no-runtime mode
- add a production static-server `/api/*` proxy to the owning Service Lasso runtime API
- fail visibly with JSON `503 service_lasso_runtime_api_unconfigured` when prod runtime API wiring is missing

## Validation
- `npm test -- --run src/lib/service-lasso-dashboard/client.test.ts` ✅
- `npm run build` ✅
- `npm run test:dev-server` ✅
- `npm test` ✅ 17 files / 116 tests
- manual prod server check without runtime API env: `/api/health` returns 503 `service_lasso_runtime_api_unconfigured` ✅
- manual prod server check with `SERVICE_LASSO_RUNTIME_API_BASE_URL=http://127.0.0.1:17880`: `/api/dashboard/services` proxies live runtime data and includes `@secretsbroker` ✅

Related: service-lasso/service-lasso#457