### PR TITLE
ISS-106 add bulk Secrets dry-run planner

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -1,6 +1,6 @@
 # Secret inventory metadata table
 
-Issue: service-lasso/lasso-serviceadmin#39
+Issues: service-lasso/lasso-serviceadmin#39, service-lasso/lasso-serviceadmin#106
 
 The secret inventory surface is an advanced Secrets Broker planning view for metadata/state-first ref visibility. It is intentionally not a password vault and does not resolve secret payloads.
 
@@ -10,6 +10,8 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - Shows namespace/ref id, source/backend, owning service/workspace, presence state, key version, last updated, last used, expiry/rotation status, and adjacent metadata links.
 - Links to provider metadata, ref usage, and audit views where applicable.
 - Shows unavailable privileged operations as explanatory text, not controls.
+- The Secrets Broker Secrets page also exposes a Stage 1 bulk campaign dry-run planner. Operators can select multiple metadata rows, choose a campaign operation, and generate safe per-ref/aggregate capability, policy, risk, audit, and blocker metadata.
+- The bulk planner is non-mutating. Its apply button is unavailable in this stage and the generated plan contains refs, owners, providers, policy names, blockers, and expected actions only.
 
 ## Not implemented in this slice
 
@@ -19,7 +21,7 @@ This slice does **not** implement:
 - raw reveal controls
 - clipboard/copy value controls
 - backend reads or writes
-- bulk edit or bulk rotation operations
+- bulk edit or bulk rotation apply operations
 - provider credential access
 - arbitrary password-vault/note storage behavior
 - backend enforcement claims
@@ -34,6 +36,8 @@ Any future raw reveal or mutation workflow must be separate from this inventory 
 - timeout/cancellation behavior
 - no-logging/no-export boundaries for revealed values
 - tests proving values do not leak into ordinary UI, logs, diagnostics, support bundles, or table fixtures
