### PR TITLE
fix(routes): use full-height table layout

### DIFF
--- a/src/features/service-routes/index.tsx
+++ b/src/features/service-routes/index.tsx
@@ -13,7 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { ExternalLink, Route, ShieldCheck } from 'lucide-react'
+import { ExternalLink, ShieldCheck } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import type {
@@ -24,13 +24,7 @@ import { cn } from '@/lib/utils'
 import { useTableUrlState } from '@/hooks/use-table-url-state'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -281,35 +275,6 @@ function ServiceRoutesLoading() {
   )
 }
 
-function RouteSummary({ rows }: { rows: ServiceRouteRow[] }) {
-  const publicRoutes = rows.filter((row) => row.exposure === 'public').length
-  const lanRoutes = rows.filter((row) => row.exposure === 'lan').length
-  const localRoutes = rows.filter((row) => row.exposure === 'local').length
-
-  return (
-    <div className='grid gap-3 sm:grid-cols-3'>
-      <Card>
-        <CardHeader className='gap-2'>
-          <CardDescription>Traefik / public</CardDescription>
-          <CardTitle className='text-2xl'>{publicRoutes}</CardTitle>
-        </CardHeader>
-      </Card>
-      <Card>
-        <CardHeader className='gap-2'>
-          <CardDescription>LAN routes</CardDescription>
-          <CardTitle className='text-2xl'>{lanRoutes}</CardTitle>
-        </CardHeader>
-      </Card>
-      <Card>
-        <CardHeader className='gap-2'>
-          <CardDescription>Local endpoints</CardDescription>
-          <CardTitle className='text-2xl'>{localRoutes}</CardTitle>
-        </CardHeader>
-      </Card>
-    </div>
-  )
-}
-
 function ServiceRoutesTable({ rows }: { rows: ServiceRouteRow[] }) {
   const search = route.useSearch()
   const navigate = route.useNavigate()
@@ -510,24 +475,7 @@ export function ServiceRoutes() {
         {servicesQuery.isLoading ? (
           <ServiceRoutesLoading />
         ) : (
-          <>
-            <RouteSummary rows={rows} />
-            <Card>
-              <CardHeader>
-                <CardTitle className='flex items-center gap-2'>
-                  <Route className='size-5' />
-                  Route inventory
-                </CardTitle>
-                <CardDescription>
-                  Runtime and stub data stay value-safe: no env values, tokens,
-                  or secret material are displayed on this page.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ServiceRoutesTable rows={rows} />
-              </CardContent>
-            </Card>
-          </>
+          <ServiceRoutesTable rows={rows} />
         )}
       </Main>
     </>

--- a/src/features/service-routes/service-routes.test.tsx
+++ b/src/features/service-routes/service-routes.test.tsx
@@ -1,6 +1,29 @@
 import { renderRoute } from '@/test/render-route'
 import { screen, waitFor } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
+  useServices: () => ({
+    data: [
+      {
+        id: '@traefik',
+        name: 'Traefik',
+        status: 'running',
+        endpoints: [
+          {
+            label: 'Local dashboard',
+            url: 'https://traefik.localtest.me',
+            bind: '127.0.0.1',
+            port: 443,
+            protocol: 'https',
+            exposure: 'public',
+          },
+        ],
+      },
+    ],
+    isLoading: false,
+  }),
+}))
 
 describe('service routes page', () => {
   it('renders service endpoint inventory without secret material', async () => {
@@ -12,8 +35,12 @@ describe('service routes page', () => {
       ).toBeVisible()
     })
 
-    expect(await screen.findByText('Route inventory')).toBeVisible()
-    expect(screen.getAllByText('Traefik')[0]).toBeVisible()
+    expect(screen.queryByText('Route inventory')).not.toBeInTheDocument()
+    expect(screen.queryByText('LAN routes')).not.toBeInTheDocument()
+    expect(screen.queryByText('Local endpoints')).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /service/i })).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /route/i })).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /url/i })).toBeVisible()
     expect(screen.getByText('Local dashboard')).toBeVisible()
     expect(screen.getByText('https://traefik.localtest.me')).toBeVisible()
     expect(screen.queryByText(/secret:\/\//i)).not.toBeInTheDocument()


### PR DESCRIPTION
Closes #139.

## Summary
- removes the Routes top-level count cards
- removes the nested `Route inventory` card title/description wrapper
- renders the Routes table/toolbar/pagination directly in the page like Services
- updates the Routes regression test to cover the simplified layout and value-safety checks

## Validation
- `npm test -- src/features/service-routes/service-routes.test.tsx src/test/app-screens.test.tsx` -> 34 passed
- `npm test` -> 21 files / 139 tests passed
- `npm run build` -> passed
- `npm run format:check` -> passed
- `npm run lint` -> passed with existing unrelated warnings in Installed/Logs/Network/Runtime/Variables