### PR TITLE
fix(installed): make table fill page

### DIFF
--- a/src/features/installed/index.tsx
+++ b/src/features/installed/index.tsx
@@ -20,13 +20,6 @@ import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -83,15 +76,11 @@ function PathCell({ icon, value }: { icon: ElementType; value?: string }) {
 
 function InstalledLoading() {
   return (
-    <Card>
-      <CardHeader>
-        <Skeleton className='h-6 w-40' />
-        <Skeleton className='h-4 w-80' />
-      </CardHeader>
-      <CardContent>
-        <Skeleton className='h-[420px] w-full' />
-      </CardContent>
-    </Card>
+    <div className='flex flex-1 flex-col gap-4'>
+      <Skeleton className='h-10 w-full max-w-xl' />
+      <Skeleton className='h-[420px] w-full' />
+      <Skeleton className='mt-auto h-9 w-full max-w-md' />
+    </div>
   )
 }
 
@@ -198,6 +187,7 @@ export function Installed() {
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: servicesQuery.data ?? [],
     columns,
@@ -257,90 +247,79 @@ export function Installed() {
         {servicesQuery.isLoading ? (
           <InstalledLoading />
         ) : (
-          <Card>
-            <CardHeader>
-              <CardTitle className='flex items-center gap-2'>
-                <PackageCheck className='size-4' /> Installed services
-              </CardTitle>
-              <CardDescription>
-                {table.getFilteredRowModel().rows.length} services shown with
-                package, version, and path details.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className='space-y-4'>
-              <DataTableToolbar
-                table={table}
-                searchPlaceholder='Search services, packages, versions, or paths...'
-                searchKey='name'
-                filters={[
-                  {
-                    columnId: 'installed',
-                    title: 'Installed',
-                    options: [
-                      { label: 'Installed', value: 'installed' },
-                      { label: 'Missing', value: 'missing' },
-                    ],
-                  },
-                  {
-                    columnId: 'runtime',
-                    title: 'Runtime',
-                    options: runtimes.map((runtime) => ({
-                      label: runtime,
-                      value: runtime,
-                    })),
-                  },
-                ]}
-              />
+          <div className='flex flex-1 flex-col gap-4'>
+            <DataTableToolbar
+              table={table}
+              searchPlaceholder='Search services, packages, versions, or paths...'
+              searchKey='name'
+              filters={[
+                {
+                  columnId: 'installed',
+                  title: 'Installed',
+                  options: [
+                    { label: 'Installed', value: 'installed' },
+                    { label: 'Missing', value: 'missing' },
+                  ],
+                },
+                {
+                  columnId: 'runtime',
+                  title: 'Runtime',
+                  options: runtimes.map((runtime) => ({
+                    label: runtime,
+                    value: runtime,
+                  })),
+                },
+              ]}
+            />
 
-              <div className='overflow-hidden rounded-md border'>
-                <Table>
-                  <TableHeader>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                      <TableRow key={headerGroup.id}>
-                        {headerGroup.headers.map((header) => (
-                          <TableHead key={header.id} colSpan={header.colSpan}>
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext()
-                                )}
-                          </TableHead>
+            <div className='overflow-hidden rounded-md border'>
+              <Table>
+                <TableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id} colSpan={header.colSpan}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.length ? (
+                    table.getRowModel().rows.map((row) => (
+                      <TableRow key={row.id}>
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id}>
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </TableCell>
                         ))}
                       </TableRow>
-                    ))}
-                  </TableHeader>
-                  <TableBody>
-                    {table.getRowModel().rows.length ? (
-                      table.getRowModel().rows.map((row) => (
-                        <TableRow key={row.id}>
-                          {row.getVisibleCells().map((cell) => (
-                            <TableCell key={cell.id}>
-                              {flexRender(
-                                cell.column.columnDef.cell,
-                                cell.getContext()
-                              )}
-                            </TableCell>
-                          ))}
-                        </TableRow>
-                      ))
-                    ) : (
-                      <TableRow>
-                        <TableCell
-                          colSpan={columns.length}
-                          className='h-24 text-center'
-                        >
-                          No installed services match the current filters.
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </TableBody>
-                </Table>
-              </div>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell
+                        colSpan={columns.length}
+                        className='h-24 text-center'
+                      >
+                        No installed services match the current filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
 
-              <DataTablePagination table={table} className='mt-auto' />
-            </CardContent>
-          </Card>
+            <DataTablePagination table={table} className='mt-auto' />
+          </div>
         )}
       </Main>
     </>

--- a/src/features/installed/installed.test.tsx
+++ b/src/features/installed/installed.test.tsx
@@ -1,0 +1,48 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
+  useServices: () => ({
+    data: [
+      {
+        id: '@serviceadmin',
+        name: 'Service Admin',
+        installed: true,
+        metadata: {
+          runtime: '@node',
+          version: '2026.6.5-b4f9a3e',
+          packageId: 'service-lasso/lasso-serviceadmin',
+          installPath: 'C:/service-lasso/services/@serviceadmin/runtime',
+          configPath: 'C:/service-lasso/services/@serviceadmin/config',
+          dataPath: 'C:/service-lasso/services/@serviceadmin/data',
+        },
+      },
+    ],
+    isLoading: false,
+  }),
+}))
+
+describe('installed page', () => {
+  it('renders the installed table without a nested services card wrapper', async () => {
+    await renderRoute('/installed')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Installed$/i })
+      ).toBeVisible()
+    })
+
+    expect(screen.queryByText('Installed services')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/package, version, and path details/i)
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /service/i })).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /installed/i })
+    ).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /package/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /Service Admin/i })).toBeVisible()
+    expect(screen.getByText('2026.6.5-b4f9a3e')).toBeVisible()
+  })
+})

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -142,6 +142,12 @@ test('runtime, network, installed, and variables tables render', async ({
   await expect(page.getByRole('heading', { name: 'Installed' })).toBeVisible()
   await expect(
     page.getByText('Installed services', { exact: true })
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole('columnheader', { name: /service/i })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('columnheader', { name: /package/i })
   ).toBeVisible()
   await expect(
     page.getByRole('cell', { name: 'lasso-@serviceadmin', exact: true })


### PR DESCRIPTION
## Summary\n- Removes the nested Installed services card/title/description shell.\n- Renders Installed toolbar/table/pagination directly in the same full-height table surface pattern as Services.\n- Adds focused Installed regression coverage and updates browser UI expectations.\n\n## Validation\n- 
pm test -- src/features/installed/installed.test.tsx src/features/runtime/runtime.test.tsx src/test/app-screens.test.tsx -> 35/35 passed\n- 
pm run test:ui -> 10/10 passed\n- 
pm test -> 141/141 passed\n- 
pm run build -> passed\n- 
pm run format:check -- src/features/installed/index.tsx src/features/installed/installed.test.tsx tests/ui/service-admin.spec.ts -> passed\n- 
pm run lint -> passed with existing unrelated warnings in logs/network/variables\n- git diff --check -> passed\n\nCloses #143