### PR TITLE
ISS-105 add safe secret delete preview

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -6,6 +6,7 @@ import {
   SearchIcon,
   ShieldCheck,
   SlidersHorizontal,
+  Trash2,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -130,8 +131,8 @@ export function SecretsManagementPage() {
             </h1>
             <p className='mt-1 text-muted-foreground'>
               Secrets Broker management table for safe metadata search,
-              controlled reveal entry, and dry-run edit/reset/policy actions.
-              Rows never render raw secret values.
+              controlled reveal entry, and dry-run edit/reset/delete/policy
+              actions. Rows never render raw secret values.
             </p>
           </div>
           <Badge variant='secondary'>Stub preview · values hidden</Badge>
@@ -144,9 +145,9 @@ export function SecretsManagementPage() {
             Metadata search is local over safe refs and labels only.
             Broker-backed value search, when supported, returns matching
             refs/metadata only. Reveal delegates to the audited #38 pattern;
-            edit, reset, and policy changes require dry-run/preview before
-            apply. The mutation API on this page is stubbed preview behavior
-            until the production Secrets Broker contract lands.
+            edit, reset, delete, and policy changes require dry-run/preview
+            before apply. The mutation API on this page is stubbed preview
+            behavior until the production Secrets Broker contract lands.
           </AlertDescription>
         </Alert>
 
@@ -168,7 +169,7 @@ export function SecretsManagementPage() {
           <Card>
             <CardHeader className='pb-2'>
               <CardDescription>Dry-run actions</CardDescription>
-              <CardTitle className='text-3xl'>3</CardTitle>
+              <CardTitle className='text-3xl'>4</CardTitle>
             </CardHeader>
           </Card>
           <Card>
@@ -382,6 +383,14 @@ export function SecretsManagementPage() {
                             type='button'
                             size='sm'
                             variant='outline'
+                            onClick={() => chooseAction(row.id, 'delete')}
+                          >
+                            Delete dry-run
+                          </Button>
+                          <Button
+                            type='button'
+                            size='sm'
+                            variant='outline'
                             onClick={() => chooseAction(row.id, 'policy')}
                           >
                             Apply policy preview
@@ -403,6 +412,8 @@ export function SecretsManagementPage() {
                 <Eye className='size-4' />
               ) : actionPreview.action === 'reset' ? (
                 <RotateCcw className='size-4' />
+              ) : actionPreview.action === 'delete' ? (
+                <Trash2 className='size-4' />
               ) : (
                 <SlidersHorizontal className='size-4' />
               )}
@@ -441,7 +452,7 @@ export function SecretsManagementPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Stub update/reset/reveal API preview</CardTitle>
+            <CardTitle>Stub update/reset/delete/reveal API preview</CardTitle>
             <CardDescription>
               Deterministic non-production status model for a single selected
               secret. This previews the operator flow only; no secret material

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -22,7 +22,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Visible values/i)).toBeVisible()
     expect(screen.getByText(/Stub preview · values hidden/i)).toBeVisible()
     expect(
-      screen.getByText(/Stub update\/reset\/reveal API preview/i)
+      screen.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
     ).toBeVisible()
     expect(screen.getAllByText(/Stub API · preview only/i)[0]).toBeVisible()
     expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
@@ -30,6 +30,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Controlled reveal/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Edit\/update dry-run/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Reset\/rotate dry-run/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Delete dry-run/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Apply policy preview/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Raw values hidden/i)[0]).toBeVisible()
     expect(screen.getByText(/No bulk mutation/i)).toBeVisible()
