### PR TITLE
fix #133: align variables with proper table state

### DIFF
--- a/src/features/variables/index.tsx
+++ b/src/features/variables/index.tsx
@@ -1,8 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import {
   type ColumnDef,
-  type ColumnFiltersState,
   type SortingState,
   flexRender,
   getCoreRowModel,
@@ -17,6 +16,8 @@ import { Copy } from 'lucide-react'
 import { copyText } from '@/lib/copy-text'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import { cn } from '@/lib/utils'
+import { type NavigateFn, useTableUrlState } from '@/hooks/use-table-url-state'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -42,7 +43,8 @@ import { ThemeSwitch } from '@/components/theme-switch'
 
 type VariablesProps = {
   service?: string
-  keyFilter?: string
+  search: Record<string, unknown>
+  navigate: NavigateFn
 }
 
 type VariableRow = {
@@ -53,6 +55,7 @@ type VariableRow = {
   secret: 'secret' | 'plain'
   source: string
   services: { id: string; name: string }[]
+  searchText: string
 }
 
 function VariablesLoading() {
@@ -190,7 +193,7 @@ const columns: ColumnDef<VariableRow>[] = [
   },
 ]
 
-export function Variables({ service, keyFilter }: VariablesProps) {
+export function Variables({ service, search, navigate }: VariablesProps) {
   usePageMetadata({
     title: 'Service Admin - Variables',
     description: 'Service Admin environment variables and config values view.',
@@ -200,9 +203,27 @@ export function Variables({ service, keyFilter }: VariablesProps) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'key', desc: false },
   ])
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
-    keyFilter ? [{ id: 'key', value: keyFilter }] : []
-  )
+
+  const {
+    globalFilter,
+    onGlobalFilterChange,
+    columnFilters,
+    onColumnFiltersChange,
+    pagination,
+    onPaginationChange,
+    ensurePageInRange,
+  } = useTableUrlState({
+    search,
+    navigate,
+    pagination: { defaultPage: 1, defaultPageSize: 10 },
+    globalFilter: { key: 'q' },
+    columnFilters: [
+      { columnId: 'key', searchKey: 'key', type: 'string' },
+      { columnId: 'scope', searchKey: 'scope', type: 'array' },
+      { columnId: 'source', searchKey: 'source', type: 'array' },
+      { columnId: 'secret', searchKey: 'visibility', type: 'array' },
+    ],
+  })
 
   const rows = useMemo<VariableRow[]>(() => {
     const services = (servicesQuery.data ?? []).filter(
@@ -222,9 +243,20 @@ export function Variables({ service, keyFilter }: VariablesProps) {
 
         const existing = map.get(id)
         if (existing) {
-          existing.services.push({ id: service.id, name: service.name })
+          const serviceRef = { id: service.id, name: service.name }
+          existing.services.push(serviceRef)
+          existing.searchText = [
+            existing.searchText,
+            serviceRef.id,
+            serviceRef.name,
+          ]
+            .join(' ')
+            .toLowerCase()
           continue
         }
+
+        const safeValue = variable.secret ? '' : variable.value
+        const serviceRef = { id: service.id, name: service.name }
 
         map.set(id, {
           id,
@@ -233,7 +265,18 @@ export function Variables({ service, keyFilter }: VariablesProps) {
           scope: variable.scope,
           secret: variable.secret ? 'secret' : 'plain',
           source: variable.source ?? 'Not recorded',
-          services: [{ id: service.id, name: service.name }],
+          services: [serviceRef],
+          searchText: [
+            variable.key,
+            safeValue,
+            variable.scope,
+            variable.secret ? 'secret' : 'plain',
+            variable.source ?? 'Not recorded',
+            serviceRef.id,
+            serviceRef.name,
+          ]
+            .join(' ')
+            .toLowerCase(),
         })
       }
     }
@@ -253,9 +296,20 @@ export function Variables({ service, keyFilter }: VariablesProps) {
     state: {
       sorting,
       columnFilters,
+      globalFilter,
+      pagination,
     },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
+    onColumnFiltersChange,
+    onGlobalFilterChange,
+    onPaginationChange,
+    globalFilterFn: (row, _columnId, filterValue) => {
+      const query = String(filterValue ?? '')
+        .trim()
+        .toLowerCase()
+      if (!query) return true
+      return row.original.searchText.includes(query)
+    },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -263,6 +317,10 @@ export function Variables({ service, keyFilter }: VariablesProps) {
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
   })
+
+  useEffect(() => {
+    ensurePageInRange(table.getPageCount())
+  }, [table, ensurePageInRange])
 
   return (
     <>
@@ -300,7 +358,6 @@ export function Variables({ service, keyFilter }: VariablesProps) {
             <DataTableToolbar
               table={table}
               searchPlaceholder='Search variable keys, values, sources, or services...'
-              searchKey='key'
               filters={[
                 {
                   columnId: 'scope',
@@ -336,9 +393,17 @@ export function Variables({ service, keyFilter }: VariablesProps) {
               <Table className='table-fixed'>
                 <TableHeader className='sticky top-0 z-10 bg-background'>
                   {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
+                    <TableRow key={headerGroup.id} className='group/row'>
                       {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id} colSpan={header.colSpan}>
+                        <TableHead
+                          key={header.id}
+                          colSpan={header.colSpan}
+                          className={cn(
+                            'bg-background group-hover/row:bg-muted',
+                            header.column.columnDef.meta?.className,
+                            header.column.columnDef.meta?.thClassName
+                          )}
+                        >
                           {header.isPlaceholder
                             ? null
                             : flexRender(
@@ -353,9 +418,16 @@ export function Variables({ service, keyFilter }: VariablesProps) {
                 <TableBody>
                   {table.getRowModel().rows.length ? (
                     table.getRowModel().rows.map((row) => (
-                      <TableRow key={row.id}>
+                      <TableRow key={row.id} className='group/row'>
                         {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id} className='min-w-0'>
+                          <TableCell
+                            key={cell.id}
+                            className={cn(
+                              'min-w-0 bg-background align-top group-hover/row:bg-muted',
+                              cell.column.columnDef.meta?.className,
+                              cell.column.columnDef.meta?.tdClassName
+                            )}
+                          >
                             {flexRender(
                               cell.column.columnDef.cell,
                               cell.getContext()

--- a/src/features/variables/variables.test.tsx
+++ b/src/features/variables/variables.test.tsx
@@ -1,5 +1,6 @@
 import { renderRoute } from '@/test/render-route'
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
@@ -15,6 +16,26 @@ vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
             scope: 'service',
             secret: false,
             source: '@serviceadmin/service.json',
+          },
+          {
+            key: 'SERVICE_LASSO_SESSION_SECRET',
+            value: 'super-secret-session-value',
+            scope: 'service',
+            secret: true,
+            source: '@serviceadmin/service.json',
+          },
+        ],
+      },
+      {
+        id: '@worker',
+        name: 'Worker Service',
+        environmentVariables: [
+          {
+            key: 'WORKER_QUEUE_URL',
+            value: 'https://queue.internal/jobs',
+            scope: 'global',
+            secret: false,
+            source: 'workspace/env',
           },
         ],
       },
@@ -38,13 +59,50 @@ describe('variables page', () => {
     expect(screen.getByRole('columnheader', { name: /key/i })).toBeVisible()
     expect(screen.getByRole('columnheader', { name: /value/i })).toBeVisible()
     expect(screen.getByRole('columnheader', { name: /source/i })).toBeVisible()
+    expect(screen.getAllByRole('button', { name: /^Scope/i })[0]).toBeVisible()
+    expect(screen.getAllByRole('button', { name: /^Source/i })[0]).toBeVisible()
+    expect(
+      screen.getAllByRole('button', { name: /^Visibility/i })[0]
+    ).toBeVisible()
     expect(screen.getByText('SERVICE_LASSO_API_BASE_URL')).toBeVisible()
     expect(screen.getByText('http://127.0.0.1:17883')).toBeVisible()
+    expect(screen.getByText('••••••••')).toBeVisible()
+    expect(
+      screen.queryByText('super-secret-session-value')
+    ).not.toBeInTheDocument()
 
     const scrollRegion = screen.getByTestId('variables-table-scroll-region')
     expect(scrollRegion).toHaveClass('flex-1')
     expect(scrollRegion).toHaveClass('overflow-auto')
     expect(scrollRegion).toHaveClass('min-h-[320px]')
     expect(screen.getByRole('button', { name: /next page/i })).toBeVisible()
+  })
+
+  it('uses the shared table search and URL-backed pagination state', async () => {
+    const user = userEvent.setup()
+    const { router } = await renderRoute('/variables?page=2&pageSize=1')
+
+    await waitFor(() => {
+      expect(screen.getByText('SERVICE_LASSO_SESSION_SECRET')).toBeVisible()
+    })
+    expect(
+      screen.queryByText('SERVICE_LASSO_API_BASE_URL')
+    ).not.toBeInTheDocument()
+    expect(screen.getAllByText(/Page 2 of 3/i)[0]).toBeVisible()
+    expect(
+      screen.queryByText('super-secret-session-value')
+    ).not.toBeInTheDocument()
+
+    await user.type(
+      screen.getByPlaceholderText(/Search variable keys/i),
+      'worker'
+    )
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ q: 'worker' })
+    })
+    expect(screen.getByText('WORKER_QUEUE_URL')).toBeVisible()
+    expect(
+      screen.queryByText('SERVICE_LASSO_API_BASE_URL')
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/routes/_authenticated/variables/index.tsx
+++ b/src/routes/_authenticated/variables/index.tsx
@@ -6,12 +6,21 @@ import { Variables } from '@/features/variables'
 const variablesSearchSchema = z.object({
   service: z.string().optional().catch(undefined),
   key: z.string().optional().catch(undefined),
+  q: z.string().optional().catch(undefined),
+  page: z.number().optional().catch(undefined),
+  pageSize: z.number().optional().catch(undefined),
+  scope: z.array(z.string()).optional().catch(undefined),
+  source: z.array(z.string()).optional().catch(undefined),
+  visibility: z.array(z.string()).optional().catch(undefined),
 })
 
 function VariablesRoute() {
   const search = Route.useSearch()
+  const navigate = Route.useNavigate()
 
-  return <Variables service={search.service} keyFilter={search.key} />
+  return (
+    <Variables service={search.service} search={search} navigate={navigate} />
+  )
 }
 
 export const Route = createFileRoute('/_authenticated/variables/')({


### PR DESCRIPTION
## Summary
- Wires `/variables` into the shared URL-backed table state pattern for search, filters, and pagination.
- Adds safe global search across variable key, non-secret value, source, scope, visibility, and service metadata without making secret values searchable/rendered.
- Keeps the stable internal scroll/table shell while adding shared table row/header styling and regression coverage.

## Validation
Logs are under `.work-agent/logs/133/` in the local repo.

- `npm run test:unit -- src/features/variables/variables.test.tsx` passed (2 tests)
- `npm run test:unit` passed (26 files / 147 tests)
- `npm run lint` passed with 0 errors; pre-existing warnings remain in `src/features/logs/index.tsx`
- `npm run build` passed
- `git diff --check` passed
- `npm run test:ui -- tests/ui/service-admin.spec.ts` passed (3 Playwright tests)

## Demo handoff
Pending canonical demo recycle and LAN health verification for this branch/commit before closure.

Fixes #133