### PR TITLE
ISS-125 move broker pages under broker routes

### DIFF
--- a/docs/optional-page-classification.md
+++ b/docs/optional-page-classification.md
@@ -11,13 +11,13 @@ This classification decides which optional Service Admin pages remain in primary
 | ZITADEL Sessions | Defer | `/auth-session` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#65 | The page is a metadata-only trusted identity preview. It should return to navigation only when a consumer app/facade provides trusted ZITADEL session and role metadata. Service Admin must stay optional-auth for local development. |
 | Fleet overview | Defer | `/fleet-overview` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#68; runtime prerequisite service-lasso/service-lasso#494 | The existing page is a planning surface for future multi-instance visibility. On-prem-first operation should prioritize the current local instance until runtime instance identity/registry support is available. |
 | Support Bundle | Keep now | `/support-bundle` | Keep visible under Operations | service-lasso/lasso-serviceadmin#66 | Secret-safe local diagnostics are useful for on-prem support and do not require fleet, hosted support, ZITADEL, or external broker credentials. |
-| Policy Simulation | Defer | `/secrets-policy-simulation` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#67; broker policy baseline service-lasso/lasso-secretsbroker#56 | The existing page is a metadata-only dry-run preview. It should return to navigation after the Service Lasso service policy assignment and broker-backed policy-evaluation contract are explicit enough for operators to trust the result. |
+| Policy Simulation | Keep under Secrets Broker | `/secrets-broker/policy-simulation` | Show as a Secrets Broker sub-page | service-lasso/lasso-serviceadmin#67; broker policy baseline service-lasso/lasso-secretsbroker#56; service-lasso/lasso-serviceadmin#125 | The existing page is a metadata-only dry-run preview and now lives in the Secrets Broker route family so policy evaluation context is grouped with broker sources, audit, diagnostics, and inventory surfaces. |
 
 ## Exact UI changes
 
 - Removed the `Fleet Overview` sidebar item that pointed to `/fleet-overview`.
 - Removed the `ZITADEL Session` sidebar item that pointed to `/auth-session`.
-- Removed the `Policy Simulation` sidebar item that pointed to `/secrets-policy-simulation`.
+- Moved the `Policy Simulation` sidebar item under `Secrets Broker` at `/secrets-broker/policy-simulation`.
 - Kept the `Support Bundle` sidebar item pointing to `/support-bundle`.
 
 ## Route retention
@@ -26,6 +26,6 @@ The deferred routes remain registered:
 
 - `/auth-session`
 - `/fleet-overview`
-- `/secrets-policy-simulation`
+- `/secrets-broker/policy-simulation`
 
 Keeping the routes lets existing implementation tests prove the metadata-only surfaces remain safe while product navigation stays focused on current operator workflows.

