### PR TITLE
feat(secret-inventory): use shared data table

### DIFF
--- a/src/features/secret-inventory/index.tsx
+++ b/src/features/secret-inventory/index.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { getRouteApi } from '@tanstack/react-router'
 import { DatabaseZap, ShieldCheck } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -10,14 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
 import { ConfigDrawer } from '@/components/config-drawer'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
@@ -28,20 +20,14 @@ import {
   countSecretInventoryByState,
   secretInventoryBoundaries,
   secretInventoryRows,
-  type SecretInventoryState,
 } from './secret-inventory'
+import { SecretInventoryTable } from './secret-inventory-table'
 
-const stateVariant: Record<
-  SecretInventoryState,
-  'default' | 'secondary' | 'destructive' | 'outline'
-> = {
-  present: 'default',
-  missing: 'destructive',
-  stale: 'secondary',
-  'rotation-due': 'outline',
-}
+const route = getRouteApi('/_authenticated/secret-inventory/')
 
 export function SecretInventoryPage() {
+  const search = route.useSearch()
+  const navigate = route.useNavigate()
   const counts = countSecretInventoryByState()
 
   usePageMetadata({
@@ -134,95 +120,11 @@ export function SecretInventoryPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <div className='overflow-x-auto rounded-md border'>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Namespace / ref</TableHead>
-                    <TableHead>Source / backend</TableHead>
-                    <TableHead>Owner</TableHead>
-                    <TableHead>State</TableHead>
-                    <TableHead>Key / rotation</TableHead>
-                    <TableHead>Last updated / used</TableHead>
-                    <TableHead>Metadata links</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {secretInventoryRows.map((row) => (
-                    <TableRow key={row.id}>
-                      <TableCell className='min-w-72 align-top'>
-                        <div className='font-medium'>{row.namespace}</div>
-                        <div className='text-sm break-all text-muted-foreground'>
-                          {row.refId}
-                        </div>
-                        <div className='mt-2 text-xs text-muted-foreground'>
-                          {row.safeNotes}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-56 align-top'>
-                        <Badge variant='outline'>{row.source}</Badge>
-                        <div className='mt-2 text-sm text-muted-foreground'>
-                          {row.backend}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-44 align-top'>
-                        <div className='font-medium'>{row.owningService}</div>
-                        <div className='text-sm text-muted-foreground'>
-                          {row.workspace}
-                        </div>
-                      </TableCell>
-                      <TableCell className='align-top'>
-                        <Badge variant={stateVariant[row.presenceState]}>
-                          {row.presenceState}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className='min-w-48 align-top'>
-                        <div>{row.keyVersion}</div>
-                        <div className='text-sm text-muted-foreground'>
-                          {row.rotationStatus}
-                        </div>
-                        <div className='text-xs text-muted-foreground'>
-                          Expiry: {row.expiry}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-52 align-top text-sm'>
-                        <div>Updated: {row.lastUpdated}</div>
-                        <div className='text-muted-foreground'>
-                          Used: {row.lastUsed}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-48 align-top'>
-                        <div className='space-y-1 text-sm'>
-                          {row.providerConnectionUrl ? (
-                            <Link
-                              to={row.providerConnectionUrl}
-                              className='block text-primary underline-offset-4 hover:underline'
-                            >
-                              provider metadata
-                            </Link>
-                          ) : null}
-                          <Link
-                            to={row.refUsageUrl}
-                            className='block text-primary underline-offset-4 hover:underline'
-                          >
-                            ref usage
-                          </Link>
-                          <Link
-                            to={row.auditUrl}
-                            className='block text-primary underline-offset-4 hover:underline'
-                          >
-                            audit events
-                          </Link>
-                        </div>
-                        <div className='mt-2 text-xs text-muted-foreground'>
-                          Unavailable: {row.unavailableActions.join(', ')}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
+            <SecretInventoryTable
+              data={secretInventoryRows}
+              search={search}
+              navigate={navigate}
+            />
           </CardContent>
         </Card>
 

--- a/src/features/secret-inventory/secret-inventory-table.tsx
+++ b/src/features/secret-inventory/secret-inventory-table.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import {
+  type ColumnDef,
+  type SortingState,
+  type VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { cn } from '@/lib/utils'
+import { type NavigateFn, useTableUrlState } from '@/hooks/use-table-url-state'
+import { Badge } from '@/components/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+} from '@/components/data-table'
+import {
+  type SecretInventoryRow,
+  type SecretInventorySource,
+  type SecretInventoryState,
+} from './secret-inventory'
+
+const stateVariant: Record<
+  SecretInventoryState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  present: 'default',
+  missing: 'destructive',
+  stale: 'secondary',
+  'rotation-due': 'outline',
+}
+
+const stateOptions: Array<{ label: string; value: SecretInventoryState }> = [
+  { label: 'Present', value: 'present' },
+  { label: 'Rotation due', value: 'rotation-due' },
+  { label: 'Stale', value: 'stale' },
+  { label: 'Missing', value: 'missing' },
+]
+
+const sourceOptions: Array<{ label: string; value: SecretInventorySource }> = [
+  { label: 'Local encrypted store', value: 'local encrypted store' },
+  { label: 'Provider connection', value: 'provider connection' },
+  { label: 'File source', value: 'file source' },
+  { label: 'Generated write-back', value: 'generated write-back' },
+]
+
+const columns: ColumnDef<SecretInventoryRow>[] = [
+  {
+    id: 'ref',
+    accessorFn: (row) =>
+      [
+        row.namespace,
+        row.refId,
+        row.owningService,
+        row.workspace,
+        row.backend,
+        row.safeNotes,
+      ].join(' '),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Namespace / ref' />
+    ),
+    cell: ({ row }) => (
+      <div className='min-w-72 align-top'>
+        <div className='font-medium'>{row.original.namespace}</div>
+        <div className='text-sm break-all text-muted-foreground'>
+          {row.original.refId}
+        </div>
+        <div className='mt-2 text-xs text-muted-foreground'>
+          {row.original.safeNotes}
+        </div>
+      </div>
+    ),
+    filterFn: (row, id, value) =>
+      String(row.getValue(id))
+        .toLowerCase()
+        .includes(String(value).toLowerCase()),
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'source',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Source / backend' />
+    ),
+    cell: ({ row }) => (
+      <div className='min-w-56 align-top'>
+        <Badge variant='outline'>{row.original.source}</Badge>
+        <div className='mt-2 text-sm text-muted-foreground'>
+          {row.original.backend}
+        </div>
+      </div>
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'owningService',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Owner' />
+    ),
+    cell: ({ row }) => (
+      <div className='min-w-44 align-top'>
+        <div className='font-medium'>{row.original.owningService}</div>
+        <div className='text-sm text-muted-foreground'>
+          {row.original.workspace}
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'presenceState',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='State' />
+    ),
+    cell: ({ row }) => (
+      <Badge variant={stateVariant[row.original.presenceState]}>
+        {row.original.presenceState}
+      </Badge>
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'rotationStatus',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Key / rotation' />
+    ),
+    cell: ({ row }) => (
+      <div className='min-w-48 align-top'>
+        <div>{row.original.keyVersion}</div>
+        <div className='text-sm text-muted-foreground'>
+          {row.original.rotationStatus}
+        </div>
+        <div className='text-xs text-muted-foreground'>
+          Expiry: {row.original.expiry}
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'lastUpdated',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Last updated / used' />
+    ),
+    cell: ({ row }) => (
+      <div className='min-w-52 align-top text-sm'>
+        <div>Updated: {row.original.lastUpdated}</div>
+        <div className='text-muted-foreground'>
+          Used: {row.original.lastUsed}
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: 'links',
+    header: 'Metadata links',
+    cell: ({ row }) => (
+      <div className='min-w-48 align-top'>
+        <div className='space-y-1 text-sm'>
+          {row.original.providerConnectionUrl ? (
+            <Link
+              to={row.original.providerConnectionUrl}
+              className='block text-primary underline-offset-4 hover:underline'
+            >
+              provider metadata
+            </Link>
+          ) : null}
+          <Link
+            to={row.original.refUsageUrl}
+            className='block text-primary underline-offset-4 hover:underline'
+          >
+            ref usage
+          </Link>
+          <Link
+            to={row.original.auditUrl}
+            className='block text-primary underline-offset-4 hover:underline'
+          >
+            audit events
+          </Link>
+        </div>
+        <div className='mt-2 text-xs text-muted-foreground'>
+          Unavailable: {row.original.unavailableActions.join(', ')}
+        </div>
+      </div>
+    ),
+    enableSorting: false,
+  },
+]
+
+type SecretInventoryTableProps = {
+  data: SecretInventoryRow[]
+  search: Record<string, unknown>
+  navigate: NavigateFn
+}
+
+export function SecretInventoryTable({
+  data,
+  search,
+  navigate,
+}: SecretInventoryTableProps) {
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'presenceState', desc: false },
+  ])
+
+  const {
+    columnFilters,
+    onColumnFiltersChange,
+    pagination,
+    onPaginationChange,
+    ensurePageInRange,
+  } = useTableUrlState({
+    search,
+    navigate,
+    pagination: { defaultPage: 1, defaultPageSize: 10 },
+    globalFilter: { enabled: false },
+    columnFilters: [
+      { columnId: 'ref', searchKey: 'ref', type: 'string' },
+      { columnId: 'presenceState', searchKey: 'state', type: 'array' },
+      { columnId: 'source', searchKey: 'source', type: 'array' },
+    ],
+  })
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      pagination,
+      columnFilters,
+      columnVisibility,
+    },
+    onPaginationChange,
+    onColumnFiltersChange,
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    getPaginationRowModel: getPaginationRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
+
+  useEffect(() => {
+    ensurePageInRange(table.getPageCount())
+  }, [table, ensurePageInRange])
+
+  return (
+    <div className='flex flex-1 flex-col gap-4'>
+      <DataTableToolbar
+        table={table}
+        searchPlaceholder='Search secret refs, owners, backends, and notes...'
+        searchKey='ref'
+        filters={[
+          {
+            columnId: 'presenceState',
+            title: 'State',
+            options: stateOptions,
+          },
+          {
+            columnId: 'source',
+            title: 'Source',
+            options: sourceOptions,
+          },
+        ]}
+      />
+      <div className='overflow-x-auto rounded-md border'>
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className='group/row'>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    className={cn(
+                      'bg-background group-hover/row:bg-muted',
+                      header.column.columnDef.meta?.className,
+                      header.column.columnDef.meta?.thClassName
+                    )}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} className='group/row'>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cn(
+                        'bg-background align-top group-hover/row:bg-muted',
+                        cell.column.columnDef.meta?.className,
+                        cell.column.columnDef.meta?.tdClassName
+                      )}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className='h-24 text-center'
+                >
+                  No secret refs match the current filters.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <DataTablePagination table={table} className='mt-auto' />
+    </div>
+  )
+}

