### PR TITLE
fix #132 derive secrets topology from service variables

### DIFF
--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -7,6 +7,7 @@ import {
 import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import {
   filterSecretsBrokerAuditEvents,
   secretsBrokerAuditEvents,
@@ -43,6 +44,7 @@ import {
   sourceBackendHasSecretValue,
 } from './source-backends'
 import {
+  buildSecretVariableMappingRows,
   buildSecretsBrokerTopology,
   filterSecretsBrokerTopology,
   topologyHasSecretValue,
@@ -51,6 +53,58 @@ import {
   workflowAuthoringBoundaries,
   workflowAuthoringHasSecretValue,
 } from './workflow-authoring'
+
+const topologyTestServices = [
+  {
+    id: 'admin-api',
+    name: 'Admin API',
+    status: 'running',
+    favorite: false,
+    note: 'Test service',
+    links: [],
+    installed: true,
+    role: 'Test service',
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '1m',
+      lastCheckAt: '2026-06-06T20:00:00Z',
+      summary: 'Healthy',
+    },
+    endpoints: [],
+    metadata: {
+      serviceType: 'api',
+      runtime: 'node',
+      version: 'test',
+      build: 'test',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [
+      {
+        key: 'ADMIN_API_TOKEN',
+        value: 'secret://services/admin/api_token',
+        scope: 'service',
+        secret: true,
+        source: '@secretsbroker/local/default',
+      },
+      {
+        key: 'UNMAPPED_PASSWORD',
+        value: 'plain-text-password-value',
+        scope: 'service',
+        source: 'service.json',
+      },
+      {
+        key: 'LOG_LEVEL',
+        value: 'debug',
+        scope: 'service',
+        source: 'service.json',
+      },
+    ],
+    recentLogs: [],
+    actions: [],
+  },
+] as DashboardService[]
 
 describe('Secrets Broker setup wizard', () => {
   it('shows the safe setup contract without plaintext values', async () => {
@@ -902,36 +956,37 @@ describe('Secrets Broker setup wizard', () => {
     ).toBe(true)
   })
 
-  it('renders Secrets Broker topology graph and accessible relationship fallback', async () => {
+  it('renders Secrets Broker topology graph and variable mapping table', async () => {
     await renderRoute('/secrets-broker/topology')
-
-    const topology = buildSecretsBrokerTopology()
-    const postgresTopology = filterSecretsBrokerTopology(topology, 'postgres')
 
     expect(
       screen.getByRole('heading', { name: /Secrets Broker topology/i })
     ).toBeVisible()
-    expect(screen.getAllByText(/Safe metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/List fallback included/i)).toBeVisible()
-    expect(screen.getByText(/Actionable relationship fallback/i)).toBeVisible()
-    expect(screen.getAllByText(/provider\/source ownership/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/missing\/denied resolution/i)[0]).toBeVisible()
-    expect(screen.getAllByRole('link', { name: /Detail/i })[0]).toBeVisible()
-    expect(screen.getAllByRole('link', { name: /Audit/i })[0]).toBeVisible()
+    expect(await screen.findByText(/Runtime inventory source/i)).toBeVisible()
+    expect(screen.getByText(/Derived from table rows/i)).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /service/i })).toBeVisible()
     expect(
-      screen.getAllByRole('link', { name: /Diagnostics/i })[0]
+      screen.getByRole('columnheader', { name: /variable/i })
     ).toBeVisible()
-    const topologySearch = screen.getByLabelText(/Search topology/i)
-    await userEvent.type(topologySearch, 'postgres')
-    expect(topologySearch).toHaveValue('postgres')
     expect(
-      screen.getByText(
-        new RegExp(
-          `Showing ${postgresTopology.nodes.length} of ${topology.nodes.length} nodes and ${postgresTopology.edges.length} of ${topology.edges.length} relationships\\.`
-        )
-      )
+      screen.getByRole('columnheader', { name: /SecretRef/i })
     ).toBeVisible()
-    expect(screen.getAllByText(/postgres/i).length).toBeGreaterThan(0)
+    expect(screen.getByText('SESSION_SECRET')).toBeVisible()
+    expect(
+      screen.getByText('secret://@serviceadmin/SESSION_SECRET')
+    ).toBeVisible()
+    expect(screen.getByText('POSTGRES_ADMIN_PASSWORD')).toBeVisible()
+    expect(screen.getAllByRole('link', { name: /^Service$/i })[0]).toBeVisible()
+    expect(
+      screen.getAllByRole('link', { name: /^Diagnostics$/i })[0]
+    ).toBeVisible()
+
+    const tableSearch = screen.getByPlaceholderText(
+      /Search services, variables, refs, sources, and status/i
+    )
+    await userEvent.type(tableSearch, 'telegram')
+    expect(tableSearch).toHaveValue('telegram')
+    expect(screen.getByText('TELEGRAM_BOT_TOKEN')).toBeVisible()
     expect(
       screen.queryByText(/correct-horse-battery-staple/i)
     ).not.toBeInTheDocument()
@@ -941,12 +996,11 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.queryByText(/sk-this-value-must-not-render/i)
     ).not.toBeInTheDocument()
-    expect(topology.edges.length).toBeGreaterThan(0)
   })
 
   it('filters topology search results without orphaning visible edges', () => {
-    const topology = buildSecretsBrokerTopology()
-    const filteredTopology = filterSecretsBrokerTopology(topology, 'postgres')
+    const topology = buildSecretsBrokerTopology(topologyTestServices)
+    const filteredTopology = filterSecretsBrokerTopology(topology, 'admin')
     const filteredNodeIds = new Set(
       filteredTopology.nodes.map((node) => node.id)
     )
@@ -955,7 +1009,7 @@ describe('Secrets Broker setup wizard', () => {
     expect(filteredTopology.nodes.length).toBeLessThan(topology.nodes.length)
     expect(filteredTopology.edges.length).toBeGreaterThan(0)
     expect(
-      filteredTopology.nodes.some((node) => node.label === 'postgres')
+      filteredTopology.nodes.some((node) => node.label === 'Admin API')
     ).toBe(true)
     expect(
       filteredTopology.edges.every(
@@ -966,32 +1020,40 @@ describe('Secrets Broker setup wizard', () => {
     expect(topologyHasSecretValue(filteredTopology)).toBe(false)
   })
 
-  it('builds topology from the same safe metadata used by list and audit views', () => {
-    const topology = buildSecretsBrokerTopology()
+  it('builds topology from runtime service variables without raw values or sample defaults', () => {
+    const topology = buildSecretsBrokerTopology(topologyTestServices)
+    const rows = buildSecretVariableMappingRows(topologyTestServices)
     const edgeNodeIds = new Set(
       topology.edges.flatMap((edge) => [edge.source, edge.target])
     )
     const topologyNodeIds = new Set(topology.nodes.map((node) => node.id))
 
+    expect(rows.map((row) => row.variableName)).toEqual([
+      'ADMIN_API_TOKEN',
+      'UNMAPPED_PASSWORD',
+    ])
+    expect(
+      rows.find((row) => row.variableName === 'ADMIN_API_TOKEN')
+    ).toMatchObject({
+      secretRef: 'secret://services/admin/api_token',
+      status: 'mapped',
+    })
+    expect(
+      rows.find((row) => row.variableName === 'UNMAPPED_PASSWORD')
+    ).toMatchObject({
+      secretRef: 'Not mapped',
+      status: 'unmapped',
+    })
     expect(topologyHasSecretValue(topology)).toBe(false)
-    expect(
-      secretsBrokerProviderConnections.every((connection) =>
-        topology.nodes.some((node) => node.id === `connection:${connection.id}`)
-      )
-    ).toBe(true)
-    expect(
-      secretsBrokerSourceBackends.every((source) =>
-        topology.nodes.some((node) => node.id === `source:${source.id}`)
-      )
-    ).toBe(true)
-    expect(
-      secretsBrokerAuditEvents.every((event) =>
-        topology.edges.some((edge) => edge.id === `audit:${event.id}`)
-      )
-    ).toBe(true)
     expect([...edgeNodeIds].every((id) => topologyNodeIds.has(id))).toBe(true)
-    expect(topology.edges.some((edge) => edge.status === 'denied')).toBe(true)
-    expect(topology.edges.some((edge) => edge.status === 'failed')).toBe(true)
+    expect(topology.edges.some((edge) => edge.status === 'ok')).toBe(true)
+    expect(topology.edges.some((edge) => edge.status === 'missing')).toBe(true)
+    expect(
+      topology.nodes.some((node) => node.label === 'run-20260507-190144')
+    ).toBe(false)
+    expect(topology.nodes.some((node) => node.label === 'service-start')).toBe(
+      false
+    )
   })
 
   it('covers audit event types, filtering, and safe detail rendering', async () => {

--- a/src/features/secrets-broker/topology-page.tsx
+++ b/src/features/secrets-broker/topology-page.tsx
@@ -1,0 +1,476 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, getRouteApi } from '@tanstack/react-router'
+import {
+  type ColumnDef,
+  type SortingState,
+  type VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Activity, AlertTriangle, Network, ShieldCheck } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import { cn } from '@/lib/utils'
+import { useTableUrlState } from '@/hooks/use-table-url-state'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import {
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+} from '@/components/data-table'
+import { DependencyGraphCanvas } from '@/components/dependency-graph-canvas'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { LongText } from '@/components/long-text'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  buildSecretsBrokerTopology,
+  type SecretVariableMappingRow,
+  type SecretVariableMappingStatus,
+  toReactFlowSecretsBrokerTopology,
+} from './topology'
+
+const route = getRouteApi('/_authenticated/secrets-broker/topology')
+
+const mappingStatusLabels: Record<SecretVariableMappingStatus, string> = {
+  mapped: 'Mapped',
+  unmapped: 'Unmapped',
+  'missing-source': 'Missing source',
+  unknown: 'Unknown',
+}
+
+function MappingStatusBadge({
+  status,
+}: {
+  status: SecretVariableMappingStatus
+}) {
+  if (status === 'mapped') {
+    return <Badge className='bg-emerald-600 hover:bg-emerald-600'>Mapped</Badge>
+  }
+
+  if (status === 'missing-source') {
+    return <Badge variant='destructive'>Missing source</Badge>
+  }
+
+  if (status === 'unmapped') {
+    return <Badge variant='secondary'>Unmapped</Badge>
+  }
+
+  return <Badge variant='outline'>Unknown</Badge>
+}
+
+const mappingColumns: ColumnDef<SecretVariableMappingRow>[] = [
+  {
+    accessorKey: 'serviceName',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Service' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex min-w-0 flex-col gap-1'>
+        <Link
+          to='/services/$serviceId'
+          params={{ serviceId: row.original.serviceId }}
+          className='truncate font-medium hover:underline'
+        >
+          {row.original.serviceName}
+        </Link>
+        <span className='text-xs text-muted-foreground'>
+          {row.original.serviceId}
+        </span>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'variableName',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Variable' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex min-w-0 flex-col gap-1'>
+        <span className='font-medium'>{row.original.variableName}</span>
+        <span className='text-xs text-muted-foreground'>
+          {row.original.scope}
+        </span>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'secretRef',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='SecretRef' />
+    ),
+    cell: ({ row }) => (
+      <LongText className='max-w-[320px] text-sm'>
+        {row.original.secretRef}
+      </LongText>
+    ),
+  },
+  {
+    accessorKey: 'provider',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Provider / source' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex min-w-0 flex-col gap-1'>
+        <span>{row.original.provider}</span>
+        <span className='text-xs text-muted-foreground'>
+          {row.original.source}
+        </span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Status' />
+    ),
+    cell: ({ row }) => <MappingStatusBadge status={row.original.status} />,
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'lastValidation',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Last validation' />
+    ),
+    cell: ({ row }) => (
+      <span className='text-sm text-muted-foreground'>
+        {row.original.lastValidation}
+      </span>
+    ),
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    cell: ({ row }) => (
+      <div className='flex flex-wrap gap-2'>
+        <Button asChild size='sm' variant='outline'>
+          <Link
+            to='/services/$serviceId'
+            params={{ serviceId: row.original.serviceId }}
+          >
+            Service
+          </Link>
+        </Button>
+        <Button asChild size='sm' variant='outline'>
+          <Link to='/secrets-broker/sources'>Source</Link>
+        </Button>
+        <Button asChild size='sm' variant='outline'>
+          <Link to='/secrets-broker/diagnostics'>Diagnostics</Link>
+        </Button>
+      </div>
+    ),
+    enableSorting: false,
+  },
+]
+
+function SecretsBrokerTopologyTable({
+  rows,
+}: {
+  rows: SecretVariableMappingRow[]
+}) {
+  const search = route.useSearch()
+  const navigate = route.useNavigate()
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'serviceName', desc: false },
+  ])
+
+  const {
+    globalFilter,
+    onGlobalFilterChange,
+    columnFilters,
+    onColumnFiltersChange,
+    pagination,
+    onPaginationChange,
+    ensurePageInRange,
+  } = useTableUrlState({
+    search,
+    navigate,
+    pagination: { defaultPage: 1, defaultPageSize: 10 },
+    globalFilter: { key: 'mapping' },
+    columnFilters: [{ columnId: 'status', searchKey: 'status', type: 'array' }],
+  })
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: rows,
+    columns: mappingColumns,
+    state: {
+      sorting,
+      pagination,
+      columnFilters,
+      columnVisibility,
+      globalFilter,
+    },
+    onPaginationChange,
+    onColumnFiltersChange,
+    onSortingChange: setSorting,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange,
+    globalFilterFn: (row, _columnId, value) =>
+      row.original.searchText.includes(String(value).toLowerCase()),
+    getPaginationRowModel: getPaginationRowModel(),
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
+
+  useEffect(() => {
+    ensurePageInRange(table.getPageCount())
+  }, [table, ensurePageInRange])
+
+  return (
+    <div className='flex flex-1 flex-col gap-4'>
+      <DataTableToolbar
+        table={table}
+        searchPlaceholder='Search services, variables, refs, sources, and status...'
+        filters={[
+          {
+            columnId: 'status',
+            title: 'Status',
+            options: Object.entries(mappingStatusLabels).map(
+              ([value, label]) => ({ value, label })
+            ),
+          },
+        ]}
+      />
+      <div className='overflow-hidden rounded-md border'>
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className='group/row'>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    className={cn(
+                      'bg-background group-hover/row:bg-muted',
+                      header.column.columnDef.meta?.className,
+                      header.column.columnDef.meta?.thClassName
+                    )}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} className='group/row'>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cn(
+                        'bg-background align-top group-hover/row:bg-muted',
+                        cell.column.columnDef.meta?.className,
+                        cell.column.columnDef.meta?.tdClassName
+                      )}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={mappingColumns.length}
+                  className='h-24 text-center'
+                >
+                  No secret variable mappings match the current filters.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <DataTablePagination table={table} className='mt-auto' />
+    </div>
+  )
+}
+
+function TopologyLoading() {
+  return (
+    <Card>
+      <CardHeader>
+        <Skeleton className='h-6 w-52' />
+        <Skeleton className='h-4 w-96' />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className='h-[520px] w-full' />
+      </CardContent>
+    </Card>
+  )
+}
+
+export function SecretsBrokerTopologyPage() {
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Topology',
+    description: 'Inspect safe service variable to SecretRef mapping metadata.',
+  })
+
+  const servicesQuery = useServices()
+  const topology = useMemo(
+    () => buildSecretsBrokerTopology(servicesQuery.data ?? []),
+    [servicesQuery.data]
+  )
+  const graph = useMemo(
+    () => toReactFlowSecretsBrokerTopology(topology),
+    [topology]
+  )
+  const unmappedCount = topology.rows.filter(
+    (row) => row.status !== 'mapped'
+  ).length
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='flex flex-wrap items-end justify-between gap-3'>
+          <div>
+            <h2 className='text-2xl font-bold tracking-tight'>
+              Secrets Broker topology
+            </h2>
+            <p className='text-muted-foreground'>
+              Service variables, SecretRef mappings, sources, and unmapped
+              secret-like entries from the runtime service inventory.
+            </p>
+          </div>
+          <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+            <ShieldCheck className='size-4' />
+            Values hidden
+          </div>
+        </div>
+
+        {servicesQuery.isLoading ? (
+          <TopologyLoading />
+        ) : (
+          <>
+            <div className='grid gap-3 md:grid-cols-4'>
+              <Card>
+                <CardContent className='p-4'>
+                  <div className='text-xs text-muted-foreground'>Mappings</div>
+                  <div className='text-2xl font-bold'>
+                    {topology.rows.length}
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='p-4'>
+                  <div className='text-xs text-muted-foreground'>Mapped</div>
+                  <div className='text-2xl font-bold'>
+                    {topology.rows.length - unmappedCount}
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='p-4'>
+                  <div className='text-xs text-muted-foreground'>
+                    Needs action
+                  </div>
+                  <div className='text-2xl font-bold'>{unmappedCount}</div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='flex items-center gap-2 p-4 text-sm text-muted-foreground'>
+                  <Activity className='size-4' />
+                  Runtime inventory source
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card>
+              <CardHeader className='space-y-1'>
+                <div className='flex flex-wrap items-center justify-between gap-2'>
+                  <div className='flex items-center gap-2 font-semibold'>
+                    <Network className='size-4' />
+                    Mapping graph
+                  </div>
+                  <Badge variant='secondary'>Derived from table rows</Badge>
+                </div>
+              </CardHeader>
+              <CardContent>
+                {topology.rows.length ? (
+                  <DependencyGraphCanvas
+                    nodes={graph.nodes}
+                    edges={graph.edges}
+                    height={420}
+                    draggable={false}
+                    selectable={false}
+                    showMiniMap={false}
+                    legendItems={[
+                      { label: 'mapped', color: '#16a34a' },
+                      {
+                        label: 'missing / unmapped',
+                        color: '#f97316',
+                        dashed: true,
+                      },
+                      { label: 'unknown', color: '#64748b', dashed: true },
+                    ]}
+                  />
+                ) : (
+                  <div className='flex min-h-[240px] items-center justify-center rounded-md border text-sm text-muted-foreground'>
+                    No secret-like service variables were reported by the
+                    runtime.
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {unmappedCount ? (
+              <div className='flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100'>
+                <AlertTriangle className='size-4' />
+                {unmappedCount} secret-like variable
+                {unmappedCount === 1 ? '' : 's'} need mapping review.
+              </div>
+            ) : null}
+
+            <SecretsBrokerTopologyTable rows={topology.rows} />
+          </>
+        )}
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/topology.ts
+++ b/src/features/secrets-broker/topology.ts
@@ -1,25 +1,26 @@
 import type { Edge, Node } from '@xyflow/react'
-import { secretsBrokerAuditEvents } from './audit-events'
-import { secretsBrokerProviderConnections } from './provider-connections'
-import { secretsBrokerSourceBackends } from './source-backends'
+import type {
+  DashboardService,
+  ServiceEnvironmentVariable,
+} from '@/lib/service-lasso-dashboard/types'
+
+export type SecretVariableMappingStatus =
+  | 'mapped'
+  | 'unmapped'
+  | 'missing-source'
+  | 'unknown'
 
 export type SecretsBrokerTopologyNodeKind =
   | 'broker'
-  | 'source'
-  | 'connection'
+  | 'provider'
   | 'ref'
   | 'service'
-  | 'workflow'
-  | 'run'
+  | 'variable'
 
 export type SecretsBrokerTopologyEdgeKind =
-  | 'resolves-from'
-  | 'uses'
-  | 'writes-back'
-  | 'failed'
-  | 'denied'
-  | 'provider-owns'
-  | 'run-uses'
+  | 'maps-to'
+  | 'provided-by'
+  | 'uses-variable'
 
 export type SecretsBrokerTopologyNode = {
   id: string
@@ -37,319 +38,283 @@ export type SecretsBrokerTopologyEdge = {
   target: string
   label: string
   kind: SecretsBrokerTopologyEdgeKind
-  status: 'ok' | 'warning' | 'failed' | 'denied' | 'missing'
+  status: 'ok' | 'warning' | 'failed' | 'denied' | 'missing' | 'unknown'
   detailHref: string
   auditHref: string
   diagnosticHref?: string
 }
 
+export type SecretVariableMappingRow = {
+  id: string
+  serviceId: string
+  serviceName: string
+  variableName: string
+  scope: ServiceEnvironmentVariable['scope']
+  source: string
+  secretRef: string
+  provider: string
+  status: SecretVariableMappingStatus
+  lastValidation: string
+  detailHref: string
+  variablesHref: string
+  sourceHref: string
+  auditHref: string
+  diagnosticsHref: string
+  searchText: string
+}
+
 export type SecretsBrokerTopology = {
+  rows: SecretVariableMappingRow[]
   nodes: SecretsBrokerTopologyNode[]
   edges: SecretsBrokerTopologyEdge[]
 }
 
-const serviceIds = ['@serviceadmin', '@secretsbroker', 'postgres']
-const workflowIds = [
-  'service-start',
-  'secret-rotation-preview',
-  'deploy-payments-api',
-]
-const runIds = ['run-20260507-190144', 'run-20260507-185812']
+const secretNamePattern =
+  /(^|_)(SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|CREDENTIAL|KEY)($|_)/i
+const secretRefPattern = /^secret:\/\//i
+const legacySecretRefPattern = /^[a-z0-9@._:/-]+\.[A-Z0-9_]+$/i
 
-function serviceNode(id: string): SecretsBrokerTopologyNode {
-  return {
-    id: `service:${id}`,
-    label: id,
-    kind: 'service',
-    summary: 'Service using broker refs or broker metadata.',
-    detailHref: `/services/${encodeURIComponent(id)}`,
-    auditHref: `/secrets-broker/audit-events`,
-    diagnosticHref: `/secrets-broker/diagnostics`,
+function safeNodeId(value: string) {
+  return value.replace(/[^a-z0-9@._:/-]+/gi, '-')
+}
+
+function isSecretLikeVariable(variable: ServiceEnvironmentVariable) {
+  return (
+    variable.secret === true ||
+    secretRefPattern.test(variable.value) ||
+    secretNamePattern.test(variable.key)
+  )
+}
+
+function extractSafeSecretRef(variable: ServiceEnvironmentVariable) {
+  if (secretRefPattern.test(variable.value)) return variable.value
+  if (variable.secret && legacySecretRefPattern.test(variable.value)) {
+    return `secret://${variable.value}`
   }
+  return ''
 }
 
-function workflowNode(id: string): SecretsBrokerTopologyNode {
-  return {
-    id: `workflow:${id}`,
-    label: id,
-    kind: 'workflow',
-    summary: 'Workflow using broker refs through an audited run identity.',
-    detailHref: `/dependencies?service=${encodeURIComponent(id)}`,
-    auditHref: `/secrets-broker/audit-events`,
-    diagnosticHref: `/secrets-broker/diagnostics`,
-  }
+function providerFromSource(source: string) {
+  if (!source || source === 'Not mapped') return 'None'
+  return source.replace(/^@secretsbroker\//, '')
 }
 
-function runNode(id: string): SecretsBrokerTopologyNode {
-  return {
-    id: `run:${id}`,
-    label: id,
-    kind: 'run',
-    summary: 'Audited workflow/service run context with safe metadata only.',
-    detailHref: `/secrets-broker/audit-events`,
-    auditHref: `/secrets-broker/audit-events`,
-    diagnosticHref: `/secrets-broker/diagnostics`,
-  }
+function mappingStatusFor(variable: ServiceEnvironmentVariable) {
+  const hasSafeRef = Boolean(extractSafeSecretRef(variable))
+  const hasBrokerSource = Boolean(variable.source?.includes('@secretsbroker'))
+
+  if (hasSafeRef && hasBrokerSource) return 'mapped'
+  if (variable.secret && !hasSafeRef) return 'missing-source'
+  if (hasSafeRef) return 'unknown'
+  return 'unmapped'
 }
 
-function refId(ref: string) {
-  return `ref:${ref.replace(/[^a-z0-9@._:/-]+/gi, '-')}`
+function validationFor(status: SecretVariableMappingStatus) {
+  if (status === 'mapped') return 'SecretRef mapping present'
+  if (status === 'missing-source') return 'Secret flag set without safe ref'
+  if (status === 'unknown') return 'SecretRef present without broker source'
+  return 'Secret-like variable is not mapped'
 }
 
-function refNode(ref: string): SecretsBrokerTopologyNode {
-  return {
-    id: refId(ref),
-    label: ref,
-    kind: 'ref',
-    summary: 'SecretRef identifier only; resolved value is hidden.',
-    detailHref: `/secrets-broker/audit-events`,
-    auditHref: `/secrets-broker/audit-events`,
-    diagnosticHref: `/secrets-broker/diagnostics`,
-  }
+export function buildSecretVariableMappingRows(
+  services: DashboardService[]
+): SecretVariableMappingRow[] {
+  return services.flatMap((service) =>
+    service.environmentVariables
+      .filter(isSecretLikeVariable)
+      .map((variable) => {
+        const status = mappingStatusFor(variable)
+        const safeRef = extractSafeSecretRef(variable)
+        const source =
+          variable.source ?? (safeRef ? 'Unknown source' : 'Not mapped')
+        const provider = providerFromSource(source)
+        const row: SecretVariableMappingRow = {
+          id: `${service.id}:${variable.scope}:${variable.key}`,
+          serviceId: service.id,
+          serviceName: service.name,
+          variableName: variable.key,
+          scope: variable.scope,
+          source,
+          secretRef: safeRef || 'Not mapped',
+          provider,
+          status,
+          lastValidation: validationFor(status),
+          detailHref: `/services/${encodeURIComponent(service.id)}`,
+          variablesHref: `/services/${encodeURIComponent(service.id)}`,
+          sourceHref: '/secrets-broker/sources',
+          auditHref: '/secrets-broker/audit-events',
+          diagnosticsHref: '/secrets-broker/diagnostics',
+          searchText: '',
+        }
+
+        return {
+          ...row,
+          searchText: [
+            row.serviceId,
+            row.serviceName,
+            row.variableName,
+            row.scope,
+            row.source,
+            row.secretRef,
+            row.provider,
+            row.status,
+            row.lastValidation,
+          ]
+            .join(' ')
+            .toLowerCase(),
+        }
+      })
+  )
 }
 
-function edgeStatusFromOutcome(
-  outcome: (typeof secretsBrokerAuditEvents)[number]['outcome']
-): SecretsBrokerTopologyEdge['status'] {
-  if (outcome === 'denied' || outcome === 'revoked') return 'denied'
-  if (outcome === 'failure') return 'failed'
-  return 'ok'
+function addNode(
+  nodes: Map<string, SecretsBrokerTopologyNode>,
+  node: SecretsBrokerTopologyNode
+) {
+  if (!nodes.has(node.id)) nodes.set(node.id, node)
 }
 
-function edgeKindFromEvent(
-  event: (typeof secretsBrokerAuditEvents)[number]
-): SecretsBrokerTopologyEdgeKind {
-  if (event.outcome === 'denied' || event.outcome === 'revoked') return 'denied'
-  if (event.outcome === 'failure') return 'failed'
-  if (event.type === 'write_back_denied' || event.type === 'secret_rotated') {
-    return 'writes-back'
-  }
-  return 'uses'
+function edgeStatusFor(status: SecretVariableMappingStatus) {
+  if (status === 'mapped') return 'ok'
+  if (status === 'unmapped') return 'missing'
+  if (status === 'missing-source') return 'missing'
+  return 'unknown'
 }
 
-export function buildSecretsBrokerTopology(): SecretsBrokerTopology {
+export function buildSecretsBrokerTopology(
+  services: DashboardService[] = []
+): SecretsBrokerTopology {
+  const rows = buildSecretVariableMappingRows(services)
   const nodes = new Map<string, SecretsBrokerTopologyNode>()
   const edges: SecretsBrokerTopologyEdge[] = []
 
-  nodes.set('broker:@secretsbroker', {
+  addNode(nodes, {
     id: 'broker:@secretsbroker',
     label: '@secretsbroker',
     kind: 'broker',
-    summary:
-      'Broker service mediating secret refs, providers, policies, and audit.',
+    summary: 'Broker metadata surface for service SecretRef mappings.',
     detailHref: '/secrets-broker',
     auditHref: '/secrets-broker/audit-events',
     diagnosticHref: '/secrets-broker/diagnostics',
   })
 
-  secretsBrokerSourceBackends.forEach((source) => {
-    const sourceNode: SecretsBrokerTopologyNode = {
-      id: `source:${source.id}`,
-      label: source.title,
-      kind: 'source',
-      summary: `${source.provider} source · ${source.state} · ${source.mode}`,
-      detailHref: '/secrets-broker/sources',
-      auditHref: '/secrets-broker/audit-events',
-      diagnosticHref: '/secrets-broker/diagnostics',
-    }
-    nodes.set(sourceNode.id, sourceNode)
-    edges.push({
-      id: `broker-source:${source.id}`,
-      source: sourceNode.id,
-      target: 'broker:@secretsbroker',
-      label: 'provider/source ownership',
-      kind: 'provider-owns',
-      status:
-        source.state === 'failing'
-          ? 'failed'
-          : source.state === 'not-configured'
-            ? 'missing'
-            : 'ok',
-      detailHref: '/secrets-broker/sources',
-      auditHref: '/secrets-broker/audit-events',
-      diagnosticHref: '/secrets-broker/diagnostics',
+  rows.forEach((row) => {
+    const serviceNodeId = `service:${safeNodeId(row.serviceId)}`
+    const variableNodeId = `variable:${safeNodeId(row.id)}`
+    const providerNodeId = `provider:${safeNodeId(row.provider)}`
+    const refNodeId = `ref:${safeNodeId(row.secretRef)}`
+    const status = edgeStatusFor(row.status)
+
+    addNode(nodes, {
+      id: serviceNodeId,
+      label: row.serviceName,
+      kind: 'service',
+      summary: `${row.serviceId} runtime service`,
+      detailHref: row.detailHref,
+      auditHref: row.auditHref,
+      diagnosticHref: row.diagnosticsHref,
+    })
+    addNode(nodes, {
+      id: variableNodeId,
+      label: row.variableName,
+      kind: 'variable',
+      summary: `${row.scope} variable; raw value hidden`,
+      detailHref: row.variablesHref,
+      auditHref: row.auditHref,
+      diagnosticHref: row.diagnosticsHref,
     })
 
-    source.exampleRefs.forEach((ref) => {
-      const safeRefNode = refNode(ref)
-      nodes.set(safeRefNode.id, safeRefNode)
-      edges.push({
-        id: `source-ref:${source.id}:${safeRefNode.id}`,
-        source: sourceNode.id,
-        target: safeRefNode.id,
-        label: 'resolves from',
-        kind: 'resolves-from',
-        status:
-          source.testResult.outcome === 'failure'
-            ? 'failed'
-            : source.testResult.outcome === 'not-run'
-              ? 'warning'
-              : 'ok',
-        detailHref: '/secrets-broker/sources',
-        auditHref: '/secrets-broker/audit-events',
-        diagnosticHref: '/secrets-broker/diagnostics',
-      })
+    edges.push({
+      id: `service-variable:${row.id}`,
+      source: serviceNodeId,
+      target: variableNodeId,
+      label: 'declares variable',
+      kind: 'uses-variable',
+      status,
+      detailHref: row.detailHref,
+      auditHref: row.auditHref,
+      diagnosticHref: row.diagnosticsHref,
     })
+
+    if (row.status === 'mapped' || row.status === 'unknown') {
+      addNode(nodes, {
+        id: refNodeId,
+        label: row.secretRef,
+        kind: 'ref',
+        summary: 'SecretRef identifier only; resolved value hidden',
+        detailHref: row.auditHref,
+        auditHref: row.auditHref,
+        diagnosticHref: row.diagnosticsHref,
+      })
+      edges.push({
+        id: `variable-ref:${row.id}`,
+        source: variableNodeId,
+        target: refNodeId,
+        label: 'maps to SecretRef',
+        kind: 'maps-to',
+        status,
+        detailHref: row.detailHref,
+        auditHref: row.auditHref,
+        diagnosticHref: row.diagnosticsHref,
+      })
+    }
+
+    if (row.provider !== 'None') {
+      addNode(nodes, {
+        id: providerNodeId,
+        label: row.provider,
+        kind: 'provider',
+        summary: `${row.source} metadata source`,
+        detailHref: row.sourceHref,
+        auditHref: row.auditHref,
+        diagnosticHref: row.diagnosticsHref,
+      })
+      edges.push({
+        id: `provider-variable:${row.id}`,
+        source: providerNodeId,
+        target: variableNodeId,
+        label: 'provides mapping metadata',
+        kind: 'provided-by',
+        status,
+        detailHref: row.sourceHref,
+        auditHref: row.auditHref,
+        diagnosticHref: row.diagnosticsHref,
+      })
+    } else {
+      edges.push({
+        id: `broker-variable:${row.id}`,
+        source: 'broker:@secretsbroker',
+        target: variableNodeId,
+        label: 'mapping missing',
+        kind: 'maps-to',
+        status,
+        detailHref: row.detailHref,
+        auditHref: row.auditHref,
+        diagnosticHref: row.diagnosticsHref,
+      })
+    }
   })
 
-  secretsBrokerProviderConnections.forEach((connection) => {
-    const connectionNode: SecretsBrokerTopologyNode = {
-      id: `connection:${connection.id}`,
-      label: connection.title,
-      kind: 'connection',
-      summary: `${connection.provider} connection · ${connection.state} · ${connection.secretMaterial.presence}`,
-      detailHref: `/secrets-broker/${connection.id}`,
-      auditHref: '/secrets-broker/audit-events',
-      diagnosticHref: '/secrets-broker/diagnostics',
-    }
-    nodes.set(connectionNode.id, connectionNode)
-    edges.push({
-      id: `broker-connection:${connection.id}`,
-      source: 'broker:@secretsbroker',
-      target: connectionNode.id,
-      label: 'provider connection',
-      kind: 'provider-owns',
-      status:
-        connection.state === 'healthy'
-          ? 'ok'
-          : connection.state === 'missing'
-            ? 'missing'
-            : connection.state === 'failed'
-              ? 'failed'
-              : 'warning',
-      detailHref: `/secrets-broker/${connection.id}`,
-      auditHref: '/secrets-broker/audit-events',
-      diagnosticHref: '/secrets-broker/diagnostics',
-    })
-
-    connection.usage.linkedServices.forEach((service) => {
-      const node = serviceNode(service)
-      nodes.set(node.id, node)
-      edges.push({
-        id: `connection-service:${connection.id}:${service}`,
-        source: connectionNode.id,
-        target: node.id,
-        label:
-          connection.state === 'healthy' ? 'uses' : 'missing/denied resolution',
-        kind:
-          connection.state === 'healthy'
-            ? 'uses'
-            : connection.state === 'missing'
-              ? 'denied'
-              : 'failed',
-        status:
-          connection.state === 'healthy'
-            ? 'ok'
-            : connection.state === 'missing'
-              ? 'missing'
-              : 'warning',
-        detailHref: `/secrets-broker/${connection.id}`,
-        auditHref: '/secrets-broker/audit-events',
-        diagnosticHref: '/secrets-broker/diagnostics',
-      })
-    })
-
-    connection.usage.linkedWorkflows.forEach((workflow) => {
-      const node = workflowNode(workflow)
-      nodes.set(node.id, node)
-      edges.push({
-        id: `connection-workflow:${connection.id}:${workflow}`,
-        source: connectionNode.id,
-        target: node.id,
-        label: 'workflow uses',
-        kind: 'uses',
-        status: connection.state === 'healthy' ? 'ok' : 'warning',
-        detailHref: `/secrets-broker/${connection.id}`,
-        auditHref: '/secrets-broker/audit-events',
-        diagnosticHref: '/secrets-broker/diagnostics',
-      })
-    })
-
-    connection.usage.linkedRuns.forEach((run) => {
-      const node = runNode(run)
-      nodes.set(node.id, node)
-      edges.push({
-        id: `connection-run:${connection.id}:${run}`,
-        source: connectionNode.id,
-        target: node.id,
-        label: 'audited run',
-        kind: 'run-uses',
-        status: connection.state === 'healthy' ? 'ok' : 'warning',
-        detailHref: `/secrets-broker/${connection.id}`,
-        auditHref: '/secrets-broker/audit-events',
-        diagnosticHref: '/secrets-broker/diagnostics',
-      })
-    })
-  })
-
-  serviceIds.forEach((service) =>
-    nodes.set(`service:${service}`, serviceNode(service))
-  )
-  workflowIds.forEach((workflow) =>
-    nodes.set(`workflow:${workflow}`, workflowNode(workflow))
-  )
-  runIds.forEach((run) => nodes.set(`run:${run}`, runNode(run)))
-
-  secretsBrokerAuditEvents.forEach((event) => {
-    const targetKind =
-      event.actorType === 'workflow'
-        ? 'workflow'
-        : event.actorType === 'cli-session'
-          ? 'run'
-          : 'service'
-    const targetId = `${targetKind}:${event.serviceOrWorkflow}`
-    if (!nodes.has(targetId)) {
-      nodes.set(
-        targetId,
-        targetKind === 'workflow'
-          ? workflowNode(event.serviceOrWorkflow)
-          : targetKind === 'run'
-            ? runNode(event.serviceOrWorkflow)
-            : serviceNode(event.serviceOrWorkflow)
-      )
-    }
-    const safeRefNode = refNode(event.ref)
-    nodes.set(safeRefNode.id, safeRefNode)
-    edges.push({
-      id: `audit:${event.id}`,
-      source: safeRefNode.id,
-      target: targetId,
-      label: event.type.replace(/_/g, ' '),
-      kind: edgeKindFromEvent(event),
-      status: edgeStatusFromOutcome(event.outcome),
-      detailHref: `/secrets-broker/audit-events`,
-      auditHref: `/secrets-broker/audit-events`,
-      diagnosticHref:
-        event.outcome === 'failure' || event.outcome === 'denied'
-          ? '/secrets-broker/diagnostics'
-          : undefined,
-    })
-  })
-
-  return { nodes: Array.from(nodes.values()), edges }
+  return { rows, nodes: Array.from(nodes.values()), edges }
 }
 
 const nodePositionByKind: Record<
   SecretsBrokerTopologyNodeKind,
   { x: number; y: number }
 > = {
-  source: { x: -620, y: 0 },
-  broker: { x: -300, y: 0 },
-  connection: { x: 20, y: 0 },
+  broker: { x: -580, y: 0 },
+  provider: { x: -300, y: -120 },
+  service: { x: -300, y: 160 },
+  variable: { x: 20, y: 0 },
   ref: { x: 340, y: 0 },
-  service: { x: 660, y: -120 },
-  workflow: { x: 660, y: 120 },
-  run: { x: 980, y: 120 },
 }
 
 const nodeKindColor: Record<SecretsBrokerTopologyNodeKind, string> = {
   broker: '#2563eb',
-  source: '#0891b2',
-  connection: '#7c3aed',
-  ref: '#f59e0b',
+  provider: '#0891b2',
   service: '#16a34a',
-  workflow: '#db2777',
-  run: '#64748b',
+  variable: '#7c3aed',
+  ref: '#f59e0b',
 }
 
 const edgeStatusColor: Record<SecretsBrokerTopologyEdge['status'], string> = {
@@ -358,6 +323,7 @@ const edgeStatusColor: Record<SecretsBrokerTopologyEdge['status'], string> = {
   failed: '#dc2626',
   denied: '#991b1b',
   missing: '#f97316',
+  unknown: '#64748b',
 }
 
 export function toReactFlowSecretsBrokerTopology(
@@ -378,12 +344,12 @@ export function toReactFlowSecretsBrokerTopology(
       },
       style: {
         border: `2px solid ${nodeKindColor[node.kind]}`,
-        borderRadius: 12,
+        borderRadius: 8,
         background: '#ffffff',
         color: '#0f172a',
         fontSize: 12,
         minWidth: 150,
-        maxWidth: 210,
+        maxWidth: 230,
         whiteSpace: 'pre-line',
       },
     }
@@ -394,7 +360,7 @@ export function toReactFlowSecretsBrokerTopology(
     source: edge.source,
     target: edge.target,
     label: edge.label,
-    animated: edge.status === 'failed' || edge.status === 'denied',
+    animated: edge.status === 'missing',
     style: {
       stroke: edgeStatusColor[edge.status],
       strokeWidth: edge.status === 'ok' ? 2 : 3,
@@ -418,7 +384,6 @@ export function filterSecretsBrokerTopology(
   query: string
 ): SecretsBrokerTopology {
   const normalizedQuery = query.trim().toLowerCase()
-
   if (!normalizedQuery) return topology
 
   const nodesById = new Map(topology.nodes.map((node) => [node.id, node]))
@@ -463,6 +428,9 @@ export function filterSecretsBrokerTopology(
   })
 
   return {
+    rows: topology.rows.filter((row) =>
+      row.searchText.includes(normalizedQuery)
+    ),
     nodes: topology.nodes.filter((node) => visibleNodeIds.has(node.id)),
     edges: topology.edges.filter((edge) => visibleEdgeIds.has(edge.id)),
   }
@@ -470,6 +438,16 @@ export function filterSecretsBrokerTopology(
 
 export function topologyHasSecretValue(topology: SecretsBrokerTopology) {
   const joined = [
+    ...topology.rows.flatMap((row) => [
+      row.id,
+      row.serviceId,
+      row.serviceName,
+      row.variableName,
+      row.source,
+      row.secretRef,
+      row.provider,
+      row.lastValidation,
+    ]),
     ...topology.nodes.flatMap((node) => [node.id, node.label, node.summary]),
     ...topology.edges.flatMap((edge) => [edge.id, edge.label]),
   ].join(' ')

--- a/src/routes/_authenticated/secrets-broker/topology.tsx
+++ b/src/routes/_authenticated/secrets-broker/topology.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { SecretsBrokerSetupWizard } from '@/features/secrets-broker'
+import { SecretsBrokerTopologyPage } from '@/features/secrets-broker/topology-page'
 
 export const Route = createFileRoute('/_authenticated/secrets-broker/topology')(
   {
-    component: () => <SecretsBrokerSetupWizard focusSection='topology' />,
+    component: SecretsBrokerTopologyPage,
   }
 )


### PR DESCRIPTION
## Summary
- Replace the Secrets Broker topology builder with runtime service-variable-derived mapping rows.
- Add a dedicated topology page with graph and shared data-table search/filter/pagination.
- Keep rendered surfaces metadata-only and add regressions for unmapped variables, no sample run/workflow defaults, and no raw value leakage.

## Validation
- `npm test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` (32 passed)
- `npm test` (145 passed)
- `npm run build`
- `npm run lint` (passes; existing warnings remain in `src/features/logs/index.tsx`)

Closes #132