--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -37,7 +37,7 @@ describe('sidebar optional page classification', () => {
     expect(titles).toContain('Support Bundle')
     expect(titles).not.toContain('Fleet Overview')
     expect(titles).not.toContain('ZITADEL Session')
-    expect(titles).not.toContain('Policy Simulation')
+    expect(titles).toContain('Policy Simulation')
   })
 
   it('links visible Secrets Broker sub-items to route-backed pages only', () => {
@@ -57,7 +57,8 @@ describe('sidebar optional page classification', () => {
       '/secrets-broker/topology',
       '/secrets-broker/audit-events',
       '/secrets-broker/diagnostics',
-      '/secret-inventory',
+      '/secrets-broker/secret-inventory',
+      '/secrets-broker/policy-simulation',
     ])
     expect(
       secretsBrokerGroup?.items.every((item) => !item.url?.includes('#'))

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -152,8 +152,13 @@ export const sidebarData: SidebarData = {
         },
         {
           title: 'Secret Inventory',
-          url: '/secret-inventory',
+          url: '/secrets-broker/secret-inventory',
           icon: DatabaseZap,
+        },
+        {
+          title: 'Policy Simulation',
+          url: '/secrets-broker/policy-simulation',
+          icon: ClipboardCheck,
         },
       ],
     },

--- a/src/features/secret-inventory/index.tsx
+++ b/src/features/secret-inventory/index.tsx
@@ -23,7 +23,7 @@ import {
 } from './secret-inventory'
 import { SecretInventoryTable } from './secret-inventory-table'
 
-const route = getRouteApi('/_authenticated/secret-inventory/')
+const route = getRouteApi('/_authenticated/secrets-broker/secret-inventory')
 
 export function SecretInventoryPage() {
   const search = route.useSearch()

--- a/src/features/secret-inventory/secret-inventory.test.tsx
+++ b/src/features/secret-inventory/secret-inventory.test.tsx
@@ -11,7 +11,7 @@ import {
 
 describe('secret inventory metadata view', () => {
   it('renders deterministic local fixture metadata without plaintext controls', async () => {
-    await renderRoute('/secret-inventory')
+    await renderRoute('/secrets-broker/secret-inventory')
 
     expect(
       await screen.findByRole('heading', { name: /^Secret inventory$/i })
@@ -33,7 +33,7 @@ describe('secret inventory metadata view', () => {
   })
 
   it('shows unavailable privileged actions as blocked text, not controls', async () => {
-    await renderRoute('/secret-inventory')
+    await renderRoute('/secrets-broker/secret-inventory')
 
     expect(screen.getAllByText(/show plaintext/i)[0]).toBeVisible()
     expect(screen.getAllByText(/copy value/i)[0]).toBeVisible()
@@ -70,7 +70,9 @@ describe('secret inventory metadata view', () => {
 
   it('supports shared data-table search and pagination for inventory refs', async () => {
     const user = userEvent.setup()
-    const { router } = await renderRoute('/secret-inventory?pageSize=2')
+    const { router } = await renderRoute(
+      '/secrets-broker/secret-inventory?pageSize=2'
+    )
 
     expect(screen.getByPlaceholderText(/Search secret refs/i)).toBeVisible()
     expect(screen.getByText('local/serviceadmin')).toBeVisible()

--- a/src/features/secrets-policy-simulation/policy-simulation.test.tsx
+++ b/src/features/secrets-policy-simulation/policy-simulation.test.tsx
@@ -9,7 +9,7 @@ import {
 
 describe('Secrets Broker policy simulation surface', () => {
   it('renders an allowed read dry-run without resolving secret values', async () => {
-    await renderRoute('/secrets-policy-simulation')
+    await renderRoute('/secrets-broker/policy-simulation')
 
     expect(
       await screen.findByRole('heading', {
@@ -36,7 +36,7 @@ describe('Secrets Broker policy simulation surface', () => {
 
   it('covers denied unknown locked and source-auth-required outcomes', async () => {
     const user = userEvent.setup()
-    await renderRoute('/secrets-policy-simulation')
+    await renderRoute('/secrets-broker/policy-simulation')
 
     await user.selectOptions(
       screen.getByLabelText(/Simulation scenario/i),

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,9 +32,7 @@ import { Route as AuthenticatedSupportBundleIndexRouteImport } from './routes/_a
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as AuthenticatedServicesIndexRouteImport } from './routes/_authenticated/services/index'
 import { Route as AuthenticatedServiceRoutesIndexRouteImport } from './routes/_authenticated/service-routes/index'
-import { Route as AuthenticatedSecretsPolicySimulationIndexRouteImport } from './routes/_authenticated/secrets-policy-simulation/index'
 import { Route as AuthenticatedSecretsBrokerIndexRouteImport } from './routes/_authenticated/secrets-broker/index'
-import { Route as AuthenticatedSecretInventoryIndexRouteImport } from './routes/_authenticated/secret-inventory/index'
 import { Route as AuthenticatedRuntimeIndexRouteImport } from './routes/_authenticated/runtime/index'
 import { Route as AuthenticatedNetworkIndexRouteImport } from './routes/_authenticated/network/index'
 import { Route as AuthenticatedLogsIndexRouteImport } from './routes/_authenticated/logs/index'
@@ -58,7 +56,9 @@ import { Route as AuthenticatedSecretsBrokerTopologyRouteImport } from './routes
 import { Route as AuthenticatedSecretsBrokerSourcesRouteImport } from './routes/_authenticated/secrets-broker/sources'
 import { Route as AuthenticatedSecretsBrokerSingleRevealRouteImport } from './routes/_authenticated/secrets-broker/single-reveal'
 import { Route as AuthenticatedSecretsBrokerSecretsRouteImport } from './routes/_authenticated/secrets-broker/secrets'
+import { Route as AuthenticatedSecretsBrokerSecretInventoryRouteImport } from './routes/_authenticated/secrets-broker/secret-inventory'
 import { Route as AuthenticatedSecretsBrokerProviderConnectionsRouteImport } from './routes/_authenticated/secrets-broker/provider-connections'
+import { Route as AuthenticatedSecretsBrokerPolicySimulationRouteImport } from './routes/_authenticated/secrets-broker/policy-simulation'
 import { Route as AuthenticatedSecretsBrokerDiagnosticsRouteImport } from './routes/_authenticated/secrets-broker/diagnostics'
 import { Route as AuthenticatedSecretsBrokerConfigurationRouteImport } from './routes/_authenticated/secrets-broker/configuration'
 import { Route as AuthenticatedSecretsBrokerBackupKeysRouteImport } from './routes/_authenticated/secrets-broker/backup-keys'
@@ -184,22 +184,10 @@ const AuthenticatedServiceRoutesIndexRoute =
     path: '/service-routes/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
-const AuthenticatedSecretsPolicySimulationIndexRoute =
-  AuthenticatedSecretsPolicySimulationIndexRouteImport.update({
-    id: '/secrets-policy-simulation/',
-    path: '/secrets-policy-simulation/',
-    getParentRoute: () => AuthenticatedRouteRoute,
-  } as any)
 const AuthenticatedSecretsBrokerIndexRoute =
   AuthenticatedSecretsBrokerIndexRouteImport.update({
     id: '/secrets-broker/',
     path: '/secrets-broker/',
-    getParentRoute: () => AuthenticatedRouteRoute,
-  } as any)
-const AuthenticatedSecretInventoryIndexRoute =
-  AuthenticatedSecretInventoryIndexRouteImport.update({
-    id: '/secret-inventory/',
-    path: '/secret-inventory/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedRuntimeIndexRoute =
@@ -335,10 +323,22 @@ const AuthenticatedSecretsBrokerSecretsRoute =
     path: '/secrets-broker/secrets',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedSecretsBrokerSecretInventoryRoute =
+  AuthenticatedSecretsBrokerSecretInventoryRouteImport.update({
+    id: '/secrets-broker/secret-inventory',
+    path: '/secrets-broker/secret-inventory',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSecretsBrokerProviderConnectionsRoute =
   AuthenticatedSecretsBrokerProviderConnectionsRouteImport.update({
     id: '/secrets-broker/provider-connections',
     path: '/secrets-broker/provider-connections',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedSecretsBrokerPolicySimulationRoute =
+  AuthenticatedSecretsBrokerPolicySimulationRouteImport.update({
+    id: '/secrets-broker/policy-simulation',
+    path: '/secrets-broker/policy-simulation',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
 const AuthenticatedSecretsBrokerDiagnosticsRoute =
@@ -398,7 +398,9 @@ export interface FileRoutesByFullPath {
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
+  '/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
   '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/secrets-broker/single-reveal': typeof AuthenticatedSecretsBrokerSingleRevealRoute
   '/secrets-broker/sources': typeof AuthenticatedSecretsBrokerSourcesRoute
@@ -422,9 +424,7 @@ export interface FileRoutesByFullPath {
   '/logs/': typeof AuthenticatedLogsIndexRoute
   '/network/': typeof AuthenticatedNetworkIndexRoute
   '/runtime/': typeof AuthenticatedRuntimeIndexRoute
-  '/secret-inventory/': typeof AuthenticatedSecretInventoryIndexRoute
   '/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
-  '/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/service-routes/': typeof AuthenticatedServiceRoutesIndexRoute
   '/services/': typeof AuthenticatedServicesIndexRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
@@ -452,7 +452,9 @@ export interface FileRoutesByTo {
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
+  '/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
   '/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/secrets-broker/single-reveal': typeof AuthenticatedSecretsBrokerSingleRevealRoute
   '/secrets-broker/sources': typeof AuthenticatedSecretsBrokerSourcesRoute
@@ -476,9 +478,7 @@ export interface FileRoutesByTo {
   '/logs': typeof AuthenticatedLogsIndexRoute
   '/network': typeof AuthenticatedNetworkIndexRoute
   '/runtime': typeof AuthenticatedRuntimeIndexRoute
-  '/secret-inventory': typeof AuthenticatedSecretInventoryIndexRoute
   '/secrets-broker': typeof AuthenticatedSecretsBrokerIndexRoute
-  '/secrets-policy-simulation': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/service-routes': typeof AuthenticatedServiceRoutesIndexRoute
   '/services': typeof AuthenticatedServicesIndexRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
@@ -511,7 +511,9 @@ export interface FileRoutesById {
   '/_authenticated/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/_authenticated/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/_authenticated/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/_authenticated/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/_authenticated/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
+  '/_authenticated/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
   '/_authenticated/secrets-broker/secrets': typeof AuthenticatedSecretsBrokerSecretsRoute
   '/_authenticated/secrets-broker/single-reveal': typeof AuthenticatedSecretsBrokerSingleRevealRoute
   '/_authenticated/secrets-broker/sources': typeof AuthenticatedSecretsBrokerSourcesRoute
@@ -535,9 +537,7 @@ export interface FileRoutesById {
   '/_authenticated/logs/': typeof AuthenticatedLogsIndexRoute
   '/_authenticated/network/': typeof AuthenticatedNetworkIndexRoute
   '/_authenticated/runtime/': typeof AuthenticatedRuntimeIndexRoute
-  '/_authenticated/secret-inventory/': typeof AuthenticatedSecretInventoryIndexRoute
   '/_authenticated/secrets-broker/': typeof AuthenticatedSecretsBrokerIndexRoute
-  '/_authenticated/secrets-policy-simulation/': typeof AuthenticatedSecretsPolicySimulationIndexRoute
   '/_authenticated/service-routes/': typeof AuthenticatedServiceRoutesIndexRoute
   '/_authenticated/services/': typeof AuthenticatedServicesIndexRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
@@ -568,7 +568,9 @@ export interface FileRouteTypes {
     | '/secrets-broker/backup-keys'
     | '/secrets-broker/configuration'
     | '/secrets-broker/diagnostics'
+    | '/secrets-broker/policy-simulation'
     | '/secrets-broker/provider-connections'
+    | '/secrets-broker/secret-inventory'
     | '/secrets-broker/secrets'
     | '/secrets-broker/single-reveal'
     | '/secrets-broker/sources'
@@ -592,9 +594,7 @@ export interface FileRouteTypes {
     | '/logs/'
     | '/network/'
     | '/runtime/'
-    | '/secret-inventory/'
     | '/secrets-broker/'
-    | '/secrets-policy-simulation/'
     | '/service-routes/'
     | '/services/'
     | '/settings/'
@@ -622,7 +622,9 @@ export interface FileRouteTypes {
     | '/secrets-broker/backup-keys'
     | '/secrets-broker/configuration'
     | '/secrets-broker/diagnostics'
+    | '/secrets-broker/policy-simulation'
     | '/secrets-broker/provider-connections'
+    | '/secrets-broker/secret-inventory'
     | '/secrets-broker/secrets'
     | '/secrets-broker/single-reveal'
     | '/secrets-broker/sources'
@@ -646,9 +648,7 @@ export interface FileRouteTypes {
     | '/logs'
     | '/network'
     | '/runtime'
-    | '/secret-inventory'
     | '/secrets-broker'
-    | '/secrets-policy-simulation'
     | '/service-routes'
     | '/services'
     | '/settings'
@@ -680,7 +680,9 @@ export interface FileRouteTypes {
     | '/_authenticated/secrets-broker/backup-keys'
     | '/_authenticated/secrets-broker/configuration'
     | '/_authenticated/secrets-broker/diagnostics'
+    | '/_authenticated/secrets-broker/policy-simulation'
     | '/_authenticated/secrets-broker/provider-connections'
+    | '/_authenticated/secrets-broker/secret-inventory'
     | '/_authenticated/secrets-broker/secrets'
     | '/_authenticated/secrets-broker/single-reveal'
     | '/_authenticated/secrets-broker/sources'
@@ -704,9 +706,7 @@ export interface FileRouteTypes {
     | '/_authenticated/logs/'
     | '/_authenticated/network/'
     | '/_authenticated/runtime/'
-    | '/_authenticated/secret-inventory/'
     | '/_authenticated/secrets-broker/'
-    | '/_authenticated/secrets-policy-simulation/'
     | '/_authenticated/service-routes/'
     | '/_authenticated/services/'
     | '/_authenticated/settings/'
@@ -894,25 +894,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedServiceRoutesIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
-    '/_authenticated/secrets-policy-simulation/': {
-      id: '/_authenticated/secrets-policy-simulation/'
-      path: '/secrets-policy-simulation'
-      fullPath: '/secrets-policy-simulation/'
-      preLoaderRoute: typeof AuthenticatedSecretsPolicySimulationIndexRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
     '/_authenticated/secrets-broker/': {
       id: '/_authenticated/secrets-broker/'
       path: '/secrets-broker'
       fullPath: '/secrets-broker/'
       preLoaderRoute: typeof AuthenticatedSecretsBrokerIndexRouteImport
-      parentRoute: typeof AuthenticatedRouteRoute
-    }
-    '/_authenticated/secret-inventory/': {
-      id: '/_authenticated/secret-inventory/'
-      path: '/secret-inventory'
-      fullPath: '/secret-inventory/'
-      preLoaderRoute: typeof AuthenticatedSecretInventoryIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/runtime/': {
@@ -1076,11 +1062,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSecretsBrokerSecretsRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/secret-inventory': {
+      id: '/_authenticated/secrets-broker/secret-inventory'
+      path: '/secrets-broker/secret-inventory'
+      fullPath: '/secrets-broker/secret-inventory'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerSecretInventoryRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/secrets-broker/provider-connections': {
       id: '/_authenticated/secrets-broker/provider-connections'
       path: '/secrets-broker/provider-connections'
       fullPath: '/secrets-broker/provider-connections'
       preLoaderRoute: typeof AuthenticatedSecretsBrokerProviderConnectionsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/secrets-broker/policy-simulation': {
+      id: '/_authenticated/secrets-broker/policy-simulation'
+      path: '/secrets-broker/policy-simulation'
+      fullPath: '/secrets-broker/policy-simulation'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerPolicySimulationRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
     '/_authenticated/secrets-broker/diagnostics': {
@@ -1160,7 +1160,9 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSecretsBrokerBackupKeysRoute: typeof AuthenticatedSecretsBrokerBackupKeysRoute
   AuthenticatedSecretsBrokerConfigurationRoute: typeof AuthenticatedSecretsBrokerConfigurationRoute
   AuthenticatedSecretsBrokerDiagnosticsRoute: typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  AuthenticatedSecretsBrokerPolicySimulationRoute: typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   AuthenticatedSecretsBrokerProviderConnectionsRoute: typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
+  AuthenticatedSecretsBrokerSecretInventoryRoute: typeof AuthenticatedSecretsBrokerSecretInventoryRoute
   AuthenticatedSecretsBrokerSecretsRoute: typeof AuthenticatedSecretsBrokerSecretsRoute
   AuthenticatedSecretsBrokerSingleRevealRoute: typeof AuthenticatedSecretsBrokerSingleRevealRoute
   AuthenticatedSecretsBrokerSourcesRoute: typeof AuthenticatedSecretsBrokerSourcesRoute
@@ -1177,9 +1179,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedLogsIndexRoute: typeof AuthenticatedLogsIndexRoute
   AuthenticatedNetworkIndexRoute: typeof AuthenticatedNetworkIndexRoute
   AuthenticatedRuntimeIndexRoute: typeof AuthenticatedRuntimeIndexRoute
-  AuthenticatedSecretInventoryIndexRoute: typeof AuthenticatedSecretInventoryIndexRoute
   AuthenticatedSecretsBrokerIndexRoute: typeof AuthenticatedSecretsBrokerIndexRoute
-  AuthenticatedSecretsPolicySimulationIndexRoute: typeof AuthenticatedSecretsPolicySimulationIndexRoute
   AuthenticatedServiceRoutesIndexRoute: typeof AuthenticatedServiceRoutesIndexRoute
   AuthenticatedServicesIndexRoute: typeof AuthenticatedServicesIndexRoute
   AuthenticatedSupportBundleIndexRoute: typeof AuthenticatedSupportBundleIndexRoute
@@ -1202,8 +1202,12 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
     AuthenticatedSecretsBrokerConfigurationRoute,
   AuthenticatedSecretsBrokerDiagnosticsRoute:
     AuthenticatedSecretsBrokerDiagnosticsRoute,
+  AuthenticatedSecretsBrokerPolicySimulationRoute:
+    AuthenticatedSecretsBrokerPolicySimulationRoute,
   AuthenticatedSecretsBrokerProviderConnectionsRoute:
     AuthenticatedSecretsBrokerProviderConnectionsRoute,
+  AuthenticatedSecretsBrokerSecretInventoryRoute:
+    AuthenticatedSecretsBrokerSecretInventoryRoute,
   AuthenticatedSecretsBrokerSecretsRoute:
     AuthenticatedSecretsBrokerSecretsRoute,
   AuthenticatedSecretsBrokerSingleRevealRoute:
@@ -1225,11 +1229,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedLogsIndexRoute: AuthenticatedLogsIndexRoute,
   AuthenticatedNetworkIndexRoute: AuthenticatedNetworkIndexRoute,
   AuthenticatedRuntimeIndexRoute: AuthenticatedRuntimeIndexRoute,
-  AuthenticatedSecretInventoryIndexRoute:
-    AuthenticatedSecretInventoryIndexRoute,
   AuthenticatedSecretsBrokerIndexRoute: AuthenticatedSecretsBrokerIndexRoute,
-  AuthenticatedSecretsPolicySimulationIndexRoute:
-    AuthenticatedSecretsPolicySimulationIndexRoute,
   AuthenticatedServiceRoutesIndexRoute: AuthenticatedServiceRoutesIndexRoute,
   AuthenticatedServicesIndexRoute: AuthenticatedServicesIndexRoute,
   AuthenticatedSupportBundleIndexRoute: AuthenticatedSupportBundleIndexRoute,

--- a/src/routes/_authenticated/secrets-broker/policy-simulation.tsx
+++ b/src/routes/_authenticated/secrets-broker/policy-simulation.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { SecretsPolicySimulationPage } from '@/features/secrets-policy-simulation'
 
 export const Route = createFileRoute(
-  '/_authenticated/secrets-policy-simulation/'
+  '/_authenticated/secrets-broker/policy-simulation'
 )({
   component: SecretsPolicySimulationPage,
 })

--- a/src/routes/_authenticated/secrets-broker/secret-inventory.tsx
+++ b/src/routes/_authenticated/secrets-broker/secret-inventory.tsx
@@ -10,7 +10,9 @@ const secretInventorySearchSchema = z.object({
   source: z.array(z.string()).optional().catch(undefined),
 })
 
-export const Route = createFileRoute('/_authenticated/secret-inventory/')({
+export const Route = createFileRoute(
+  '/_authenticated/secrets-broker/secret-inventory'
+)({
   validateSearch: secretInventorySearchSchema,
   component: SecretInventoryPage,
 })

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -104,12 +104,12 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Diagnostics',
   },
   {
-    path: '/secret-inventory',
+    path: '/secrets-broker/secret-inventory',
     heading: /^Secret inventory$/i,
     title: 'Service Admin - Secret Inventory',
   },
   {
-    path: '/secrets-policy-simulation',
+    path: '/secrets-broker/policy-simulation',
     heading: /^Secrets Broker policy simulation$/i,
     title: 'Service Admin - Secrets Policy Simulation',
   },

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -105,6 +105,8 @@ test.describe('Secrets Broker browser coverage', () => {
       ['Topology', /\/secrets-broker\/topology$/],
       ['Audit / Events', /\/secrets-broker\/audit-events$/],
       ['Diagnostics', /\/secrets-broker\/diagnostics$/],
+      ['Secret Inventory', /\/secrets-broker\/secret-inventory$/],
+      ['Policy Simulation', /\/secrets-broker\/policy-simulation$/],
     ] as const
 
     for (const [name, urlPattern] of navLinks) {
@@ -118,12 +120,6 @@ test.describe('Secrets Broker browser coverage', () => {
       await expectNoSecretMaterial(page)
     }
 
-    await expect(
-      page.getByRole('link', { name: 'Secret Inventory' })
-    ).toBeVisible()
-    await expect(
-      page.getByRole('link', { name: 'Policy Simulation' })
-    ).toHaveCount(0)
     expect(consoleErrors).toEqual([])
   })
 
@@ -368,6 +364,11 @@ test.describe('Secrets Broker browser coverage', () => {
       ['/secrets-broker/topology', /Secrets Broker topology/i],
       ['/secrets-broker/audit-events', /Audit and events/i],
       ['/secrets-broker/diagnostics', /Diagnostics and troubleshooting/i],
+      ['/secrets-broker/secret-inventory', /^Secret inventory$/i],
+      [
+        '/secrets-broker/policy-simulation',
+        /Secrets Broker policy\s+simulation/i,
+      ],
     ] as const
 
     for (const [path, label] of sections) {


### PR DESCRIPTION
## Summary

- Move Secret Inventory to `/secrets-broker/secret-inventory`.
- Move Policy Simulation to `/secrets-broker/policy-simulation`.
- Update Secrets Broker sidebar placement, generated route tree, docs, and screen/feature tests.
- Remove the old standalone route modules so there are no duplicate canonical URLs.

## Validation

- `npm test -- --run src/components/layout/data/sidebar-data.test.ts src/features/secret-inventory/secret-inventory.test.tsx src/features/secrets-policy-simulation/policy-simulation.test.tsx src/test/app-screens.test.tsx` passed: 4 files, 44 tests.
- `npm run build` passed.
- `npm run lint` passed with 7 existing warnings in unrelated files.
- `npm test` passed: 19 files, 133 tests.

## Gate evidence

- Open PR gate: no open Service Lasso PRs found before work.
- Core `develop` hosted validation: Baseline Start Smoke run `26863825529` passed on `a441d3555589ab5372410508145532be76a828e3`.
- Service Admin `master` hosted validation: latest push checks on `68169cd6d64bea7606f909a45150a623c4211f72` were green.

Closes #125.