### PR TITLE
fix(runtime): make table fill page

### DIFF
--- a/src/features/runtime/index.tsx
+++ b/src/features/runtime/index.tsx
@@ -13,19 +13,11 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { Activity } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -49,15 +41,11 @@ import { ThemeSwitch } from '@/components/theme-switch'
 
 function RuntimeLoading() {
   return (
-    <Card>
-      <CardHeader>
-        <Skeleton className='h-6 w-44' />
-        <Skeleton className='h-4 w-96' />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className='h-[420px] w-full' />
-      </CardContent>
-    </Card>
+    <div className='flex flex-1 flex-col gap-4'>
+      <Skeleton className='h-10 w-full max-w-xl' />
+      <Skeleton className='h-[420px] w-full' />
+      <Skeleton className='mt-auto h-9 w-full max-w-md' />
+    </div>
   )
 }
 
@@ -206,6 +194,7 @@ export function Runtime() {
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: servicesQuery.data ?? [],
     columns,
@@ -222,14 +211,6 @@ export function Runtime() {
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
   })
-
-  const unhealthyCount = useMemo(
-    () =>
-      (servicesQuery.data ?? []).filter(
-        (service) => service.runtimeHealth.health !== 'healthy'
-      ).length,
-    [servicesQuery.data]
-  )
 
   const runtimes = useMemo(
     () =>
@@ -272,92 +253,81 @@ export function Runtime() {
         {servicesQuery.isLoading ? (
           <RuntimeLoading />
         ) : (
-          <Card>
-            <CardHeader>
-              <CardTitle className='flex items-center gap-2'>
-                <Activity className='size-4' /> Runtime status
-              </CardTitle>
-              <CardDescription>
-                {table.getFilteredRowModel().rows.length} services shown,{' '}
-                {unhealthyCount} with warning or critical health.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className='space-y-4'>
-              <DataTableToolbar
-                table={table}
-                searchPlaceholder='Search services, summaries, checks, or runtime...'
-                searchKey='name'
-                filters={[
-                  {
-                    columnId: 'status',
-                    title: 'Status',
-                    options: [
-                      { label: 'Running', value: 'running' },
-                      { label: 'Available', value: 'available' },
-                      { label: 'Degraded', value: 'degraded' },
-                      { label: 'Stopped', value: 'stopped' },
-                    ],
-                  },
-                  {
-                    columnId: 'runtime',
-                    title: 'Runtime',
-                    options: runtimes.map((runtime) => ({
-                      label: runtime,
-                      value: runtime,
-                    })),
-                  },
-                ]}
-              />
+          <div className='flex flex-1 flex-col gap-4'>
+            <DataTableToolbar
+              table={table}
+              searchPlaceholder='Search services, summaries, checks, or runtime...'
+              searchKey='name'
+              filters={[
+                {
+                  columnId: 'status',
+                  title: 'Status',
+                  options: [
+                    { label: 'Running', value: 'running' },
+                    { label: 'Available', value: 'available' },
+                    { label: 'Degraded', value: 'degraded' },
+                    { label: 'Stopped', value: 'stopped' },
+                  ],
+                },
+                {
+                  columnId: 'runtime',
+                  title: 'Runtime',
+                  options: runtimes.map((runtime) => ({
+                    label: runtime,
+                    value: runtime,
+                  })),
+                },
+              ]}
+            />
 
-              <div className='overflow-hidden rounded-md border'>
-                <Table className='table-fixed'>
-                  <TableHeader>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                      <TableRow key={headerGroup.id}>
-                        {headerGroup.headers.map((header) => (
-                          <TableHead key={header.id} colSpan={header.colSpan}>
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext()
-                                )}
-                          </TableHead>
+            <div className='overflow-hidden rounded-md border'>
+              <Table className='table-fixed'>
+                <TableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id} colSpan={header.colSpan}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.length ? (
+                    table.getRowModel().rows.map((row) => (
+                      <TableRow key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id} className='min-w-0'>
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </TableCell>
                         ))}
                       </TableRow>
-                    ))}
-                  </TableHeader>
-                  <TableBody>
-                    {table.getRowModel().rows.length ? (
-                      table.getRowModel().rows.map((row) => (
-                        <TableRow key={row.id}>
-                          {row.getVisibleCells().map((cell) => (
-                            <TableCell key={cell.id} className='min-w-0'>
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext()
-                              )}
-                            </TableCell>
-                          ))}
-                        </TableRow>
-                      ))
-                    ) : (
-                      <TableRow>
-                        <TableCell
-                          colSpan={columns.length}
-                          className='h-24 text-center'
-                        >
-                          No runtime rows match the current filters.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
-              </div>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell
+                        colSpan={columns.length}
+                        className='h-24 text-center'
+                      >
+                        No runtime rows match the current filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
 
-              <DataTablePagination table={table} className='mt-auto' />
-            </CardContent>
-          </Card>
+            <DataTablePagination table={table} className='mt-auto' />
+          </div>
         )}
       </Main>
     </>

--- a/src/features/runtime/runtime.test.tsx
+++ b/src/features/runtime/runtime.test.tsx
@@ -1,0 +1,44 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
+  useServices: () => ({
+    data: [
+      {
+        id: '@serviceadmin',
+        name: 'Service Admin',
+        role: '@node',
+        status: 'running',
+        runtimeHealth: {
+          health: 'healthy',
+          summary: 'Managed Service Admin runtime is healthy.',
+          uptime: '14m',
+          lastCheckAt: '2026-06-05 21:40',
+          lastRestartAt: '2026-06-05 21:26',
+        },
+      },
+    ],
+    isLoading: false,
+  }),
+}))
+
+describe('runtime page', () => {
+  it('renders the runtime table without a nested status card wrapper', async () => {
+    await renderRoute('/runtime')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Runtime$/i })).toBeVisible()
+    })
+
+    expect(screen.queryByText('Runtime status')).not.toBeInTheDocument()
+    expect(screen.queryByText(/services shown/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /service/i })).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /status/i })).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /runtime/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /Service Admin/i })).toBeVisible()
+    expect(
+      screen.getByText('Managed Service Admin runtime is healthy.')
+    ).toBeVisible()
+  })
+})

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -124,7 +124,13 @@ test('runtime, network, installed, and variables tables render', async ({
 }) => {
   await page.goto('/runtime')
   await expect(page.getByRole('heading', { name: 'Runtime' })).toBeVisible()
-  await expect(page.getByText('Runtime status')).toBeVisible()
+  await expect(page.getByText('Runtime status')).toHaveCount(0)
+  await expect(
+    page.getByRole('columnheader', { name: /service/i })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('columnheader', { name: /runtime/i })
+  ).toBeVisible()
   await expect(page.getByText('Service Admin UI')).toBeVisible()
 
   await page.goto('/network')


### PR DESCRIPTION
## Summary\n- Removes the nested Runtime status card/title/description shell.\n- Renders Runtime toolbar/table/pagination directly in the same full-height table surface pattern as Services.\n- Adds a focused Runtime regression test for the no-wrapper layout.\n\n## Validation\n- 
pm test -- src/features/runtime/runtime.test.tsx src/test/app-screens.test.tsx -> 34/34 passed\n- 
pm test -> 140/140 passed\n- 
pm run build -> passed\n- 
pm run format:check -- src/features/runtime/index.tsx src/features/runtime/runtime.test.tsx -> passed\n- 
pm run lint -> passed with existing unrelated warnings in installed/logs/network/variables\n- git diff --check -> passed\n\nCloses #141