### PR TITLE
ISS-107 classify optional Service Admin pages

### DIFF
--- a/docs/optional-page-classification.md
+++ b/docs/optional-page-classification.md
@@ -1,0 +1,31 @@
+# Optional Service Admin page classification
+
+Issue: service-lasso/lasso-serviceadmin#107
+
+Parent feedback: service-lasso/lasso-serviceadmin#97
+
+This classification decides which optional Service Admin pages remain in primary navigation for the current on-prem-first product shape. Deferred pages keep their direct routes and existing tests so already-built metadata surfaces do not regress, but they are not promoted in the sidebar until the owning runtime, broker, or identity contract is ready.
+
+| Page | Decision | Current route | Navigation action | Linked implementation issue | Reason |
+| --- | --- | --- | --- | --- | --- |
+| ZITADEL Sessions | Defer | `/auth-session` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#65 | The page is a metadata-only trusted identity preview. It should return to navigation only when a consumer app/facade provides trusted ZITADEL session and role metadata. Service Admin must stay optional-auth for local development. |
+| Fleet overview | Defer | `/fleet-overview` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#68; runtime prerequisite service-lasso/service-lasso#494 | The existing page is a planning surface for future multi-instance visibility. On-prem-first operation should prioritize the current local instance until runtime instance identity/registry support is available. |
+| Support Bundle | Keep now | `/support-bundle` | Keep visible under Operations | service-lasso/lasso-serviceadmin#66 | Secret-safe local diagnostics are useful for on-prem support and do not require fleet, hosted support, ZITADEL, or external broker credentials. |
+| Policy Simulation | Defer | `/secrets-policy-simulation` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#67; broker policy baseline service-lasso/lasso-secretsbroker#56 | The existing page is a metadata-only dry-run preview. It should return to navigation after the Service Lasso service policy assignment and broker-backed policy-evaluation contract are explicit enough for operators to trust the result. |
+
+## Exact UI changes
+
+- Removed the `Fleet Overview` sidebar item that pointed to `/fleet-overview`.
+- Removed the `ZITADEL Session` sidebar item that pointed to `/auth-session`.
+- Removed the `Policy Simulation` sidebar item that pointed to `/secrets-policy-simulation`.
+- Kept the `Support Bundle` sidebar item pointing to `/support-bundle`.
+
+## Route retention
+
+The deferred routes remain registered:
+
+- `/auth-session`
+- `/fleet-overview`
+- `/secrets-policy-simulation`
+
+Keeping the routes lets existing implementation tests prove the metadata-only surfaces remain safe while product navigation stays focused on current operator workflows.

--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { sidebarData } from './sidebar-data'
+
+function collectNavTitles() {
+  return sidebarData.navGroups.flatMap((group) =>
+    group.items.flatMap((item) => [
+      item.title,
+      ...(item.items?.map((child) => child.title) ?? []),
+    ])
+  )
+}
+
+describe('sidebar optional page classification', () => {
+  it('keeps only current optional pages in primary navigation', () => {
+    const titles = collectNavTitles()
+
+    expect(titles).toContain('Support Bundle')
+    expect(titles).not.toContain('Fleet Overview')
+    expect(titles).not.toContain('ZITADEL Session')
+    expect(titles).not.toContain('Policy Simulation')
+  })
+})

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -1,6 +1,5 @@
 import {
   Boxes,
-  Building2,
   ClipboardCheck,
   Command,
   DatabaseZap,
@@ -11,7 +10,6 @@ import {
   LifeBuoy,
   LockKeyhole,
   Network,
-  Scale,
   ShieldCheck,
   SlidersHorizontal,
   HardDrive,
@@ -53,11 +51,6 @@ export const sidebarData: SidebarData = {
           icon: Boxes,
         },
         {
-          title: 'Fleet Overview',
-          url: '/fleet-overview',
-          icon: Building2,
-        },
-        {
           title: 'Dependencies',
           url: '/dependencies',
           icon: GitBranch,
@@ -86,11 +79,6 @@ export const sidebarData: SidebarData = {
           title: 'Variables',
           url: '/variables',
           icon: SlidersHorizontal,
-        },
-        {
-          title: 'ZITADEL Session',
-          url: '/auth-session',
-          icon: LockKeyhole,
         },
         {
           title: 'Support Bundle',
@@ -172,11 +160,6 @@ export const sidebarData: SidebarData = {
           title: 'Secret Inventory',
           url: '/secret-inventory',
           icon: DatabaseZap,
-        },
-        {
-          title: 'Policy Simulation',
-          url: '/secrets-policy-simulation',
-          icon: Scale,
         },
       ],
     },

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -126,7 +126,7 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(
       page.getByRole('link', { name: 'Policy Simulation' })
-    ).toBeVisible()
+    ).toHaveCount(0)
     expect(consoleErrors).toEqual([])
   })
 


### PR DESCRIPTION
## Issue
Closes #107

## Summary
- Documented the optional-page classification for ZITADEL Sessions, Fleet overview, Support Bundle, and Policy Simulation.
- Hid deferred optional surfaces from primary sidebar navigation while keeping their direct routes registered and tested.
- Kept Support Bundle visible because secret-safe local diagnostics are useful for on-prem support.

## Scope
- In scope: classification doc, sidebar navigation, focused nav coverage.
- Out of scope: deleting existing direct routes, changing page implementations, or wiring new backend policy/identity/fleet contracts.

## Spec / contract / fixture impact
- Updated: docs/optional-page-classification.md
- Route contract: deferred routes remain available for direct access and existing app-screen tests.

## Service Lasso invariant impact
- Preserves optional Service Admin behavior and keeps secrets/token material out of classification, docs, tests, and UI changes.

## Validation
- PASS npm run test:unit -- src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx
- PASS npm run build
- PASS git diff --check
- PASS npx playwright test tests/ui/secrets-broker.spec.ts -g "dedicated Secrets Broker navigation reaches each broker sub-page"

## Approval trail
- Required: no for this bounded classification/nav-hide slice.
- Evidence: issue #107 acceptance criteria and linked existing implementation issues in docs/optional-page-classification.md.

## Cleanup
- Branch cleanup after PR merge; local checkout should return to master after handoff.