--- a/src/features/secret-inventory/secret-inventory.test.tsx
+++ b/src/features/secret-inventory/secret-inventory.test.tsx
@@ -1,5 +1,6 @@
 import { renderRoute } from '@/test/render-route'
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
   buildLargeSecretInventoryFixture,
@@ -65,5 +66,28 @@ describe('secret inventory metadata view', () => {
     expect(largeRows[124].refId).toBe('secret://fixture/workspace-5/ref-125')
     expect(new Set(largeRows.map((row) => row.id)).size).toBe(125)
     expect(secretInventoryHasPlaintextMaterial(largeRows)).toBe(false)
+  })
+
+  it('supports shared data-table search and pagination for inventory refs', async () => {
+    const user = userEvent.setup()
+    const { router } = await renderRoute('/secret-inventory?pageSize=2')
+
+    expect(screen.getByPlaceholderText(/Search secret refs/i)).toBeVisible()
+    expect(screen.getByText('local/serviceadmin')).toBeVisible()
+    expect(screen.queryByText('file/runtime')).not.toBeInTheDocument()
+    expect(screen.getAllByText(/Page 1 of 3/i)[0]).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: /Go to next page/i }))
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ page: 2 })
+    })
+
+    await user.type(
+      screen.getByPlaceholderText(/Search secret refs/i),
+      'payments'
+    )
+    expect(screen.getByText('provider/payments')).toBeVisible()
+    expect(screen.queryByText('file/runtime')).not.toBeInTheDocument()
+    expect(router.state.location.search).toMatchObject({ ref: 'payments' })
   })
 })

--- a/src/routes/_authenticated/secret-inventory/index.tsx
+++ b/src/routes/_authenticated/secret-inventory/index.tsx
@@ -1,6 +1,16 @@
+import z from 'zod'
 import { createFileRoute } from '@tanstack/react-router'
 import { SecretInventoryPage } from '@/features/secret-inventory'
 
+const secretInventorySearchSchema = z.object({
+  page: z.number().optional().catch(undefined),
+  pageSize: z.number().optional().catch(undefined),
+  ref: z.string().optional().catch(''),
+  state: z.array(z.string()).optional().catch(undefined),
+  source: z.array(z.string()).optional().catch(undefined),
+})
+
 export const Route = createFileRoute('/_authenticated/secret-inventory/')({
+  validateSearch: secretInventorySearchSchema,
   component: SecretInventoryPage,
 })


### PR DESCRIPTION
## Summary
- migrates the Secret Inventory ref table to the shared data-table toolbar, filters, sorting, column visibility, and pagination stack
- adds URL-backed Secret Inventory search params for ref/state/source and pagination
- adds focused coverage for shared table search and pagination while preserving no-plaintext controls

## Validation
- npm exec vitest run src/features/secret-inventory/secret-inventory.test.tsx
- npm run build

Closes #102.