### PR TITLE
ISS-109 restore Service Admin format baseline

### DIFF
--- a/src/features/dashboard/index.tsx
+++ b/src/features/dashboard/index.tsx
@@ -375,4 +375,3 @@ export function Dashboard() {
     </>
   )
 }
-

--- a/src/features/dependencies/index.tsx
+++ b/src/features/dependencies/index.tsx
@@ -1167,4 +1167,3 @@ export function Dependencies() {
     </>
   )
 }
-

--- a/src/features/logs/index.tsx
+++ b/src/features/logs/index.tsx
@@ -726,4 +726,3 @@ export function Logs() {
     </>
   )
 }
-

--- a/src/features/runtime/index.tsx
+++ b/src/features/runtime/index.tsx
@@ -363,4 +363,3 @@ export function Runtime() {
     </>
   )
 }
-

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1149,4 +1149,3 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
     </>
   )
 }
-

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -249,4 +249,3 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
     cell: DataTableRowActions,
   },
 ]
-

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -21,7 +21,8 @@ function service(
     links: [{ label: 'Local', url: 'http://127.0.0.1', kind: 'local' }],
     runtimeHealth: {
       state: status,
-      health: status === 'running' || status === 'available' ? 'healthy' : 'critical',
+      health:
+        status === 'running' || status === 'available' ? 'healthy' : 'critical',
       uptime: status === 'running' ? '3m' : '0m',
       lastCheckAt: '2026-04-16T16:00:03.000Z',
       lastRestartAt:

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -684,8 +684,9 @@ function buildSummary(): DashboardSummary {
     servicesTotal: services.length,
     servicesRunning: services.filter((service) => service.status === 'running')
       .length,
-    servicesAvailable: services.filter((service) => service.status === 'available')
-      .length,
+    servicesAvailable: services.filter(
+      (service) => service.status === 'available'
+    ).length,
     servicesStopped: services.filter((service) => service.status === 'stopped')
       .length,
     servicesDegraded: services.filter(


### PR DESCRIPTION
## Issue
Closes #109

## Summary
- Restores the repository Prettier baseline for the eight files reported by CI.
- Keeps the change mechanical: no UI behavior or data-shape changes.

## Scope
- In scope: Prettier-only formatting updates for the files listed in #109.
- Out of scope: unrelated UI, table, routing, lint-warning, or CI workflow changes.

## Spec / contract / fixture impact
- Not required because this is a mechanical formatting baseline fix only.

## Service Lasso invariant impact
- Invariant: Service Admin must stay optional and safe to validate independently.
- Preservation proof: no runtime, secrets, routes, or Service Lasso integration behavior changed.

## Validation
- PASS npm run format:check — all matched files use Prettier style.
- PASS npm run lint — exits 0; existing warnings only.
- PASS git diff --check — no whitespace errors.
- PASS npm run build — production build completes; existing Vite chunk-size/deprecation warnings only.

## Approval trail
- Required: no.
- Evidence: mechanical format-only diff and local validation logs under .work-agent/logs/issue-109-20260520T052823Z.

## Cleanup
- Branch: issue-109-format-baseline
- Post-merge cleanup: delete branch after merge and return local checkout to clean master.