### PR TITLE
ISS-134 make support bundle a diagnostics action

### DIFF
--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -15,7 +15,6 @@ describe('sidebar navigation data', () => {
       '/runtime',
       '/installed',
       '/variables',
-      '/support-bundle',
       '/network',
     ])
   })
@@ -34,7 +33,7 @@ describe('sidebar optional page classification', () => {
   it('keeps only current optional pages in primary navigation', () => {
     const titles = collectNavTitles()
 
-    expect(titles).toContain('Support Bundle')
+    expect(titles).not.toContain('Support Bundle')
     expect(titles).not.toContain('Fleet Overview')
     expect(titles).not.toContain('ZITADEL Session')
     expect(titles).toContain('Policy Simulation')

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -81,11 +81,6 @@ export const sidebarData: SidebarData = {
           icon: SlidersHorizontal,
         },
         {
-          title: 'Support Bundle',
-          url: '/support-bundle',
-          icon: LifeBuoy,
-        },
-        {
           title: 'Network',
           url: '/network',
           icon: Globe,

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -30,6 +30,7 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import { SupportBundleDiagnosticsAction } from '../support-bundle'
 import {
   auditEventTypeLabel,
   filterSecretsBrokerAuditEvents,
@@ -3323,6 +3324,9 @@ export function SecretsBrokerSetupWizard({
                   <DiagnosticCard key={diagnostic.id} diagnostic={diagnostic} />
                 ))}
               </div>
+              <SupportBundleDiagnosticsAction
+                diagnostics={secretsBrokerDiagnostics}
+              />
               <div className='flex gap-3 rounded-lg border p-3 text-sm'>
                 <ShieldCheck className='mt-0.5 size-4 shrink-0' />
                 <div>

--- a/src/features/support-bundle/index.tsx
+++ b/src/features/support-bundle/index.tsx
@@ -1,6 +1,4 @@
-import { useMemo, useState } from 'react'
 import { Download, FileText, ShieldAlert } from 'lucide-react'
-import { usePageMetadata } from '@/lib/page-metadata'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -11,19 +9,14 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { ConfigDrawer } from '@/components/config-drawer'
-import { Header } from '@/components/layout/header'
-import { Main } from '@/components/layout/main'
-import { ProfileDropdown } from '@/components/profile-dropdown'
-import { Search } from '@/components/search'
-import { ThemeSwitch } from '@/components/theme-switch'
+import type { SecretsBrokerDiagnostic } from '../secrets-broker/diagnostics'
 import {
-  buildSupportBundlePayload,
-  type SupportBundleSection,
+  buildSupportBundleReview,
+  type SupportBundleReviewSection,
 } from './support-bundle'
 
 const severityVariant: Record<
-  SupportBundleSection['severity'],
+  SupportBundleReviewSection['severity'],
   'default' | 'secondary' | 'destructive' | 'outline'
 > = {
   info: 'secondary',
@@ -31,215 +24,98 @@ const severityVariant: Record<
   error: 'destructive',
 }
 
-export function SupportBundlePage() {
-  const [preparedBundle, setPreparedBundle] = useState('')
-  const bundle = useMemo(() => buildSupportBundlePayload(), [])
-  const manifestPreview = useMemo(
-    () => JSON.stringify(bundle.manifest, null, 2),
-    [bundle]
+export function SupportBundleDiagnosticsAction({
+  diagnostics,
+}: {
+  diagnostics: SecretsBrokerDiagnostic[]
+}) {
+  const review = buildSupportBundleReview(
+    diagnostics.map((diagnostic) => ({
+      category: diagnostic.category,
+      status: diagnostic.status,
+    }))
   )
-  const bundlePreview = useMemo(() => JSON.stringify(bundle, null, 2), [bundle])
-  const redactionCount = bundle.diagnostics.redactionReport.reduce(
-    (total, item) => total + Number(item.redactions),
-    0
-  )
-
-  usePageMetadata({
-    title: 'Service Admin - Support Bundle',
-    description:
-      'Secret-safe Service Lasso diagnostics support bundle preview and export.',
-  })
 
   return (
-    <>
-      <Header fixed>
-        <Search />
-        <div className='ms-auto flex items-center space-x-4'>
-          <ThemeSwitch />
-          <ConfigDrawer />
-          <ProfileDropdown />
-        </div>
-      </Header>
-
-      <Main id='content' className='space-y-6'>
-        <div className='flex flex-wrap items-start justify-between gap-4'>
+    <Card role='region' aria-label='Support bundle export action'>
+      <CardHeader>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
           <div>
-            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
-              <FileText className='size-5' /> Support bundle export
-            </h1>
-            <p className='mt-1 text-muted-foreground'>
-              Preview and prepare a local diagnostics bundle for support triage.
-              The bundle is secret-safe by default: raw secrets, tokens, API
-              keys, cookies, private keys, recovery material, passwords, and
-              environment values are excluded or redacted before export.
-            </p>
+            <CardTitle className='flex items-center gap-2 text-base'>
+              <FileText className='size-4' /> Support bundle export
+            </CardTitle>
+            <CardDescription>
+              Controlled local diagnostics export from the current Secrets
+              Broker diagnostics context.
+            </CardDescription>
           </div>
-          <Badge variant='secondary'>Secret-safe diagnostics</Badge>
+          <Badge variant='outline'>{review.exportAvailability.label}</Badge>
         </div>
-
+      </CardHeader>
+      <CardContent className='space-y-4'>
         <Alert>
           <ShieldAlert className='size-4' />
-          <AlertTitle>Review before sharing</AlertTitle>
+          <AlertTitle>Export unavailable</AlertTitle>
           <AlertDescription>
-            This preview shows every included section and the manifest redaction
-            policy before export. Operators should still review the generated
-            bundle in their support workflow before sending it externally.
+            {review.exportAvailability.reason} No sample bundle or fixture
+            payload is generated here.
           </AlertDescription>
         </Alert>
 
-        <div className='grid gap-4 md:grid-cols-4'>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Sections</CardDescription>
-              <CardTitle className='text-3xl'>
-                {bundle.manifest.sections.length}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Redactions</CardDescription>
-              <CardTitle className='text-3xl'>{redactionCount}</CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Policy</CardDescription>
-              <CardTitle className='text-base'>
-                {bundle.manifest.redactionPolicy.mode}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Instance</CardDescription>
-              <CardTitle className='text-base'>
-                {bundle.manifest.instanceRef}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Included sections preview</CardTitle>
-            <CardDescription>
-              The export contains only metadata, refs, safe status codes,
-              summaries, and redacted log excerpts.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className='grid gap-3 md:grid-cols-2'>
-            {bundle.manifest.sections.map((section) => (
-              <div key={section.id} className='rounded-lg border p-4'>
-                <div className='flex items-start justify-between gap-3'>
-                  <div>
-                    <div className='font-medium'>{section.title}</div>
-                    <p className='mt-1 text-sm text-muted-foreground'>
-                      {section.summary}
-                    </p>
-                  </div>
-                  <Badge variant={severityVariant[section.severity]}>
-                    {section.severity}
-                  </Badge>
-                </div>
-                <div className='mt-3 text-xs text-muted-foreground'>
-                  {section.itemCount} item{section.itemCount === 1 ? '' : 's'}
-                </div>
-              </div>
-            ))}
-          </CardContent>
-        </Card>
-
-        <div className='grid gap-4 lg:grid-cols-2'>
-          <Card>
-            <CardHeader>
-              <CardTitle>Redaction policy</CardTitle>
-              <CardDescription>
-                Rules applied before diagnostics are displayed or exported.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className='space-y-4'>
-              <div>
-                <div className='mb-2 text-sm font-medium'>Rules</div>
-                <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
-                  {bundle.manifest.redactionPolicy.rules.map((rule) => (
-                    <li key={rule}>{rule}</li>
-                  ))}
-                </ul>
-              </div>
-              <div>
-                <div className='mb-2 text-sm font-medium'>
-                  Excluded material
-                </div>
-                <div className='flex flex-wrap gap-2'>
-                  {bundle.manifest.redactionPolicy.excludedMaterial.map(
-                    (item) => (
-                      <Badge key={item} variant='outline'>
-                        {item}
-                      </Badge>
-                    )
-                  )}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Redacted error preview</CardTitle>
-              <CardDescription>
-                Recent log excerpts after line-level redaction.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className='space-y-2'>
-                {bundle.diagnostics.recentErrors.map((line) => (
-                  <code
-                    key={line}
-                    className='block rounded-md border bg-muted px-3 py-2 text-xs break-all'
-                  >
-                    {line}
-                  </code>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Machine-readable manifest</CardTitle>
-            <CardDescription>
-              Included with the bundle so support tooling can verify timestamp,
-              sections, and redaction policy.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className='space-y-4'>
-            <pre className='max-h-80 overflow-auto rounded-lg border bg-muted p-4 text-xs'>
-              {manifestPreview}
-            </pre>
-            <div className='flex flex-wrap items-center gap-3'>
-              <Button onClick={() => setPreparedBundle(bundlePreview)}>
-                <Download className='size-4' /> Prepare export manifest
-              </Button>
-              {preparedBundle ? (
-                <span className='text-sm text-muted-foreground'>
-                  Export payload prepared for local review. No upload is
-                  performed by this UI.
-                </span>
-              ) : null}
+        <div className='grid gap-3 md:grid-cols-3'>
+          <div className='rounded-lg border p-3'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Categories
             </div>
-            {preparedBundle ? (
-              <pre
-                aria-label='Prepared support bundle payload'
-                className='max-h-80 overflow-auto rounded-lg border bg-muted p-4 text-xs'
-              >
-                {preparedBundle}
-              </pre>
-            ) : null}
-          </CardContent>
-        </Card>
-      </Main>
-    </>
+            <div className='text-2xl font-bold'>{review.sections.length}</div>
+          </div>
+          <div className='rounded-lg border p-3'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Redaction
+            </div>
+            <div className='text-sm font-medium'>{review.redactionStatus}</div>
+          </div>
+          <div className='rounded-lg border p-3'>
+            <div className='text-xs font-medium text-muted-foreground uppercase'>
+              Approximate size
+            </div>
+            <div className='text-sm font-medium'>
+              {review.approximateSizeLabel}
+            </div>
+          </div>
+        </div>
+
+        <div className='grid gap-3 lg:grid-cols-2'>
+          {review.sections.map((section) => (
+            <div key={section.id} className='rounded-lg border p-3'>
+              <div className='flex items-start justify-between gap-3'>
+                <div>
+                  <div className='font-medium'>{section.title}</div>
+                  <p className='mt-1 text-sm text-muted-foreground'>
+                    {section.summary}
+                  </p>
+                </div>
+                <Badge variant={severityVariant[section.severity]}>
+                  {section.severity}
+                </Badge>
+              </div>
+              <div className='mt-2 text-xs text-muted-foreground'>
+                {section.itemCount} item{section.itemCount === 1 ? '' : 's'}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className='flex flex-wrap items-center gap-3'>
+          <Button type='button' disabled>
+            <Download className='size-4' /> Download support bundle unavailable
+          </Button>
+          <span className='text-sm text-muted-foreground'>
+            Wire this action to the broker export endpoint when a real redacted
+            export API is available.
+          </span>
+        </div>
+      </CardContent>
+    </Card>
   )
 }

--- a/src/features/support-bundle/support-bundle.test.tsx
+++ b/src/features/support-bundle/support-bundle.test.tsx
@@ -1,58 +1,60 @@
 import { renderRoute } from '@/test/render-route'
-import { screen, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { secretsBrokerDiagnostics } from '../secrets-broker/diagnostics'
 import {
-  buildSupportBundlePayload,
+  buildSupportBundleReview,
   redactDiagnosticText,
-  supportBundleHasSecretMaterial,
+  supportBundleReviewHasSecretMaterial,
 } from './support-bundle'
 
-describe('support bundle export surface', () => {
-  it('renders support bundle preview sections and warning before export', async () => {
-    await renderRoute('/support-bundle')
+describe('support bundle diagnostics action', () => {
+  it('renders as a compact diagnostics action instead of a standalone export page', async () => {
+    await renderRoute('/secrets-broker/diagnostics')
 
     expect(
-      await screen.findByRole('heading', { name: /Support bundle export/i })
-    ).toBeVisible()
-    expect(screen.getByText(/Review before sharing/i)).toBeVisible()
-    expect(screen.getByText(/Secret-safe diagnostics/i)).toBeVisible()
-    expect(screen.getAllByText(/Service inventory/i)[0]).toBeVisible()
-    expect(
-      screen.getAllByText(/Runtime and health summaries/i)[0]
+      await screen.findByRole('heading', {
+        name: /Secrets Broker diagnostics/i,
+      })
     ).toBeVisible()
     expect(
-      screen.getAllByText(/Secrets Broker source statuses/i)[0]
+      screen.getByRole('region', { name: /Support bundle export action/i })
     ).toBeVisible()
-    expect(screen.getAllByText(/Recent redacted errors/i)[0]).toBeVisible()
-    expect(screen.getByText(/Machine-readable manifest/i)).toBeVisible()
-    expect(screen.getAllByText(/secret-safe-by-default/i)[0]).toBeVisible()
+    expect(screen.getByText(/Export endpoint unavailable/i)).toBeVisible()
+    expect(
+      screen.getByText(/No sample bundle or fixture payload is generated here/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Configuration diagnostics/i)).toBeVisible()
+    expect(screen.getByText(/Runtime diagnostics/i)).toBeVisible()
+    expect(screen.getByText(/Authentication diagnostics/i)).toBeVisible()
+    expect(screen.getByText(/Permission diagnostics/i)).toBeVisible()
+    expect(screen.getByText(/Redaction policy/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /Download support bundle unavailable/i,
+      })
+    ).toBeDisabled()
+    expect(
+      screen.queryByText(/Machine-readable manifest/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(/Prepared support bundle payload/i)
+    ).not.toBeInTheDocument()
   })
 
-  it('prepares a local payload without rendering raw secret-like values', async () => {
-    const user = userEvent.setup()
+  it('redirects the legacy standalone route to diagnostics', async () => {
     await renderRoute('/support-bundle')
 
-    await user.click(
-      screen.getByRole('button', { name: /Prepare export manifest/i })
-    )
-
-    const preparedPayload = screen.getByLabelText(/Prepared support bundle/i)
-    expect(preparedPayload).toBeVisible()
     expect(
-      within(preparedPayload).getByText(/\[REDACTED_SECRET\]/i)
+      await screen.findByRole('heading', {
+        name: /Secrets Broker diagnostics/i,
+      })
     ).toBeVisible()
     expect(
-      within(preparedPayload).getByText(/\[REDACTED_AUTHORIZATION\]/i)
+      screen.getByRole('region', { name: /Support bundle export action/i })
     ).toBeVisible()
     expect(
-      screen.queryByText(/provider-login-needed|session-cookie-placeholder/i)
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText(/bearer\s+[a-z0-9._~+/=-]+\.[a-z0-9._~+/=-]+/i)
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText(/-----BEGIN PRIVATE KEY-----/i)
+      screen.queryByText(/Machine-readable manifest/i)
     ).not.toBeInTheDocument()
   })
 
@@ -71,11 +73,18 @@ describe('support bundle export surface', () => {
     expect(redacted).not.toContain('session-canary')
   })
 
-  it('keeps generated support bundle fixtures free of secret material', () => {
-    const payload = buildSupportBundlePayload()
+  it('keeps the diagnostics review free of secret material', () => {
+    const review = buildSupportBundleReview(
+      secretsBrokerDiagnostics.map((diagnostic) => ({
+        category: diagnostic.category,
+        status: diagnostic.status,
+      }))
+    )
 
-    expect(payload.manifest.sections).toHaveLength(6)
-    expect(payload.manifest.redactionPolicy.mode).toBe('secret-safe-by-default')
-    expect(supportBundleHasSecretMaterial(payload)).toBe(false)
+    expect(review.exportAvailability.state).toBe('unavailable')
+    expect(review.sections.some((section) => section.id === 'redaction')).toBe(
+      true
+    )
+    expect(supportBundleReviewHasSecretMaterial(review)).toBe(false)
   })
 })

--- a/src/features/support-bundle/support-bundle.ts
+++ b/src/features/support-bundle/support-bundle.ts
@@ -1,49 +1,42 @@
 export type SupportBundleSeverity = 'info' | 'warning' | 'error'
 
-export type SupportBundleSectionId =
-  | 'manifest'
-  | 'service-inventory'
-  | 'runtime-health'
-  | 'secrets-broker'
-  | 'recent-errors'
-  | 'redaction-report'
+export type SupportBundleReviewSectionId =
+  | 'configuration'
+  | 'runtime'
+  | 'provider'
+  | 'auth'
+  | 'permission'
+  | 'redaction'
 
-export interface SupportBundleSection {
-  id: SupportBundleSectionId
+export type SupportBundleDiagnosticInput = {
+  category: 'configuration' | 'permission' | 'provider' | 'auth' | 'runtime'
+  status: 'pass' | 'warning' | 'fail'
+}
+
+export interface SupportBundleReviewSection {
+  id: SupportBundleReviewSectionId
   title: string
   summary: string
   itemCount: number
   severity: SupportBundleSeverity
 }
 
-export interface SupportBundleManifest {
-  bundleVersion: string
-  generatedAt: string
-  instanceRef: string
-  sections: SupportBundleSection[]
-  redactionPolicy: {
-    mode: 'secret-safe-by-default'
-    rules: string[]
-    excludedMaterial: string[]
+export interface SupportBundleReview {
+  exportAvailability: {
+    state: 'unavailable'
+    label: string
+    reason: string
   }
-}
-
-export interface SupportBundlePayload {
-  manifest: SupportBundleManifest
-  diagnostics: {
-    serviceInventory: Array<Record<string, string>>
-    runtimeHealth: Array<Record<string, string>>
-    secretsBroker: Array<Record<string, string>>
-    recentErrors: string[]
-    redactionReport: Array<Record<string, string | number>>
-  }
+  sections: SupportBundleReviewSection[]
+  redactionStatus: string
+  approximateSizeLabel: string
 }
 
 export const supportBundleRedactionRules = [
   'Bearer and Basic authorization values are replaced with [REDACTED_AUTHORIZATION].',
   'Token, API key, secret, password, cookie, and private-key assignments are replaced with [REDACTED_SECRET].',
   'Environment values are summarized by key/reference only; raw values are excluded.',
-  'Logs are included only after line-level redaction.',
+  'Logs must be included only after line-level redaction.',
 ]
 
 export const supportBundleExcludedMaterial = [
@@ -91,125 +84,93 @@ export function containsSecretLikeMaterial(value: string): boolean {
   return hasPrivateKey || hasAuthCredential || hasUnredactedAssignment
 }
 
-const rawRecentErrors = [
-  '2026-05-08T12:40:01Z WARN @secretsbroker provider=vault-east status=auth-required access_token=provider-login-needed',
-  '2026-05-08T12:41:14Z ERROR @serviceadmin export denied: cookie=session-cookie-placeholder',
-  '2026-05-08T12:42:22Z INFO service-broker retry scheduled for service=@secretsbroker correlation=diag_9bf12',
-]
+const sectionCopy: Record<
+  Exclude<SupportBundleReviewSectionId, 'redaction'>,
+  { title: string; summary: string }
+> = {
+  configuration: {
+    title: 'Configuration diagnostics',
+    summary: 'Current broker configuration checks and safe next actions.',
+  },
+  runtime: {
+    title: 'Runtime diagnostics',
+    summary: 'Current broker runtime health and degraded dependency checks.',
+  },
+  provider: {
+    title: 'Provider diagnostics',
+    summary: 'Source/provider status codes, refs, and safe failure categories.',
+  },
+  auth: {
+    title: 'Authentication diagnostics',
+    summary: 'Auth-required and lockout states without credential values.',
+  },
+  permission: {
+    title: 'Permission diagnostics',
+    summary: 'Policy and namespace decisions using metadata only.',
+  },
+}
 
-export function buildSupportBundlePayload(
-  generatedAt = '2026-05-08T13:10:00.000Z'
-): SupportBundlePayload {
-  const recentErrors = rawRecentErrors.map(redactDiagnosticText)
-  const redactionReport = rawRecentErrors.map((line, index) => ({
-    source: `recent-errors:${index + 1}`,
-    redactions: line === recentErrors[index] ? 0 : 1,
-    status: 'redacted',
-  }))
+function severityForDiagnostics(
+  diagnostics: SupportBundleDiagnosticInput[]
+): SupportBundleSeverity {
+  if (diagnostics.some((diagnostic) => diagnostic.status === 'fail')) {
+    return 'error'
+  }
 
-  const sections: SupportBundleSection[] = [
-    {
-      id: 'manifest',
-      title: 'Manifest and redaction policy',
-      summary: 'Bundle version, generated timestamp, section list, and policy.',
-      itemCount: 1,
-      severity: 'info',
-    },
-    {
-      id: 'service-inventory',
-      title: 'Service inventory',
-      summary: 'Installed local services, versions, and lifecycle status.',
-      itemCount: 4,
-      severity: 'info',
-    },
-    {
-      id: 'runtime-health',
-      title: 'Runtime and health summaries',
-      summary: 'Runtime state, uptime, last check, and degraded dependencies.',
-      itemCount: 3,
-      severity: 'warning',
-    },
-    {
-      id: 'secrets-broker',
-      title: 'Secrets Broker source statuses',
+  if (diagnostics.some((diagnostic) => diagnostic.status === 'warning')) {
+    return 'warning'
+  }
+
+  return 'info'
+}
+
+export function buildSupportBundleReview(
+  diagnostics: SupportBundleDiagnosticInput[]
+): SupportBundleReview {
+  const sections: SupportBundleReviewSection[] = Object.entries(
+    sectionCopy
+  ).map(([id, copy]) => {
+    const matchingDiagnostics = diagnostics.filter(
+      (diagnostic) => diagnostic.category === id
+    )
+
+    return {
+      id: id as Exclude<SupportBundleReviewSectionId, 'redaction'>,
+      title: copy.title,
       summary:
-        'Provider/source refs, lifecycle status, and safe error codes only.',
-      itemCount: 3,
-      severity: 'warning',
-    },
-    {
-      id: 'recent-errors',
-      title: 'Recent redacted errors',
-      summary: 'Selected log lines after authorization and secret redaction.',
-      itemCount: recentErrors.length,
-      severity: 'error',
-    },
-    {
-      id: 'redaction-report',
-      title: 'Redaction report',
-      summary: 'Per-source redaction counts without exposing removed values.',
-      itemCount: redactionReport.length,
-      severity: 'info',
-    },
-  ]
+        matchingDiagnostics.length > 0
+          ? copy.summary
+          : `${copy.summary} No current diagnostics are available from this context.`,
+      itemCount: matchingDiagnostics.length,
+      severity: severityForDiagnostics(matchingDiagnostics),
+    }
+  })
+
+  sections.push({
+    id: 'redaction',
+    title: 'Redaction policy',
+    summary:
+      'Raw secrets, credentials, private keys, recovery material, and env values are excluded before any future export.',
+    itemCount:
+      supportBundleRedactionRules.length + supportBundleExcludedMaterial.length,
+    severity: 'info',
+  })
 
   return {
-    manifest: {
-      bundleVersion: 'support-bundle.v1',
-      generatedAt,
-      instanceRef: 'service-lasso-local-dev',
-      sections,
-      redactionPolicy: {
-        mode: 'secret-safe-by-default',
-        rules: supportBundleRedactionRules,
-        excludedMaterial: supportBundleExcludedMaterial,
-      },
+    exportAvailability: {
+      state: 'unavailable',
+      label: 'Export endpoint unavailable',
+      reason:
+        'A real broker support-bundle export endpoint is not wired in Service Admin yet.',
     },
-    diagnostics: {
-      serviceInventory: [
-        { service: '@serviceadmin', version: '2.2.1', state: 'running' },
-        { service: '@secretsbroker', version: 'local', state: 'degraded' },
-        { service: '@traefik', version: 'local', state: 'running' },
-        { service: 'service-broker', version: 'local', state: 'running' },
-      ],
-      runtimeHealth: [
-        { check: 'serviceadmin-ui', status: 'healthy', ref: 'health_ui_001' },
-        {
-          check: 'secretsbroker-provider-auth',
-          status: 'auth-required',
-          ref: 'diag_provider_auth',
-        },
-        {
-          check: 'log-redaction',
-          status: 'enabled',
-          ref: 'redaction_policy_v1',
-        },
-      ],
-      secretsBroker: [
-        {
-          providerRef: 'vault-east',
-          status: 'auth-required',
-          safeErrorCode: 'PROVIDER_AUTH_REQUIRED',
-        },
-        {
-          providerRef: 'local-encrypted-store',
-          status: 'ready',
-          safeErrorCode: 'NONE',
-        },
-        {
-          providerRef: 'openclaw-exec-adapter',
-          status: 'policy-denied',
-          safeErrorCode: 'POLICY_NAMESPACE_DENIED',
-        },
-      ],
-      recentErrors,
-      redactionReport,
-    },
+    sections,
+    redactionStatus: 'Secret-safe policy preview',
+    approximateSizeLabel: 'Unavailable until backend estimates export size',
   }
 }
 
-export function supportBundleHasSecretMaterial(
-  payload = buildSupportBundlePayload()
+export function supportBundleReviewHasSecretMaterial(
+  review: SupportBundleReview
 ): boolean {
-  return containsSecretLikeMaterial(JSON.stringify(payload))
+  return containsSecretLikeMaterial(JSON.stringify(review))
 }

--- a/src/routes/_authenticated/support-bundle/index.tsx
+++ b/src/routes/_authenticated/support-bundle/index.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { SupportBundlePage } from '@/features/support-bundle'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_authenticated/support-bundle/')({
-  component: SupportBundlePage,
+  beforeLoad: () => {
+    throw redirect({ to: '/secrets-broker/diagnostics' })
+  },
 })

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -119,11 +119,6 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Trusted SSO Identity',
   },
   {
-    path: '/support-bundle',
-    heading: /^Support bundle export$/i,
-    title: 'Service Admin - Support Bundle',
-  },
-  {
     path: '/network',
     heading: /^Network$/i,
     title: 'Service Admin - Network',


### PR DESCRIPTION
## Summary
- removes the standalone support bundle entry from primary navigation
- exposes support bundle export as a compact Secrets Broker diagnostics action
- reworks support bundle data and tests around real/current-instance diagnostic categories and redaction review

## Validation
- 
pm test -- src/features/support-bundle/support-bundle.test.tsx src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx — 39 passed
- 
pm run build — passed
- 
pm run lint — passed with 3 existing warnings in src/features/logs/index.tsx
- 
pm run format:check — passed
- 
pm test — 145 passed
- git diff --check origin/master..HEAD — passed

Closes #134