### PR TITLE
fix(services): hide provider lifecycle controls

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -694,6 +694,13 @@ function ServiceActionButton({
     action.kind === 'stop' ||
     action.kind === 'restart'
   ) {
+    if (
+      service.role === 'provider' ||
+      service.metadata.serviceType === 'provider'
+    ) {
+      return null
+    }
+
     const lifecycleAction = action.kind
 
     return (

--- a/src/features/services/components/services-columns.test.ts
+++ b/src/features/services/components/services-columns.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+import { hasLifecycleAction } from './services-columns'
+
+function service(overrides: Partial<DashboardService> = {}): DashboardService {
+  return {
+    id: 'echo-service',
+    name: 'Echo Service',
+    status: 'running',
+    favorite: false,
+    note: 'ready',
+    links: [],
+    installed: true,
+    role: 'service',
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '1m',
+      lastCheckAt: '2026-06-05T00:00:00.000Z',
+      summary: 'ready',
+    },
+    endpoints: [],
+    metadata: {
+      serviceType: 'app',
+      runtime: 'direct',
+      version: '0.1.0',
+      build: 'runtime/server.js',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [],
+    recentLogs: [],
+    actions: [
+      { id: 'start', label: 'Start service', kind: 'start' },
+      { id: 'stop', label: 'Stop service', kind: 'stop' },
+      { id: 'restart', label: 'Restart service', kind: 'restart' },
+    ],
+    ...overrides,
+  }
+}
+
+describe('services table lifecycle controls', () => {
+  it('allows lifecycle actions for daemon services when the runtime advertises them', () => {
+    const daemon = service()
+
+    expect(hasLifecycleAction(daemon, 'start')).toBe(true)
+    expect(hasLifecycleAction(daemon, 'stop')).toBe(true)
+    expect(hasLifecycleAction(daemon, 'restart')).toBe(true)
+  })
+
+  it('hides daemon lifecycle actions for provider services even if stale runtime data advertises them', () => {
+    const provider = service({
+      id: '@archive',
+      name: 'Archive Runtime',
+      status: 'available',
+      role: 'provider',
+      metadata: {
+        serviceType: 'provider',
+        runtime: 'direct',
+        version: '0.1.0',
+        build: 'manifest-only',
+      },
+    })
+
+    expect(hasLifecycleAction(provider, 'start')).toBe(false)
+    expect(hasLifecycleAction(provider, 'stop')).toBe(false)
+    expect(hasLifecycleAction(provider, 'restart')).toBe(false)
+  })
+})

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -70,9 +70,25 @@ function FavoriteCell({ service }: { service: DashboardService }) {
   )
 }
 
+export function hasLifecycleAction(
+  service: DashboardService,
+  action: 'start' | 'stop' | 'restart'
+) {
+  const isProvider =
+    service.role === 'provider' || service.metadata.serviceType === 'provider'
+
+  return (
+    !isProvider &&
+    service.actions.some((candidate) => candidate.kind === action)
+  )
+}
+
 function ServiceLifecycleControls({ service }: { service: DashboardService }) {
   const actionMutation = useDashboardAction()
   const disabled = actionMutation.isPending
+  const canStart = hasLifecycleAction(service, 'start')
+  const canStop = hasLifecycleAction(service, 'stop')
+  const canRestart = hasLifecycleAction(service, 'restart')
 
   const runAction = (action: 'start' | 'stop' | 'restart') => {
     actionMutation.mutate({
@@ -82,53 +98,70 @@ function ServiceLifecycleControls({ service }: { service: DashboardService }) {
     })
   }
 
+  if (!canStart && !canStop && !canRestart) {
+    return (
+      <Badge
+        variant='outline'
+        title='Provider services are installed/configured but are not daemon-started'
+      >
+        Provider
+      </Badge>
+    )
+  }
+
   return (
     <div className='flex items-center gap-1'>
-      <Button
-        type='button'
-        size='icon'
-        variant='outline'
-        className={lifecycleActionButtonClass('start', 'size-8')}
-        aria-label={`Start ${service.name}`}
-        title={`Start ${service.name}`}
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation()
-          runAction('start')
-        }}
-      >
-        <Play className='size-3.5' />
-      </Button>
-      <Button
-        type='button'
-        size='icon'
-        variant='outline'
-        className={lifecycleActionButtonClass('stop', 'size-8')}
-        aria-label={`Stop ${service.name}`}
-        title={`Stop ${service.name}`}
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation()
-          runAction('stop')
-        }}
-      >
-        <Square className='size-3.5' />
-      </Button>
-      <Button
-        type='button'
-        size='icon'
-        variant='outline'
-        className={lifecycleActionButtonClass('restart', 'size-8')}
-        aria-label={`Restart ${service.name}`}
-        title={`Restart ${service.name}`}
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation()
-          runAction('restart')
-        }}
-      >
-        <RotateCcw className='size-3.5' />
-      </Button>
+      {canStart ? (
+        <Button
+          type='button'
+          size='icon'
+          variant='outline'
+          className={lifecycleActionButtonClass('start', 'size-8')}
+          aria-label={`Start ${service.name}`}
+          title={`Start ${service.name}`}
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation()
+            runAction('start')
+          }}
+        >
+          <Play className='size-3.5' />
+        </Button>
+      ) : null}
+      {canStop ? (
+        <Button
+          type='button'
+          size='icon'
+          variant='outline'
+          className={lifecycleActionButtonClass('stop', 'size-8')}
+          aria-label={`Stop ${service.name}`}
+          title={`Stop ${service.name}`}
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation()
+            runAction('stop')
+          }}
+        >
+          <Square className='size-3.5' />
+        </Button>
+      ) : null}
+      {canRestart ? (
+        <Button
+          type='button'
+          size='icon'
+          variant='outline'
+          className={lifecycleActionButtonClass('restart', 'size-8')}
+          aria-label={`Restart ${service.name}`}
+          title={`Restart ${service.name}`}
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation()
+            runAction('restart')
+          }}
+        >
+          <RotateCcw className='size-3.5' />
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -93,7 +93,7 @@ test('services table filters and opens service detail', async ({ page }) => {
       name: 'Restart Service Admin UI',
       exact: true,
     })
-  ).toBeEnabled()
+  ).toHaveCount(0)
 
   await page.getByRole('link', { name: /details/i }).click()
   await expect(page).toHaveURL(/\/services\/%40serviceadmin$/)


### PR DESCRIPTION
## Summary
- hide daemon start/stop/restart controls for provider-role services such as `@archive`
- defensively ignore provider lifecycle actions on the service detail view even if stale runtime data advertises them
- add unit coverage for provider lifecycle action gating

Closes #137.

## Validation
- `npm run format:check`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run test:unit` (139 tests)