### PR TITLE
ISS-104 add topology graph search

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -10,6 +10,7 @@ import {
   Network,
   ShieldCheck,
   TerminalSquare,
+  X,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { Badge } from '@/components/ui/badge'
@@ -69,6 +70,7 @@ import {
 } from './source-backends'
 import {
   buildSecretsBrokerTopology,
+  filterSecretsBrokerTopology,
   toReactFlowSecretsBrokerTopology,
 } from './topology'
 import {
@@ -1380,6 +1382,7 @@ export function SecretsBrokerSetupWizard() {
   const [auditQueryFilter, setAuditQueryFilter] = useState('')
   const [auditSinceFilter, setAuditSinceFilter] = useState('')
   const [auditUntilFilter, setAuditUntilFilter] = useState('')
+  const [topologySearchQuery, setTopologySearchQuery] = useState('')
   const [selectedAuditEventId, setSelectedAuditEventId] = useState(
     secretsBrokerAuditEvents[0].id
   )
@@ -1468,11 +1471,15 @@ export function SecretsBrokerSetupWizard() {
     filteredAuditEvents[0] ??
     secretsBrokerAuditEvents[0]
   const secretsTopology = useMemo(() => buildSecretsBrokerTopology(), [])
-  const reactFlowSecretsTopology = useMemo(
-    () => toReactFlowSecretsBrokerTopology(secretsTopology),
-    [secretsTopology]
+  const filteredSecretsTopology = useMemo(
+    () => filterSecretsBrokerTopology(secretsTopology, topologySearchQuery),
+    [secretsTopology, topologySearchQuery]
   )
-  const topologyProblemEdges = secretsTopology.edges.filter((edge) =>
+  const reactFlowSecretsTopology = useMemo(
+    () => toReactFlowSecretsBrokerTopology(filteredSecretsTopology),
+    [filteredSecretsTopology]
+  )
+  const topologyProblemEdges = filteredSecretsTopology.edges.filter((edge) =>
     ['failed', 'denied', 'missing', 'warning'].includes(edge.status)
   )
 
@@ -2276,13 +2283,13 @@ export function SecretsBrokerSetupWizard() {
               <div className='rounded-lg border p-3'>
                 <div className='text-xs text-muted-foreground'>Graph nodes</div>
                 <div className='text-2xl font-bold'>
-                  {secretsTopology.nodes.length}
+                  {filteredSecretsTopology.nodes.length}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
                 <div className='text-xs text-muted-foreground'>Graph edges</div>
                 <div className='text-2xl font-bold'>
-                  {secretsTopology.edges.length}
+                  {filteredSecretsTopology.edges.length}
                 </div>
               </div>
               <div className='rounded-lg border p-3'>
@@ -2299,6 +2306,41 @@ export function SecretsBrokerSetupWizard() {
                 </div>
                 <div className='mt-1'>hidden / never rendered</div>
               </div>
+            </div>
+
+            <div className='grid gap-3 rounded-lg border p-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end'>
+              <div>
+                <label
+                  htmlFor='secrets-topology-search'
+                  className='mb-1 block text-xs font-medium text-muted-foreground'
+                >
+                  Search topology
+                </label>
+                <Input
+                  id='secrets-topology-search'
+                  value={topologySearchQuery}
+                  onChange={(event) =>
+                    setTopologySearchQuery(event.target.value)
+                  }
+                  placeholder='Search service, workflow, provider, ref, or status'
+                />
+                <div className='mt-2 text-xs text-muted-foreground'>
+                  Showing {filteredSecretsTopology.nodes.length} of{' '}
+                  {secretsTopology.nodes.length} nodes and{' '}
+                  {filteredSecretsTopology.edges.length} of{' '}
+                  {secretsTopology.edges.length} relationships.
+                </div>
+              </div>
+              {topologySearchQuery ? (
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => setTopologySearchQuery('')}
+                >
+                  <X className='size-4' />
+                  Clear
+                </Button>
+              ) : null}
             </div>
 
             <DependencyGraphCanvas
@@ -2339,11 +2381,11 @@ export function SecretsBrokerSetupWizard() {
                   </tr>
                 </thead>
                 <tbody>
-                  {secretsTopology.edges.map((edge) => {
-                    const sourceNode = secretsTopology.nodes.find(
+                  {filteredSecretsTopology.edges.map((edge) => {
+                    const sourceNode = filteredSecretsTopology.nodes.find(
                       (node) => node.id === edge.source
                     )
-                    const targetNode = secretsTopology.nodes.find(
+                    const targetNode = filteredSecretsTopology.nodes.find(
                       (node) => node.id === edge.target
                     )
 
@@ -2394,6 +2436,13 @@ export function SecretsBrokerSetupWizard() {
                       </tr>
                     )
                   })}
+                  {!filteredSecretsTopology.edges.length ? (
+                    <tr>
+                      <td className='p-3 text-muted-foreground' colSpan={5}>
+                        No topology relationships match the current search.
+                      </td>
+                    </tr>
+                  ) : null}
                 </tbody>
               </table>
             </div>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -37,7 +37,11 @@ import {
   secretsBrokerSourceBackends,
   sourceBackendHasSecretValue,
 } from './source-backends'
-import { buildSecretsBrokerTopology, topologyHasSecretValue } from './topology'
+import {
+  buildSecretsBrokerTopology,
+  filterSecretsBrokerTopology,
+  topologyHasSecretValue,
+} from './topology'
 import {
   workflowAuthoringBoundaries,
   workflowAuthoringHasSecretValue,
@@ -783,6 +787,7 @@ describe('Secrets Broker setup wizard', () => {
     await renderRoute('/secrets-broker')
 
     const topology = buildSecretsBrokerTopology()
+    const postgresTopology = filterSecretsBrokerTopology(topology, 'postgres')
 
     expect(screen.getByText(/Secrets Broker topology/i)).toBeVisible()
     expect(screen.getAllByText(/Safe metadata only/i)[0]).toBeVisible()
@@ -795,6 +800,17 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.getAllByRole('link', { name: /Diagnostics/i })[0]
     ).toBeVisible()
+    const topologySearch = screen.getByLabelText(/Search topology/i)
+    await userEvent.type(topologySearch, 'postgres')
+    expect(topologySearch).toHaveValue('postgres')
+    expect(
+      screen.getByText(
+        new RegExp(
+          `Showing ${postgresTopology.nodes.length} of ${topology.nodes.length} nodes and ${postgresTopology.edges.length} of ${topology.edges.length} relationships\\.`
+        )
+      )
+    ).toBeVisible()
+    expect(screen.getAllByText(/postgres/i)[0]).toBeVisible()
     expect(
       screen.queryByText(/correct-horse-battery-staple/i)
     ).not.toBeInTheDocument()
@@ -805,6 +821,28 @@ describe('Secrets Broker setup wizard', () => {
       screen.queryByText(/sk-this-value-must-not-render/i)
     ).not.toBeInTheDocument()
     expect(topology.edges.length).toBeGreaterThan(0)
+  })
+
+  it('filters topology search results without orphaning visible edges', () => {
+    const topology = buildSecretsBrokerTopology()
+    const filteredTopology = filterSecretsBrokerTopology(topology, 'postgres')
+    const filteredNodeIds = new Set(
+      filteredTopology.nodes.map((node) => node.id)
+    )
+
+    expect(filteredTopology.nodes.length).toBeGreaterThan(0)
+    expect(filteredTopology.nodes.length).toBeLessThan(topology.nodes.length)
+    expect(filteredTopology.edges.length).toBeGreaterThan(0)
+    expect(
+      filteredTopology.nodes.some((node) => node.label === 'postgres')
+    ).toBe(true)
+    expect(
+      filteredTopology.edges.every(
+        (edge) =>
+          filteredNodeIds.has(edge.source) && filteredNodeIds.has(edge.target)
+      )
+    ).toBe(true)
+    expect(topologyHasSecretValue(filteredTopology)).toBe(false)
   })
 
   it('builds topology from the same safe metadata used by list and audit views', () => {

--- a/src/features/secrets-broker/topology.ts
+++ b/src/features/secrets-broker/topology.ts
@@ -406,6 +406,68 @@ export function toReactFlowSecretsBrokerTopology(
   return { nodes, edges }
 }
 
+function topologySearchMatches(
+  query: string,
+  values: Array<string | undefined>
+) {
+  return values.some((value) => value?.toLowerCase().includes(query))
+}
+
+export function filterSecretsBrokerTopology(
+  topology: SecretsBrokerTopology,
+  query: string
+): SecretsBrokerTopology {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  if (!normalizedQuery) return topology
+
+  const nodesById = new Map(topology.nodes.map((node) => [node.id, node]))
+  const directlyMatchedNodeIds = new Set(
+    topology.nodes
+      .filter((node) =>
+        topologySearchMatches(normalizedQuery, [
+          node.id,
+          node.label,
+          node.kind,
+          node.summary,
+        ])
+      )
+      .map((node) => node.id)
+  )
+  const visibleNodeIds = new Set(directlyMatchedNodeIds)
+  const visibleEdgeIds = new Set<string>()
+
+  topology.edges.forEach((edge) => {
+    const sourceNode = nodesById.get(edge.source)
+    const targetNode = nodesById.get(edge.target)
+    const edgeMatches = topologySearchMatches(normalizedQuery, [
+      edge.id,
+      edge.label,
+      edge.kind,
+      edge.status,
+      sourceNode?.label,
+      sourceNode?.kind,
+      targetNode?.label,
+      targetNode?.kind,
+    ])
+
+    if (
+      edgeMatches ||
+      directlyMatchedNodeIds.has(edge.source) ||
+      directlyMatchedNodeIds.has(edge.target)
+    ) {
+      visibleEdgeIds.add(edge.id)
+      visibleNodeIds.add(edge.source)
+      visibleNodeIds.add(edge.target)
+    }
+  })
+
+  return {
+    nodes: topology.nodes.filter((node) => visibleNodeIds.has(node.id)),
+    edges: topology.edges.filter((edge) => visibleEdgeIds.has(edge.id)),
+  }
+}
+
 export function topologyHasSecretValue(topology: SecretsBrokerTopology) {
   const joined = [
     ...topology.nodes.flatMap((node) => [node.id, node.label, node.summary]),


### PR DESCRIPTION
## Issue
Closes #104

## Summary
- Add a Secrets Broker topology search input that filters graph nodes, graph edges, and the accessible relationship fallback together.
- Add a reusable topology filter that keeps matching node neighborhoods connected and prevents orphaned visible edges.
- Add UI and unit coverage proving filtered topology stays safe and omits raw secret material.

## Scope
- In scope: Secrets Broker topology search/filter behavior and tests.
- Out of scope: unrelated Secrets Broker page splits, mutation workflows, provider configuration, and Service Admin navigation changes.

## Spec / contract / fixture impact
- Updated: not required; this is a focused UI affordance for an existing safe topology surface.
- Fixtures: no fixture shape changes.

## Service Lasso invariant impact
- Invariant: secrets and provider credentials must not render in UI or test fixtures.
- Preservation proof: existing secret leak assertions remain in the topology UI test, and new filtered-topology coverage asserts `topologyHasSecretValue(filteredTopology) === false`.

## Validation
- PASS `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 1 file, 29 tests passed.
- PASS `npm run lint` — exit 0; 7 warnings remain in unrelated existing files.
- PASS `npm run build` — production build completed; existing chunk-size warning remains.

## Approval trail
- Required: no.
- Evidence: issue is Ready in Project #1 View 1 and implementation is bounded to #104.

## Cleanup
- Branch: `issue-104-topology-search`.
- Local cleanup after merge: switch back to `master`; `.work-agent/` evidence logs may remain untracked locally.