### PR TITLE
fix(#160): use live support bundle diagnostics preview

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -3324,9 +3324,7 @@ export function SecretsBrokerSetupWizard({
                   <DiagnosticCard key={diagnostic.id} diagnostic={diagnostic} />
                 ))}
               </div>
-              <SupportBundleDiagnosticsAction
-                diagnostics={secretsBrokerDiagnostics}
-              />
+              <SupportBundleDiagnosticsAction />
               <div className='flex gap-3 rounded-lg border p-3 text-sm'>
                 <ShieldCheck className='mt-0.5 size-4 shrink-0' />
                 <div>

--- a/src/features/support-bundle/index.tsx
+++ b/src/features/support-bundle/index.tsx
@@ -1,4 +1,8 @@
 import { Download, FileText, ShieldAlert } from 'lucide-react'
+import {
+  useDashboardSummary,
+  useServices,
+} from '@/lib/service-lasso-dashboard/hooks'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -9,7 +13,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import type { SecretsBrokerDiagnostic } from '../secrets-broker/diagnostics'
 import {
   buildSupportBundleReview,
   type SupportBundleReviewSection,
@@ -24,17 +27,15 @@ const severityVariant: Record<
   error: 'destructive',
 }
 
-export function SupportBundleDiagnosticsAction({
-  diagnostics,
-}: {
-  diagnostics: SecretsBrokerDiagnostic[]
-}) {
-  const review = buildSupportBundleReview(
-    diagnostics.map((diagnostic) => ({
-      category: diagnostic.category,
-      status: diagnostic.status,
-    }))
-  )
+export function SupportBundleDiagnosticsAction() {
+  const summaryQuery = useDashboardSummary()
+  const servicesQuery = useServices()
+  const review = buildSupportBundleReview({
+    summary: summaryQuery.data,
+    services: servicesQuery.data,
+    isLoading: summaryQuery.isLoading || servicesQuery.isLoading,
+    error: summaryQuery.error ?? servicesQuery.error,
+  })
 
   return (
     <Card role='region' aria-label='Support bundle export action'>
@@ -61,6 +62,26 @@ export function SupportBundleDiagnosticsAction({
             payload is generated here.
           </AlertDescription>
         </Alert>
+
+        <div className='rounded-lg border p-3'>
+          <div className='flex flex-wrap items-start justify-between gap-3'>
+            <div>
+              <div className='font-medium'>{review.sourceState.label}</div>
+              <p className='mt-1 text-sm text-muted-foreground'>
+                {review.sourceState.summary}
+              </p>
+            </div>
+            <Badge
+              variant={
+                review.sourceState.state === 'error'
+                  ? 'destructive'
+                  : 'secondary'
+              }
+            >
+              {review.sourceState.state}
+            </Badge>
+          </div>
+        </div>
 
         <div className='grid gap-3 md:grid-cols-3'>
           <div className='rounded-lg border p-3'>
@@ -105,6 +126,49 @@ export function SupportBundleDiagnosticsAction({
             </div>
           ))}
         </div>
+
+        {review.previewItems.length ? (
+          <div className='space-y-3'>
+            <div>
+              <h3 className='text-sm font-medium'>Live metadata review</h3>
+              <p className='text-sm text-muted-foreground'>
+                These groups are assembled from current runtime metadata only.
+                Secret values, provider credentials, environment values, and
+                private material are excluded or redacted.
+              </p>
+            </div>
+            <div className='grid gap-3 lg:grid-cols-2'>
+              {review.previewItems.map((item) => (
+                <div key={item.id} className='rounded-lg border p-3'>
+                  <div className='mb-2 flex items-start justify-between gap-3'>
+                    <div>
+                      <div className='font-medium'>{item.title}</div>
+                      <div className='text-xs text-muted-foreground'>
+                        {item.source}
+                      </div>
+                    </div>
+                    <Badge variant={severityVariant[item.status]}>
+                      {item.status}
+                    </Badge>
+                  </div>
+                  <ul className='space-y-1 text-sm text-muted-foreground'>
+                    {item.details.slice(0, 5).map((detail) => (
+                      <li key={detail} className='break-words'>
+                        {detail}
+                      </li>
+                    ))}
+                  </ul>
+                  {item.details.length > 5 ? (
+                    <div className='mt-2 text-xs text-muted-foreground'>
+                      {item.details.length - 5} more metadata records excluded
+                      from the compact review.
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         <div className='flex flex-wrap items-center gap-3'>
           <Button type='button' disabled>

--- a/src/features/support-bundle/support-bundle.test.tsx
+++ b/src/features/support-bundle/support-bundle.test.tsx
@@ -1,12 +1,92 @@
 import { renderRoute } from '@/test/render-route'
 import { screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { secretsBrokerDiagnostics } from '../secrets-broker/diagnostics'
+import type {
+  DashboardService,
+  DashboardSummary,
+} from '@/lib/service-lasso-dashboard/types'
 import {
   buildSupportBundleReview,
   redactDiagnosticText,
   supportBundleReviewHasSecretMaterial,
 } from './support-bundle'
+
+function service(overrides: Partial<DashboardService> = {}): DashboardService {
+  return {
+    id: '@serviceadmin',
+    name: 'Service Admin',
+    status: 'running',
+    favorite: true,
+    note: 'Runtime API service metadata.',
+    links: [],
+    installed: true,
+    role: 'vite-preview',
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '5m',
+      lastCheckAt: '2026-06-09T02:35:00.000Z',
+      summary: 'Service Admin UI is reachable.',
+    },
+    endpoints: [
+      {
+        label: 'LAN',
+        url: 'http://192.168.1.53:17700',
+        bind: '0.0.0.0',
+        port: 17700,
+        protocol: 'http',
+        exposure: 'lan',
+      },
+    ],
+    metadata: {
+      serviceType: 'core',
+      runtime: 'vite-preview',
+      version: '2026.6.9-test',
+      build: 'test',
+      configPath: 'C:\\service-lasso\\serviceadmin\\service.json',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [
+      {
+        key: 'SESSION_SECRET',
+        value: 'session-secret-plaintext-canary',
+        scope: 'service',
+        secret: true,
+        source: 'runtime env',
+      },
+    ],
+    recentLogs: [
+      {
+        timestamp: '2026-06-09T02:35:00.000Z',
+        level: 'info',
+        source: 'app',
+        message: 'started with token=runtime-token-canary',
+      },
+    ],
+    actions: [],
+    ...overrides,
+  }
+}
+
+const summary: DashboardSummary = {
+  runtime: {
+    status: 'healthy',
+    lastReloadedAt: '2026-06-09T02:35:00.000Z',
+    warningCount: 0,
+  },
+  servicesTotal: 1,
+  servicesRunning: 1,
+  servicesAvailable: 0,
+  servicesStopped: 0,
+  servicesDegraded: 0,
+  networkExposureCount: 1,
+  installedCount: 1,
+  favorites: [],
+  others: [],
+  warnings: [],
+  problemServices: [],
+}
 
 describe('support bundle diagnostics action', () => {
   it('renders as a compact diagnostics action instead of a standalone export page', async () => {
@@ -24,6 +104,10 @@ describe('support bundle diagnostics action', () => {
     expect(
       screen.getByText(/No sample bundle or fixture payload is generated here/i)
     ).toBeVisible()
+    expect(await screen.findByText(/Live diagnostics preview/i)).toBeVisible()
+    expect(screen.getByText(/Live metadata review/i)).toBeVisible()
+    expect(screen.getByText(/Runtime health summary/i)).toBeVisible()
+    expect(screen.getByText(/Secret reference inventory/i)).toBeVisible()
     expect(screen.getByText(/Configuration diagnostics/i)).toBeVisible()
     expect(screen.getByText(/Runtime diagnostics/i)).toBeVisible()
     expect(screen.getByText(/Authentication diagnostics/i)).toBeVisible()
@@ -73,18 +157,35 @@ describe('support bundle diagnostics action', () => {
     expect(redacted).not.toContain('session-canary')
   })
 
-  it('keeps the diagnostics review free of secret material', () => {
-    const review = buildSupportBundleReview(
-      secretsBrokerDiagnostics.map((diagnostic) => ({
-        category: diagnostic.category,
-        status: diagnostic.status,
-      }))
-    )
+  it('builds the review from runtime/service metadata without raw values', () => {
+    const review = buildSupportBundleReview({
+      summary,
+      services: [service()],
+    })
 
     expect(review.exportAvailability.state).toBe('unavailable')
+    expect(review.sourceState.state).toBe('available')
+    expect(review.previewItems.map((item) => item.id)).toEqual([
+      'runtime-summary',
+      'secret-ref-inventory',
+      'route-endpoint-metadata',
+      'recent-log-summaries',
+    ])
     expect(review.sections.some((section) => section.id === 'redaction')).toBe(
       true
     )
     expect(supportBundleReviewHasSecretMaterial(review)).toBe(false)
+    expect(JSON.stringify(review)).not.toContain(
+      'session-secret-plaintext-canary'
+    )
+    expect(JSON.stringify(review)).not.toContain('runtime-token-canary')
+  })
+
+  it('marks the review unavailable instead of preparing fixture data without runtime metadata', () => {
+    const review = buildSupportBundleReview()
+
+    expect(review.sourceState.state).toBe('unavailable')
+    expect(review.previewItems).toEqual([])
+    expect(review.approximateSizeLabel).toMatch(/Unavailable/i)
   })
 })

--- a/src/features/support-bundle/support-bundle.ts
+++ b/src/features/support-bundle/support-bundle.ts
@@ -1,3 +1,8 @@
+import type {
+  DashboardService,
+  DashboardSummary,
+} from '@/lib/service-lasso-dashboard/types'
+
 export type SupportBundleSeverity = 'info' | 'warning' | 'error'
 
 export type SupportBundleReviewSectionId =
@@ -8,10 +13,11 @@ export type SupportBundleReviewSectionId =
   | 'permission'
   | 'redaction'
 
-export type SupportBundleDiagnosticInput = {
-  category: 'configuration' | 'permission' | 'provider' | 'auth' | 'runtime'
-  status: 'pass' | 'warning' | 'fail'
-}
+export type SupportBundleSourceState =
+  | 'available'
+  | 'loading'
+  | 'unavailable'
+  | 'error'
 
 export interface SupportBundleReviewSection {
   id: SupportBundleReviewSectionId
@@ -21,15 +27,36 @@ export interface SupportBundleReviewSection {
   severity: SupportBundleSeverity
 }
 
+export interface SupportBundleReviewItem {
+  id: string
+  title: string
+  source: string
+  status: SupportBundleSeverity
+  details: string[]
+}
+
 export interface SupportBundleReview {
   exportAvailability: {
     state: 'unavailable'
     label: string
     reason: string
   }
+  sourceState: {
+    state: SupportBundleSourceState
+    label: string
+    summary: string
+  }
   sections: SupportBundleReviewSection[]
+  previewItems: SupportBundleReviewItem[]
   redactionStatus: string
   approximateSizeLabel: string
+}
+
+export type SupportBundleRuntimeInput = {
+  summary?: DashboardSummary
+  services?: DashboardService[]
+  isLoading?: boolean
+  error?: unknown
 }
 
 export const supportBundleRedactionRules = [
@@ -51,7 +78,7 @@ export const supportBundleExcludedMaterial = [
 ]
 
 const assignmentPattern =
-  /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
+  /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
 const authPattern = /\b(bearer|basic)\s+[a-z0-9._~+/=-]+/gi
 const privateKeyPattern =
   /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/gi
@@ -77,7 +104,7 @@ export function containsSecretLikeMaterial(value: string): boolean {
     )
   const hasUnredactedAssignment = [
     ...value.matchAll(
-      /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
+      /\b(access[_-]?token|refresh[_-]?token|id[_-]?token|token|api[_-]?key|client[_-]?secret|session[_-]?secret|secret|password|cookie|private[_-]?key|recovery[_-]?key|env[_-]?value)\s*[:=]\s*([^\s,;]+)/gi
     ),
   ].some((match) => !match[2].startsWith('[REDACTED_'))
 
@@ -110,39 +137,229 @@ const sectionCopy: Record<
   },
 }
 
-function severityForDiagnostics(
-  diagnostics: SupportBundleDiagnosticInput[]
-): SupportBundleSeverity {
-  if (diagnostics.some((diagnostic) => diagnostic.status === 'fail')) {
+function serviceSeverity(services: DashboardService[]): SupportBundleSeverity {
+  if (
+    services.some(
+      (service) =>
+        service.status === 'stopped' ||
+        service.runtimeHealth.health === 'critical'
+    )
+  ) {
     return 'error'
   }
 
-  if (diagnostics.some((diagnostic) => diagnostic.status === 'warning')) {
+  if (
+    services.some(
+      (service) =>
+        service.status === 'degraded' ||
+        service.runtimeHealth.health === 'warning'
+    )
+  ) {
     return 'warning'
   }
 
   return 'info'
 }
 
+function sourceStateForRuntimeInput(
+  input: SupportBundleRuntimeInput
+): SupportBundleReview['sourceState'] {
+  if (input.isLoading) {
+    return {
+      state: 'loading',
+      label: 'Collecting live diagnostics',
+      summary: 'Runtime and service metadata are still loading.',
+    }
+  }
+
+  if (input.error) {
+    return {
+      state: 'error',
+      label: 'Live diagnostics unavailable',
+      summary:
+        'Runtime API data could not be loaded, so no bundle preview payload is prepared.',
+    }
+  }
+
+  const serviceCount = input.services?.length ?? 0
+
+  if (!input.summary && serviceCount === 0) {
+    return {
+      state: 'unavailable',
+      label: 'No live diagnostics loaded',
+      summary:
+        'No runtime dashboard data is available for support bundle review.',
+    }
+  }
+
+  return {
+    state: 'available',
+    label: 'Live diagnostics preview',
+    summary: `${serviceCount} service${serviceCount === 1 ? '' : 's'} loaded from the current runtime dashboard context.`,
+  }
+}
+
+function buildPreviewItems({
+  summary,
+  services = [],
+}: SupportBundleRuntimeInput): SupportBundleReviewItem[] {
+  const items: SupportBundleReviewItem[] = []
+
+  if (summary) {
+    items.push({
+      id: 'runtime-summary',
+      title: 'Runtime health summary',
+      source: 'Service Lasso runtime API',
+      status: summary.runtime.status === 'warning' ? 'warning' : 'info',
+      details: [
+        `${summary.servicesRunning} running`,
+        `${summary.servicesAvailable ?? 0} available`,
+        `${summary.servicesDegraded} degraded`,
+        `${summary.servicesStopped} stopped`,
+        `${summary.runtime.warningCount} runtime warnings`,
+      ],
+    })
+  }
+
+  const problemServices = services.filter(
+    (service) =>
+      service.status === 'degraded' ||
+      service.status === 'stopped' ||
+      service.runtimeHealth.health !== 'healthy'
+  )
+
+  if (problemServices.length) {
+    items.push({
+      id: 'service-health-problems',
+      title: 'Service health exceptions',
+      source: 'Service Lasso runtime API',
+      status: serviceSeverity(problemServices),
+      details: problemServices.map((service) =>
+        redactDiagnosticText(
+          `${service.id}: ${service.status}; ${service.runtimeHealth.summary}`
+        )
+      ),
+    })
+  }
+
+  const secretRefs = services.flatMap((service) =>
+    service.environmentVariables
+      .filter(
+        (variable) => variable.secret || variable.value.startsWith('secret://')
+      )
+      .map(
+        (variable) =>
+          `${service.id}: ${variable.key} from ${variable.source ?? 'runtime metadata'} (value excluded)`
+      )
+  )
+
+  if (secretRefs.length) {
+    items.push({
+      id: 'secret-ref-inventory',
+      title: 'Secret reference inventory',
+      source: 'Service metadata',
+      status: 'info',
+      details: secretRefs,
+    })
+  }
+
+  const endpointDetails = services.flatMap((service) =>
+    service.endpoints.map(
+      (endpoint) =>
+        `${service.id}: ${endpoint.label} ${endpoint.protocol}/${endpoint.exposure} ${endpoint.bind}:${endpoint.port}`
+    )
+  )
+
+  if (endpointDetails.length) {
+    items.push({
+      id: 'route-endpoint-metadata',
+      title: 'Route and endpoint metadata',
+      source: 'Service metadata',
+      status: 'info',
+      details: endpointDetails,
+    })
+  }
+
+  const logDetails = services.flatMap((service) =>
+    service.recentLogs
+      .slice(0, 3)
+      .map((entry) =>
+        redactDiagnosticText(
+          `${service.id}: ${entry.timestamp} ${entry.level}/${entry.source} ${entry.message}`
+        )
+      )
+  )
+
+  if (logDetails.length) {
+    items.push({
+      id: 'recent-log-summaries',
+      title: 'Recent log summaries',
+      source: 'Runtime log preview',
+      status: logDetails.some((line) => line.includes(' error/'))
+        ? 'warning'
+        : 'info',
+      details: logDetails,
+    })
+  }
+
+  return items
+}
+
 export function buildSupportBundleReview(
-  diagnostics: SupportBundleDiagnosticInput[]
+  input: SupportBundleRuntimeInput = {}
 ): SupportBundleReview {
+  const services = input.services ?? []
+  const previewItems = buildPreviewItems(input)
+  const sectionCounts: Record<
+    Exclude<SupportBundleReviewSectionId, 'redaction'>,
+    number
+  > = {
+    configuration: services.filter(
+      (service) =>
+        service.metadata.configPath ||
+        service.metadata.dataPath ||
+        service.metadata.installPath
+    ).length,
+    runtime: input.summary ? 1 + services.length : services.length,
+    provider: services.filter(
+      (service) =>
+        service.id.toLowerCase().includes('secretsbroker') ||
+        service.name.toLowerCase().includes('secrets broker')
+    ).length,
+    auth: services.reduce(
+      (count, service) =>
+        count +
+        service.environmentVariables.filter(
+          (variable) =>
+            variable.secret || variable.value.startsWith('secret://')
+        ).length,
+      0
+    ),
+    permission: services.reduce(
+      (count, service) => count + service.dependencies.length,
+      0
+    ),
+  }
+  const overallSeverity = serviceSeverity(services)
+
   const sections: SupportBundleReviewSection[] = Object.entries(
     sectionCopy
   ).map(([id, copy]) => {
-    const matchingDiagnostics = diagnostics.filter(
-      (diagnostic) => diagnostic.category === id
-    )
+    const sectionId = id as Exclude<SupportBundleReviewSectionId, 'redaction'>
+    const itemCount = sectionCounts[sectionId]
 
     return {
-      id: id as Exclude<SupportBundleReviewSectionId, 'redaction'>,
+      id: sectionId,
       title: copy.title,
       summary:
-        matchingDiagnostics.length > 0
+        itemCount > 0
           ? copy.summary
-          : `${copy.summary} No current diagnostics are available from this context.`,
-      itemCount: matchingDiagnostics.length,
-      severity: severityForDiagnostics(matchingDiagnostics),
+          : `${copy.summary} No live records are currently available for this category.`,
+      itemCount,
+      severity:
+        sectionId === 'runtime' || sectionId === 'provider'
+          ? overallSeverity
+          : 'info',
     }
   })
 
@@ -161,11 +378,16 @@ export function buildSupportBundleReview(
       state: 'unavailable',
       label: 'Export endpoint unavailable',
       reason:
-        'A real broker support-bundle export endpoint is not wired in Service Admin yet.',
+        'A real redacted support-bundle export endpoint is not wired in Service Admin yet.',
     },
+    sourceState: sourceStateForRuntimeInput(input),
     sections,
+    previewItems,
     redactionStatus: 'Secret-safe policy preview',
-    approximateSizeLabel: 'Unavailable until backend estimates export size',
+    approximateSizeLabel:
+      previewItems.length > 0
+        ? `${previewItems.length} metadata group${previewItems.length === 1 ? '' : 's'} in review`
+        : 'Unavailable until live metadata is loaded',
   }
 }
 


### PR DESCRIPTION
## Issue
Closes #160

## Summary
- Reworks the Support Bundle action so its review is built from current Service Lasso runtime dashboard and service metadata instead of static Secrets Broker diagnostic fixtures.
- Keeps export/download unavailable until a real redacted backend bundle endpoint exists, while showing a live metadata review for runtime health, service exceptions, secret-ref inventory, endpoints, and recent log summaries.
- Expands redaction coverage for plain `token=` diagnostic/log snippets and adds canary tests proving raw env/log secret values are not present.

## Validation
- PASS `npm run test:unit -- src/features/support-bundle/support-bundle.test.tsx` - `.work-agent/logs/issue-160-20260609-0230/support-bundle-test.log`
- PASS `npm run test:unit` - `.work-agent/logs/issue-160-20260609-0230/test-unit.log`
- PASS `npm run lint` - `.work-agent/logs/issue-160-20260609-0230/lint.log` (0 errors; existing warnings in `src/features/logs/index.tsx`)
- PASS `npm run build` - `.work-agent/logs/issue-160-20260609-0230/build.log` (existing Vite chunk-size warnings)
- PASS `git diff --check` - `.work-agent/logs/issue-160-20260609-0230/git-diff-check.log`
- PASS `npm run test:ui -- tests/ui/secrets-broker.spec.ts` - `.work-agent/logs/issue-160-20260609-0230/ui-secrets-broker.log`

## Demo
Pending canonical demo recycle/check in this cron run before final handoff.