### PR TITLE
Ignore agent scratch workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist-ssr
 **/Thumbs.db
 
 .tmp*
+.work-agent/


### PR DESCRIPTION
Adds .work-agent/ to .gitignore so local agent evidence and scratch logs do not show as untracked product files.