@@ -72,7 +73,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
-  it('previews reveal edit reset and policy actions behind dry-run or confirmation gates', async () => {
+  it('previews reveal edit reset delete and policy actions behind dry-run or confirmation gates', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')
 
@@ -106,6 +107,17 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
 
     await user.click(
+      screen.getAllByRole('button', { name: /Delete dry-run/i })[0]
+    )
+    expect(
+      screen.getByText(/Delete dry-run for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/delete preview required before apply/i)
+    ).toBeVisible()
+    expect(screen.getByText(/recovery guidance/i)).toBeVisible()
+
+    await user.click(
       screen.getAllByRole('button', { name: /Apply policy preview/i })[0]
     )
     expect(
@@ -121,12 +133,12 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeDisabled()
   })
 
-  it('covers stub update reset reveal preview states and gated apply readiness', async () => {
+  it('covers stub update reset delete reveal preview states and gated apply readiness', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')
 
     expect(
-      screen.getByText(/Stub update\/reset\/reveal API preview/i)
+      screen.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
     ).toBeVisible()
     expect(screen.getByText(/audit reason required/i)).toBeVisible()
     expect(
@@ -204,7 +216,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       buildStubSecretMutationPreview(
         managedSecretRows[0],
-        'edit',
+        'delete',
         'ready',
         'operator requested safe preview',
         true

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -9,6 +9,7 @@ export type ManagedSecretAction =
   | 'reveal'
   | 'edit'
   | 'reset'
+  | 'delete'
   | 'policy'
 
 export type ManagedSecretRow = {
@@ -78,7 +79,8 @@ export const managedSecretRows: ManagedSecretRow[] = [
     rotationStatus: 'healthy',
     policy: 'policy/openclaw/service-lasso/read-single-secret',
     auditStatus: 'audit available',
-    backendCapability: 'reveal, edit dry-run, reset dry-run, policy preview',
+    backendCapability:
+      'reveal, edit dry-run, reset dry-run, delete dry-run, policy preview',
     valueSearch: 'supported',
     safeTags: ['startup', 'session', 'local'],
   },
@@ -96,7 +98,7 @@ export const managedSecretRows: ManagedSecretRow[] = [
     rotationStatus: 'due within 7 days',
     policy: 'policy/openclaw/service-lasso/provider-read',
     auditStatus: 'audit available',
-    backendCapability: 'metadata, reveal challenge, reset dry-run',
+    backendCapability: 'metadata, reveal challenge, reset dry-run, delete dry-run',
     valueSearch: 'supported',
     safeTags: ['identity', 'provider', 'rotation'],
   },
@@ -143,8 +145,8 @@ export const managedSecretSafetyBoundaries = [
   'Metadata search filters refs/tags/provider/owner locally; it does not index raw secret values.',
   'Broker-backed value search is represented as supported or unsupported and returns ref metadata only.',
   'Reveal delegates to the controlled #38 pattern: explicit action, audit status, timeout, and value hidden by default.',
-  'Edit, reset, and policy actions require dry-run/preview before apply and never use spreadsheet-style plaintext editing.',
-  'The update/reset/reveal API shown here is a deterministic stub preview until the Secrets Broker production mutation contract lands.',
+  'Edit, reset, delete, and policy actions require dry-run/preview before apply and never use spreadsheet-style plaintext editing.',
+  'The update/reset/delete/reveal API shown here is a deterministic stub preview until the Secrets Broker production mutation contract lands.',
 ]
 
 export const stubSecretMutationStates: Array<{
@@ -174,6 +176,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:action-preview',
     'secrets-management:stub-mutation-preview',
     'secrets-management:stub-mutation-apply-status',
+    'secrets-management:stub-delete-preview',
   ],
   persistedStorage: 'none',
 }
@@ -231,6 +234,8 @@ export function buildStubSecretMutationPreview(
   const actionLabel =
     action === 'reset'
       ? 'reset/rotate'
+      : action === 'delete'
+        ? 'delete'
       : action === 'reveal'
         ? 'reveal'
         : 'update'
@@ -424,6 +429,22 @@ export function buildManagedSecretActionPreview(
           'Preview checks backend support, policy, affected service restart notes, and audit status without generating or displaying raw material in Service Admin.',
         nextStep:
           'Run reset/rotate preview first; apply remains disabled until preview and audit reason are accepted.',
+        requiresConfirmation: true,
+      }
+    case 'delete':
+      return {
+        action,
+        title: `Delete dry-run for ${row.name}`,
+        status:
+          row.state === 'missing'
+            ? 'blocked: ref already missing'
+            : 'delete preview required before apply',
+        preview:
+          'Preview checks delete capability, policy, affected service references, audit readiness, and recovery guidance without reading or exporting the current value.',
+        nextStep:
+          row.state === 'missing'
+            ? 'No delete can be applied until the provider/source reports an existing ref.'
+            : 'Run delete preview first; apply remains disabled until preview, audit reason, and explicit confirmation are accepted.',
         requiresConfirmation: true,
       }
     case 'policy':

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -173,9 +173,19 @@ test.describe('Secrets Broker browser coverage', () => {
         name: /Apply disabled until dry-run preview is accepted/i,
       })
     ).toBeDisabled()
+    await page
+      .getByRole('button', { name: /Delete dry-run/i })
+      .first()
+      .click()
+    await expect(
+      page.getByText(/Delete dry-run for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/delete preview required before apply/i)
+    ).toBeVisible()
 
     await expect(
-      page.getByText(/Stub update\/reset\/reveal API preview/i)
+      page.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
     ).toBeVisible()
     await expect(page.getByText(/audit reason required/i)).toBeVisible()
     await expect(


### PR DESCRIPTION
## Issue
Closes #105

## Summary
- Adds a single-secret delete dry-run action beside the existing update/reset/reveal/policy previews.
- Extends the deterministic stub mutation model so delete previews use the same audit reason, explicit confirmation, policy/auth/unavailable, success, failure, and cancel states.
- Keeps the flow metadata-only: no raw values, provider credentials, tokens, private keys, recovery material, or raw env values are rendered, logged, stored, or exposed.

## Scope
- In scope: focused safe stub-backed single-secret delete preview/apply-readiness UI and test coverage.
- Out of scope: bulk campaign behavior, real broker mutation/provider credential writes, and raw value reveal/export.

## Spec / contract / fixture impact
- Updated UI contract and fixtures in the Secrets Broker secrets management model/tests.
- No production broker API contract changed; this remains clearly marked as stub/non-production behavior.

## Service Lasso invariant impact
- Preserves Secrets Broker local-first, value-hidden behavior.
- Preserves Service Admin as optional UI; this is a frontend workflow preview only.
- No secrets are included in fixtures, logs, routes, diagnostics, or PR evidence.

## Validation
- PASS npm run test -- src/features/secrets-broker/secrets-management.test.tsx - 6 tests passed.
- PASS git diff --check.
- PASS npm run build.
- PASS npm run test:ui -- tests/ui/secrets-broker.spec.ts - 7 browser tests passed.

## Approval trail
- Required: yes, normal PR review/CI before merge.
- Evidence: issue #105 selected from Project #1 Ready queue.

## Cleanup
- Local branch will remain issue-105-secret-mutation-flow until PR checks/review are complete; worker will return checkout to master after final handoff if no immediate merge is available.
