### PR TITLE
fix #130 route legacy secret sources hash

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { Link } from '@tanstack/react-router'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate } from '@tanstack/react-router'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -906,6 +906,13 @@ function SafeExample({ value }: { value: string }) {
 }
 
 function SourceBackendCard({ source }: { source: SecretsBrokerSourceBackend }) {
+  const actionLinks: Partial<
+    Record<SecretsBrokerSourceBackend['supportedActions'][number], string>
+  > = {
+    'view-diagnostics': '/secrets-broker/diagnostics',
+    'edit-configuration': '/secrets-broker/configuration',
+  }
+
   return (
     <div className='rounded-lg border p-4 text-sm'>
       <div className='mb-3 flex flex-wrap items-start justify-between gap-3'>
@@ -1013,11 +1020,25 @@ function SourceBackendCard({ source }: { source: SecretsBrokerSourceBackend }) {
       )}
 
       <div className='mt-3 flex flex-wrap gap-2'>
-        {source.supportedActions.map((action) => (
-          <Button key={action} type='button' variant='outline' size='sm'>
-            {sourceActionCopy[action]}
-          </Button>
-        ))}
+        {source.supportedActions.map((action) => {
+          const href = actionLinks[action]
+
+          return href ? (
+            <Button
+              key={action}
+              type='button'
+              variant='outline'
+              size='sm'
+              asChild
+            >
+              <Link to={href}>{sourceActionCopy[action]}</Link>
+            </Button>
+          ) : (
+            <Button key={action} type='button' variant='outline' size='sm'>
+              {sourceActionCopy[action]}
+            </Button>
+          )
+        })}
       </div>
     </div>
   )
@@ -1874,7 +1895,18 @@ export function SecretsBrokerSetupWizard({
 }: {
   focusSection?: SecretsBrokerSectionFocus
 } = {}) {
+  const { hash } = useLocation()
+  const navigate = useNavigate()
   const pageMetadata = secretsBrokerSectionMetadata[focusSection]
+
+  useEffect(() => {
+    if (
+      focusSection === 'overview' &&
+      (hash === 'secret-sources' || hash === '#secret-sources')
+    ) {
+      void navigate({ to: '/secrets-broker/sources', replace: true })
+    }
+  }, [focusSection, hash, navigate])
 
   usePageMetadata({
     title: pageMetadata.title,

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -4,7 +4,7 @@ import {
   collectBrowserLeakSurfaces,
   serviceLassoSecretLeakSentinels,
 } from '@/test/secret-leak-harness'
-import { fireEvent, screen, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
@@ -448,15 +448,43 @@ describe('Secrets Broker setup wizard', () => {
       screen.getAllByRole('button', { name: /Test source/i })[0]
     ).toBeVisible()
     expect(
-      screen.getAllByRole('button', { name: /View diagnostics/i })[0]
-    ).toBeVisible()
+      screen.getAllByRole('link', { name: /View diagnostics/i })[0]
+    ).toHaveAttribute('href', '/secrets-broker/diagnostics')
     expect(
-      screen.getAllByRole('button', { name: /Edit configuration/i })[0]
-    ).toBeVisible()
+      screen.getAllByRole('link', { name: /Edit configuration/i })[0]
+    ).toHaveAttribute('href', '/secrets-broker/configuration')
     expect(screen.getByText(/3 keys matched allowlist/i)).toBeVisible()
     expect(screen.getByText(/path policy denied/i)).toBeVisible()
     expect(screen.getByText(/command not executed/i)).toBeVisible()
     expect(screen.getAllByText(/value=hidden/i)[0]).toBeVisible()
+  })
+
+  it('routes the legacy secret-sources hash to the canonical sources page', async () => {
+    const { router } = await renderRoute('/secrets-broker#secret-sources')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Secrets Broker sources$/i })
+      ).toBeVisible()
+    })
+
+    expect(router.state.location.pathname).toBe('/secrets-broker/sources')
+    expect(
+      screen.queryByRole('heading', { name: /^Secrets Broker setup$/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('links source configuration actions to the dedicated configuration page', async () => {
+    await renderRoute('/secrets-broker/sources')
+
+    const configurationLinks = screen.getAllByRole('link', {
+      name: /Edit configuration/i,
+    })
+
+    expect(configurationLinks[0]).toHaveAttribute(
+      'href',
+      '/secrets-broker/configuration'
+    )
   })
 
   it('keeps source backend fixtures free of secret values', () => {


### PR DESCRIPTION
## Summary\n- route legacy /secrets-broker#secret-sources visits to the canonical /secrets-broker/sources page\n- make source backend View diagnostics and Edit configuration actions real links to the split pages\n- add regression coverage for the legacy hash route and configuration link\n\n## Validation\n- npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx src/features/secrets-broker/provider-configuration.test.tsx\n- npm run build\n- npm run format:check\n- npm test\n- npm run lint (passes with existing unrelated warnings)\n- powershell -ExecutionPolicy Bypass -File scripts/test.ps1\n- git diff --check\n\nDemo deployment/live-check evidence will be added after updating the managed demo runtime.