+
+Any future bulk apply workflow must build on the Stage 1 dry-run planner and must add fresh revalidation, audit reason capture, explicit confirmation for high-risk plans, per-ref policy enforcement, operation IDs, partial outcome reporting, and tests proving unsupported, denied, auth-required, missing-provider, stale-plan, success, and partial-failure states remain value-safe.
 
 ## Secret-safety boundary
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import {
   DatabaseZap,
   Eye,
+  ListChecks,
   RotateCcw,
   SearchIcon,
   ShieldCheck,
@@ -34,13 +35,16 @@ import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
+  buildBulkSecretCampaignPlan,
   buildManagedSecretActionPreview,
   buildStubSecretMutationPreview,
+  bulkSecretCampaignOperations,
   filterManagedSecrets,
   managedSecretRows,
   managedSecretSafetyBoundaries,
   stubSecretMutationStates,
   valueSearchManagedSecrets,
+  type BulkSecretCampaignOperation,
   type ManagedSecretAction,
   type ManagedSecretState,
   type StubSecretMutationState,
@@ -69,6 +73,13 @@ export function SecretsManagementPage() {
   const [stubState, setStubState] = useState<StubSecretMutationState>('ready')
   const [auditReason, setAuditReason] = useState('')
   const [confirmed, setConfirmed] = useState(false)
+  const [bulkSelectedIds, setBulkSelectedIds] = useState<string[]>([
+    managedSecretRows[0].id,
+    managedSecretRows[1].id,
+  ])
+  const [bulkOperation, setBulkOperation] =
+    useState<BulkSecretCampaignOperation>('rotate-reset')
+  const [bulkPlanGenerated, setBulkPlanGenerated] = useState(false)
 
   usePageMetadata({
     title: 'Service Admin - Secrets Broker Secrets',
@@ -105,10 +116,33 @@ export function SecretsManagementPage() {
     auditReason,
     confirmed
   )
+  const bulkPlan = useMemo(
+    () =>
+      buildBulkSecretCampaignPlan(
+        managedSecretRows,
+        bulkSelectedIds,
+        bulkOperation
+      ),
+    [bulkOperation, bulkSelectedIds]
+  )
 
   function chooseAction(rowId: string, action: ManagedSecretAction) {
     setSelectedRowId(rowId)
     setSelectedAction(action)
+  }
+
+  function toggleBulkSelection(rowId: string, checked: boolean) {
+    setBulkPlanGenerated(false)
+    setBulkSelectedIds((current) =>
+      checked
+        ? [...new Set([...current, rowId])]
+        : current.filter((id) => id !== rowId)
+    )
+  }
+
+  function setOperation(operation: BulkSecretCampaignOperation) {
+    setBulkPlanGenerated(false)
+    setBulkOperation(operation)
   }
 
   return (
@@ -284,7 +318,8 @@ export function SecretsManagementPage() {
           <CardHeader>
             <CardTitle>Secrets management table</CardTitle>
             <CardDescription>
-              Searchable safe metadata rows with controlled row actions. Apply
+              Searchable safe metadata rows with controlled row actions and
+              multi-ref selection for non-mutating campaign planning. Apply
               controls are represented as dry-run/preview states, not direct
               mutation.
             </CardDescription>
@@ -294,6 +329,7 @@ export function SecretsManagementPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead className='w-12'>Plan</TableHead>
                     <TableHead>Secret ref</TableHead>
                     <TableHead>Owner / provider</TableHead>
                     <TableHead>Status</TableHead>
@@ -304,6 +340,16 @@ export function SecretsManagementPage() {
                 <TableBody>
                   {filteredRows.map((row) => (
                     <TableRow key={row.id}>
+                      <TableCell className='align-top'>
+                        <input
+                          type='checkbox'
+                          aria-label={`Select ${row.name} for bulk dry-run`}
+                          checked={bulkSelectedIds.includes(row.id)}
+                          onChange={(event) =>
+                            toggleBulkSelection(row.id, event.target.checked)
+                          }
+                        />
+                      </TableCell>
                       <TableCell className='min-w-80 align-top'>
                         <div className='font-medium'>{row.name}</div>
                         <div className='text-sm break-all text-muted-foreground'>
@@ -392,6 +438,197 @@ export function SecretsManagementPage() {
                   ))}
                 </TableBody>
               </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <ListChecks className='size-4' /> Bulk campaign dry-run planner
+            </CardTitle>
+            <CardDescription>
+              Stage 1 campaign planning only. The plan evaluates selected refs,
+              capability, policy, risk, audit needs, and blockers without
+              reading or writing raw secret material.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='space-y-4 text-sm'>
+            <div className='grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto]'>
+              <div className='space-y-2'>
+                <label
+                  htmlFor='bulk-operation'
+                  className='text-sm font-medium text-muted-foreground'
+                >
+                  Campaign operation
+                </label>
+                <select
+                  id='bulk-operation'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={bulkOperation}
+                  onChange={(event) =>
+                    setOperation(
+                      event.target.value as BulkSecretCampaignOperation
+                    )
+                  }
+                >
+                  {bulkSecretCampaignOperations.map((operation) => (
+                    <option key={operation.id} value={operation.id}>
+                      {operation.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className='flex items-end'>
+                <Button
+                  type='button'
+                  disabled={bulkSelectedIds.length === 0}
+                  onClick={() => setBulkPlanGenerated(true)}
+                >
+                  Generate bulk dry-run plan
+                </Button>
+              </div>
+            </div>
+
+            <div className='grid gap-3 md:grid-cols-3 xl:grid-cols-6'>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  Selected
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.selectedCount}
+                </div>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  Applicable
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.applicableCount}
+                </div>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  Denied
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.deniedCount}
+                </div>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  Unsupported
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.unsupportedCount}
+                </div>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  Auth required
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.authRequiredCount}
+                </div>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs text-muted-foreground uppercase'>
+                  High risk
+                </div>
+                <div className='text-2xl font-semibold'>
+                  {bulkPlan.highRiskCount}
+                </div>
+              </div>
+            </div>
+
+            {bulkSelectedIds.length === 0 ? (
+              <div className='rounded-md border bg-muted/40 p-3'>
+                No refs selected. Select at least one metadata row before
+                generating a campaign dry-run plan.
+              </div>
+            ) : bulkPlanGenerated ? (
+              <div className='overflow-x-auto rounded-md border'>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Ref</TableHead>
+                      <TableHead>Provider / target</TableHead>
+                      <TableHead>Capability / policy</TableHead>
+                      <TableHead>Risk / audit</TableHead>
+                      <TableHead>Expected action</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {bulkPlan.items.map((item) => (
+                      <TableRow key={item.id}>
+                        <TableCell className='min-w-72 align-top'>
+                          <div className='font-medium'>{item.name}</div>
+                          <div className='text-sm break-all text-muted-foreground'>
+                            {item.ref}
+                          </div>
+                          <div className='text-xs text-muted-foreground'>
+                            {item.owningService}
+                          </div>
+                        </TableCell>
+                        <TableCell className='min-w-56 align-top'>
+                          <div>{item.sourceProvider}</div>
+                          <div className='mt-2 text-xs text-muted-foreground'>
+                            Target: {item.targetProvider}
+                          </div>
+                          <div className='text-xs break-all text-muted-foreground'>
+                            {item.targetPolicy}
+                          </div>
+                        </TableCell>
+                        <TableCell className='min-w-64 align-top'>
+                          <div>{item.capabilityResult}</div>
+                          <div className='mt-2 text-muted-foreground'>
+                            {item.policyResult}
+                          </div>
+                          {item.blockers.length > 0 ? (
+                            <div className='mt-2 flex flex-wrap gap-1'>
+                              {item.blockers.map((blocker) => (
+                                <Badge key={blocker} variant='outline'>
+                                  {blocker}
+                                </Badge>
+                              ))}
+                            </div>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className='min-w-56 align-top'>
+                          <Badge
+                            variant={
+                              item.risk === 'high' ? 'destructive' : 'outline'
+                            }
+                          >
+                            {item.risk} risk
+                          </Badge>
+                          <div className='mt-2 text-muted-foreground'>
+                            {item.auditRequirement}
+                          </div>
+                        </TableCell>
+                        <TableCell className='min-w-56 align-top'>
+                          {item.expectedAction}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className='rounded-md border bg-muted/40 p-3'>
+                {bulkPlan.selectedCount} refs selected. Generate dry-run to
+                calculate capability, policy, risk, audit, and blocker metadata.
+              </div>
+            )}
+
+            <div className='flex flex-wrap gap-2'>
+              <Button type='button' disabled>
+                Bulk apply unavailable in Stage 1
+              </Button>
+              <Badge variant='secondary'>Dry-run only</Badge>
+              <Badge variant='outline'>No raw values</Badge>
+              <Badge variant='outline'>No provider credentials</Badge>
+              <Badge variant='outline'>No export</Badge>
             </div>
           </CardContent>
         </Card>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -3,8 +3,10 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
+  buildBulkSecretCampaignPlan,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
+  managedSecretBulkPlanHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretsHaveSecretMaterial,
@@ -69,6 +71,40 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/Value search supported: 1 safe ref metadata match/i)
     ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('generates a non-mutating bulk dry-run plan for selected refs', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    expect(screen.getByText(/Bulk campaign dry-run planner/i)).toBeVisible()
+    expect(screen.getByText(/2 refs selected/i)).toBeVisible()
+
+    await user.click(
+      screen.getByLabelText(/Select NODE_REGISTRY_AUTH for bulk dry-run/i)
+    )
+    await user.click(
+      screen.getByLabelText(/Select PAYMENTS_SIGNING_REF for bulk dry-run/i)
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    )
+
+    expect(screen.getByText(/supported: metadata dry-run only/i)).toBeVisible()
+    expect(
+      screen.getByText(/auth required: provider challenge before dry-run/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/unsupported: reset dry-run unavailable/i)
+    ).toBeVisible()
+    expect(screen.getByText('missing provider/source')).toBeVisible()
+    expect(
+      screen.getByText(/denied: policy is readonly for this ref/i)
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Bulk apply unavailable in Stage 1/i })
+    ).toBeDisabled()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
@@ -219,5 +255,18 @@ describe('Secrets Broker secrets management page', () => {
         true
       ).canApply
     ).toBe(false)
+    const bulkPlan = buildBulkSecretCampaignPlan(
+      managedSecretRows,
+      managedSecretRows.map((row) => row.id),
+      'rotate-reset'
+    )
+    expect(bulkPlan.selectedCount).toBe(4)
+    expect(bulkPlan.applicableCount).toBe(1)
+    expect(bulkPlan.deniedCount).toBe(1)
+    expect(bulkPlan.unsupportedCount).toBe(1)
+    expect(bulkPlan.authRequiredCount).toBe(1)
+    expect(bulkPlan.missingProviderCount).toBe(1)
+    expect(bulkPlan.applyAvailable).toBe(false)
+    expect(managedSecretBulkPlanHasSecretMaterial(bulkPlan)).toBe(false)
   })
 })

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -63,6 +63,42 @@ export type StubSecretMutationPreview = {
   stubOnly: true
 }
 
+export type BulkSecretCampaignOperation =
+  | 'rotate-reset'
+  | 'update-edit'
+  | 'apply-policy'
+  | 'migrate-provider'
+  | 'mark-action-required'
+
+export type BulkSecretCampaignItem = {
+  id: string
+  ref: string
+  name: string
+  owningService: string
+  sourceProvider: string
+  targetProvider: string
+  targetPolicy: string
+  capabilityResult: string
+  policyResult: string
+  risk: 'low' | 'medium' | 'high'
+  auditRequirement: string
+  expectedAction: string
+  blockers: string[]
+}
+
+export type BulkSecretCampaignPlan = {
+  operation: BulkSecretCampaignOperation
+  selectedCount: number
+  applicableCount: number
+  deniedCount: number
+  unsupportedCount: number
+  authRequiredCount: number
+  missingProviderCount: number
+  highRiskCount: number
+  items: BulkSecretCampaignItem[]
+  applyAvailable: false
+}
+
 export const managedSecretRows: ManagedSecretRow[] = [
   {
     id: 'serviceadmin-session-signing',
@@ -160,6 +196,17 @@ export const stubSecretMutationStates: Array<{
   { id: 'failure', label: 'Stub apply failure' },
 ]
 
+export const bulkSecretCampaignOperations: Array<{
+  id: BulkSecretCampaignOperation
+  label: string
+}> = [
+  { id: 'rotate-reset', label: 'Rotate/reset selected refs' },
+  { id: 'update-edit', label: 'Update/edit selected refs' },
+  { id: 'apply-policy', label: 'Apply policy preview' },
+  { id: 'migrate-provider', label: 'Migrate/remap provider' },
+  { id: 'mark-action-required', label: 'Mark action required' },
+]
+
 export const managedSecretSafeSurfaces = {
   route: '/secrets-broker/secrets',
   pageTitle: 'Service Admin - Secrets Broker Secrets',
@@ -174,6 +221,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:action-preview',
     'secrets-management:stub-mutation-preview',
     'secrets-management:stub-mutation-apply-status',
+    'secrets-management:bulk-campaign-dry-run',
   ],
   persistedStorage: 'none',
 }
@@ -377,6 +425,118 @@ export function buildStubSecretMutationPreview(
   }
 }
 
+export function buildBulkSecretCampaignPlan(
+  rows: ManagedSecretRow[],
+  selectedIds: string[],
+  operation: BulkSecretCampaignOperation
+): BulkSecretCampaignPlan {
+  const selected = rows.filter((row) => selectedIds.includes(row.id))
+  const items = selected.map((row): BulkSecretCampaignItem => {
+    const blockers: string[] = []
+    let capabilityResult = 'supported: metadata dry-run only'
+    let policyResult = 'allow preview'
+    let risk: BulkSecretCampaignItem['risk'] = 'medium'
+    let expectedAction = 'Generate campaign dry-run metadata; do not apply.'
+
+    if (operation === 'mark-action-required') {
+      risk = 'low'
+      expectedAction = 'Mark ref for follow-up only; no provider mutation.'
+    }
+
+    if (
+      operation === 'rotate-reset' ||
+      operation === 'update-edit' ||
+      operation === 'migrate-provider'
+    ) {
+      risk = 'high'
+    }
+
+    if (row.policy.includes('readonly')) {
+      policyResult = 'denied: policy is readonly for this ref'
+      blockers.push('policy denied')
+    }
+
+    if (row.state === 'missing') {
+      capabilityResult = 'missing provider/source'
+      blockers.push('provider/source missing')
+      expectedAction = 'Skip until the provider/source is configured.'
+    } else if (
+      operation === 'rotate-reset' &&
+      !row.backendCapability.includes('reset dry-run')
+    ) {
+      capabilityResult = 'unsupported: reset dry-run unavailable'
+      blockers.push('unsupported capability')
+      expectedAction = 'Skip this ref or choose an edit/policy preview.'
+    } else if (
+      operation === 'update-edit' &&
+      !row.backendCapability.includes('edit dry-run')
+    ) {
+      capabilityResult = 'unsupported: edit dry-run unavailable'
+      blockers.push('unsupported capability')
+      expectedAction = 'Skip this ref or choose a reset/policy preview.'
+    } else if (
+      operation === 'migrate-provider' &&
+      row.provider === 'file source'
+    ) {
+      capabilityResult = 'unsupported: file sources migrate outside broker'
+      blockers.push('unsupported capability')
+      expectedAction = 'Document external provider action only.'
+    } else if (
+      operation === 'rotate-reset' &&
+      row.safeTags.includes('provider')
+    ) {
+      capabilityResult = 'auth required: provider challenge before dry-run'
+      blockers.push('provider auth required')
+      expectedAction = 'Request provider auth, then rerun dry-run.'
+    }
+
+    return {
+      id: row.id,
+      ref: row.ref,
+      name: row.name,
+      owningService: row.owningService,
+      sourceProvider: `${row.provider} / ${row.source}`,
+      targetProvider:
+        operation === 'migrate-provider'
+          ? '@secretsbroker/local/default'
+          : row.source,
+      targetPolicy:
+        operation === 'apply-policy'
+          ? 'policy/openclaw/service-lasso/bulk-campaign-preview'
+          : row.policy,
+      capabilityResult,
+      policyResult,
+      risk,
+      auditRequirement:
+        risk === 'high'
+          ? 'campaign audit reason and fresh dry-run required before apply'
+          : 'campaign audit summary required',
+      expectedAction,
+      blockers,
+    }
+  })
+
+  return {
+    operation,
+    selectedCount: items.length,
+    applicableCount: items.filter((item) => item.blockers.length === 0).length,
+    deniedCount: items.filter((item) => item.policyResult.includes('denied'))
+      .length,
+    unsupportedCount: items.filter((item) =>
+      item.capabilityResult.includes('unsupported')
+    ).length,
+    authRequiredCount: items.filter((item) =>
+      item.capabilityResult.includes('auth required')
+    ).length,
+    missingProviderCount: items.filter((item) =>
+      item.capabilityResult.includes('missing provider')
+    ).length,
+    highRiskCount: items.filter((item) => item.risk === 'high').length,
+    items,
+    applyAvailable: false,
+  }
+}
+
 export function buildManagedSecretActionPreview(
   row: ManagedSecretRow,
   action: ManagedSecretAction
@@ -461,4 +621,10 @@ export function managedSecretsHaveSecretMaterial(rows = managedSecretRows) {
 
 export function managedSecretSafeSurfacesIncludeSecretMaterial() {
   return forbiddenSecretPattern.test(JSON.stringify(managedSecretSafeSurfaces))
+}
+
+export function managedSecretBulkPlanHasSecretMaterial(
+  plan: BulkSecretCampaignPlan
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(plan))
 }


### PR DESCRIPTION
## Issue
Closes #106

## Summary
- add a Stage 1 bulk campaign dry-run planner to the Secrets Broker Secrets page
- model per-ref capability, policy, risk, audit, blocker, target provider/policy, and expected-action metadata without secret values
- keep bulk apply disabled and document the dry-run-only boundary

## Scope
- In scope: non-mutating planner UI, deterministic safe fixture/model output, tests, and docs
- Out of scope: bulk apply, raw value reveal/export, provider credential editing, backend mutation enforcement

## Spec / contract / fixture impact
- Updated: docs/secret-inventory.md with #106 Stage 1 planner behavior and future bulk-apply requirements.
- Fixtures/model: managed secret rows remain metadata-only; generated plans are derived from safe refs, ownership, providers, policies, and blocker metadata.

## Service Lasso invariant impact
- Invariant: secrets and provider credentials stay out of UI/logs/diagnostics/fixtures by default.
- Preservation proof: planner output exposes safe metadata only, apply is unavailable, and tests assert generated bulk plans do not contain secret material.

## Validation
- PASS `npm test -- src/features/secrets-broker/secrets-management.test.tsx` — 7 tests passed
- PASS `npm run build`
- PASS `npm run lint` — 0 errors, existing repo warnings only
- PASS `npm run format:check`
- PASS `git diff --check`

## Approval trail
- Required: no special approval for Stage 1 dry-run-only UI slice.
- Evidence: issue #106 is Ready and explicitly scoped to non-mutating dry-run planning.

## Cleanup
- Local checkout will return to `master` after PR creation.
