### PR TITLE
feat(#153): split Secrets Broker operational controls route

### DIFF
--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -47,6 +47,7 @@ describe('sidebar optional page classification', () => {
     expect(secretsBrokerGroup?.items.map((item) => item.url)).toEqual([
       '/secrets-broker',
       '/secrets-broker/secrets',
+      '/secrets-broker/operational-controls',
       '/secrets-broker/configuration',
       '/secrets-broker/sources',
       '/secrets-broker/provider-connections',

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -101,6 +101,11 @@ export const sidebarData: SidebarData = {
           icon: DatabaseZap,
         },
         {
+          title: 'Operational Controls',
+          url: '/secrets-broker/operational-controls',
+          icon: ShieldCheck,
+        },
+        {
           title: 'Configuration',
           url: '/secrets-broker/configuration',
           icon: Settings,

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -2304,7 +2304,6 @@ export function SecretsBrokerSetupWizard({
                 </CardContent>
               </Card>
             </div>
-
           </>
         ) : null}
 

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -138,6 +138,7 @@ type SecretsBrokerOverviewScenario = {
 
 export type SecretsBrokerSectionFocus =
   | 'overview'
+  | 'operational-controls'
   | 'sources'
   | 'provider-connections'
   | 'single-reveal'
@@ -155,6 +156,12 @@ const secretsBrokerSectionMetadata: Record<
     title: 'Service Admin - Secrets Broker Setup',
     heading: 'Secrets Broker setup',
     description: 'Configure sources, policies, and recovery safely.',
+  },
+  'operational-controls': {
+    title: 'Service Admin - Secrets Broker Operational Controls',
+    heading: 'Secrets Broker operational controls',
+    description:
+      'Inspect policy, audit, telemetry, event filtering, and lockout posture.',
   },
   sources: {
     title: 'Service Admin - Secrets Broker Sources',
@@ -1901,11 +1908,27 @@ export function SecretsBrokerSetupWizard({
   const pageMetadata = secretsBrokerSectionMetadata[focusSection]
 
   useEffect(() => {
-    if (
-      focusSection === 'overview' &&
-      (hash === 'secret-sources' || hash === '#secret-sources')
-    ) {
-      void navigate({ to: '/secrets-broker/sources', replace: true })
+    if (focusSection !== 'overview') return
+
+    const legacyHash = hash.replace(/^#/, '')
+    const legacyHashRoute: Partial<Record<string, string>> = {
+      'operational-controls': '/secrets-broker/operational-controls',
+      'secret-sources': '/secrets-broker/sources',
+      'provider-connections': '/secrets-broker/provider-connections',
+      'single-secret-reveal': '/secrets-broker/single-reveal',
+      'single-reveal': '/secrets-broker/single-reveal',
+      'backup-keys': '/secrets-broker/backup-keys',
+      'workflow-authoring-boundary': '/secrets-broker/workflow-boundaries',
+      'workflow-boundaries': '/secrets-broker/workflow-boundaries',
+      'secrets-topology': '/secrets-broker/topology',
+      topology: '/secrets-broker/topology',
+      'audit-events': '/secrets-broker/audit-events',
+      diagnostics: '/secrets-broker/diagnostics',
+    }
+    const route = legacyHashRoute[legacyHash]
+
+    if (route) {
+      void navigate({ to: route, replace: true })
     }
   }, [focusSection, hash, navigate])
 
@@ -2076,13 +2099,16 @@ export function SecretsBrokerSetupWizard({
                       values.
                     </CardDescription>
                   </div>
-                  <Badge
-                    variant={
-                      brokerOverviewStateVariant[brokerOverview.health.state]
-                    }
-                  >
-                    {brokerOverviewStateCopy[brokerOverview.health.state]}
-                  </Badge>
+                  <div className='flex flex-wrap gap-2'>
+                    <Badge
+                      variant={
+                        brokerOverviewStateVariant[brokerOverview.health.state]
+                      }
+                    >
+                      {brokerOverviewStateCopy[brokerOverview.health.state]}
+                    </Badge>
+                    <Badge variant='outline'>Raw values hidden</Badge>
+                  </div>
                 </div>
               </CardHeader>
               <CardContent className='space-y-4'>
@@ -2279,8 +2305,11 @@ export function SecretsBrokerSetupWizard({
               </Card>
             </div>
 
-            <OperationalControlsPanel />
           </>
+        ) : null}
+
+        {focusSection === 'operational-controls' ? (
+          <OperationalControlsPanel />
         ) : null}
 
         {focusSection === 'single-reveal' ? (

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -193,7 +193,7 @@ describe('Secrets Broker setup wizard', () => {
 
   it('renders operational controls with policy telemetry event filters and lockout state', async () => {
     const user = userEvent.setup()
-    await renderRoute('/secrets-broker')
+    await renderRoute('/secrets-broker/operational-controls')
 
     expect(screen.getAllByText(/Operational controls/i)[0]).toBeVisible()
     expect(screen.getByText(/Effective service policy/i)).toBeVisible()
@@ -526,6 +526,23 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.queryByRole('heading', { name: /^Secrets Broker setup$/i })
     ).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['operational-controls', '/secrets-broker/operational-controls'],
+    ['provider-connections', '/secrets-broker/provider-connections'],
+    ['single-secret-reveal', '/secrets-broker/single-reveal'],
+    ['backup-keys', '/secrets-broker/backup-keys'],
+    ['workflow-authoring-boundary', '/secrets-broker/workflow-boundaries'],
+    ['secrets-topology', '/secrets-broker/topology'],
+    ['audit-events', '/secrets-broker/audit-events'],
+    ['diagnostics', '/secrets-broker/diagnostics'],
+  ])('routes legacy #%s hash to %s', async (hash, path) => {
+    const { router } = await renderRoute(`/secrets-broker#${hash}`)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(path)
+    })
   })
 
   it('links source configuration actions to the dedicated configuration page', async () => {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -59,6 +59,7 @@ import { Route as AuthenticatedSecretsBrokerSecretsRouteImport } from './routes/
 import { Route as AuthenticatedSecretsBrokerSecretInventoryRouteImport } from './routes/_authenticated/secrets-broker/secret-inventory'
 import { Route as AuthenticatedSecretsBrokerProviderConnectionsRouteImport } from './routes/_authenticated/secrets-broker/provider-connections'
 import { Route as AuthenticatedSecretsBrokerPolicySimulationRouteImport } from './routes/_authenticated/secrets-broker/policy-simulation'
+import { Route as AuthenticatedSecretsBrokerOperationalControlsRouteImport } from './routes/_authenticated/secrets-broker/operational-controls'
 import { Route as AuthenticatedSecretsBrokerDiagnosticsRouteImport } from './routes/_authenticated/secrets-broker/diagnostics'
 import { Route as AuthenticatedSecretsBrokerConfigurationRouteImport } from './routes/_authenticated/secrets-broker/configuration'
 import { Route as AuthenticatedSecretsBrokerBackupKeysRouteImport } from './routes/_authenticated/secrets-broker/backup-keys'
@@ -341,6 +342,12 @@ const AuthenticatedSecretsBrokerPolicySimulationRoute =
     path: '/secrets-broker/policy-simulation',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedSecretsBrokerOperationalControlsRoute =
+  AuthenticatedSecretsBrokerOperationalControlsRouteImport.update({
+    id: '/secrets-broker/operational-controls',
+    path: '/secrets-broker/operational-controls',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedSecretsBrokerDiagnosticsRoute =
   AuthenticatedSecretsBrokerDiagnosticsRouteImport.update({
     id: '/secrets-broker/diagnostics',
@@ -398,6 +405,7 @@ export interface FileRoutesByFullPath {
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/secrets-broker/operational-controls': typeof AuthenticatedSecretsBrokerOperationalControlsRoute
   '/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
   '/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
@@ -452,6 +460,7 @@ export interface FileRoutesByTo {
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/secrets-broker/operational-controls': typeof AuthenticatedSecretsBrokerOperationalControlsRoute
   '/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
   '/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
@@ -511,6 +520,7 @@ export interface FileRoutesById {
   '/_authenticated/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
   '/_authenticated/secrets-broker/configuration': typeof AuthenticatedSecretsBrokerConfigurationRoute
   '/_authenticated/secrets-broker/diagnostics': typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  '/_authenticated/secrets-broker/operational-controls': typeof AuthenticatedSecretsBrokerOperationalControlsRoute
   '/_authenticated/secrets-broker/policy-simulation': typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   '/_authenticated/secrets-broker/provider-connections': typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
   '/_authenticated/secrets-broker/secret-inventory': typeof AuthenticatedSecretsBrokerSecretInventoryRoute
@@ -568,6 +578,7 @@ export interface FileRouteTypes {
     | '/secrets-broker/backup-keys'
     | '/secrets-broker/configuration'
     | '/secrets-broker/diagnostics'
+    | '/secrets-broker/operational-controls'
     | '/secrets-broker/policy-simulation'
     | '/secrets-broker/provider-connections'
     | '/secrets-broker/secret-inventory'
@@ -622,6 +633,7 @@ export interface FileRouteTypes {
     | '/secrets-broker/backup-keys'
     | '/secrets-broker/configuration'
     | '/secrets-broker/diagnostics'
+    | '/secrets-broker/operational-controls'
     | '/secrets-broker/policy-simulation'
     | '/secrets-broker/provider-connections'
     | '/secrets-broker/secret-inventory'
@@ -680,6 +692,7 @@ export interface FileRouteTypes {
     | '/_authenticated/secrets-broker/backup-keys'
     | '/_authenticated/secrets-broker/configuration'
     | '/_authenticated/secrets-broker/diagnostics'
+    | '/_authenticated/secrets-broker/operational-controls'
     | '/_authenticated/secrets-broker/policy-simulation'
     | '/_authenticated/secrets-broker/provider-connections'
     | '/_authenticated/secrets-broker/secret-inventory'
@@ -1083,6 +1096,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSecretsBrokerPolicySimulationRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/secrets-broker/operational-controls': {
+      id: '/_authenticated/secrets-broker/operational-controls'
+      path: '/secrets-broker/operational-controls'
+      fullPath: '/secrets-broker/operational-controls'
+      preLoaderRoute: typeof AuthenticatedSecretsBrokerOperationalControlsRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/secrets-broker/diagnostics': {
       id: '/_authenticated/secrets-broker/diagnostics'
       path: '/secrets-broker/diagnostics'
@@ -1160,6 +1180,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSecretsBrokerBackupKeysRoute: typeof AuthenticatedSecretsBrokerBackupKeysRoute
   AuthenticatedSecretsBrokerConfigurationRoute: typeof AuthenticatedSecretsBrokerConfigurationRoute
   AuthenticatedSecretsBrokerDiagnosticsRoute: typeof AuthenticatedSecretsBrokerDiagnosticsRoute
+  AuthenticatedSecretsBrokerOperationalControlsRoute: typeof AuthenticatedSecretsBrokerOperationalControlsRoute
   AuthenticatedSecretsBrokerPolicySimulationRoute: typeof AuthenticatedSecretsBrokerPolicySimulationRoute
   AuthenticatedSecretsBrokerProviderConnectionsRoute: typeof AuthenticatedSecretsBrokerProviderConnectionsRoute
   AuthenticatedSecretsBrokerSecretInventoryRoute: typeof AuthenticatedSecretsBrokerSecretInventoryRoute
@@ -1202,6 +1223,8 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
     AuthenticatedSecretsBrokerConfigurationRoute,
   AuthenticatedSecretsBrokerDiagnosticsRoute:
     AuthenticatedSecretsBrokerDiagnosticsRoute,
+  AuthenticatedSecretsBrokerOperationalControlsRoute:
+    AuthenticatedSecretsBrokerOperationalControlsRoute,
   AuthenticatedSecretsBrokerPolicySimulationRoute:
     AuthenticatedSecretsBrokerPolicySimulationRoute,
   AuthenticatedSecretsBrokerProviderConnectionsRoute:

--- a/src/routes/_authenticated/secrets-broker/operational-controls.tsx
+++ b/src/routes/_authenticated/secrets-broker/operational-controls.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { SecretsBrokerSetupWizard } from '@/features/secrets-broker'
+
+export const Route = createFileRoute(
+  '/_authenticated/secrets-broker/operational-controls'
+)({
+  component: () => (
+    <SecretsBrokerSetupWizard focusSection='operational-controls' />
+  ),
+})

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -69,6 +69,11 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Sources',
   },
   {
+    path: '/secrets-broker/operational-controls',
+    heading: /^Secrets Broker operational controls$/i,
+    title: 'Service Admin - Secrets Broker Operational Controls',
+  },
+  {
     path: '/secrets-broker/provider-connections',
     heading: /^Secrets Broker provider connections$/i,
     title: 'Service Admin - Secrets Broker Provider Connections',

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -364,10 +364,7 @@ test.describe('Secrets Broker browser coverage', () => {
   }) => {
     const sections = [
       ['/secrets-broker/single-reveal', /Privileged single-secret reveal/i],
-      [
-        '/secrets-broker/operational-controls',
-        /Operational controls/i,
-      ],
+      ['/secrets-broker/operational-controls', /Operational controls/i],
       ['/secrets-broker/sources', /Secret Sources \/ Backends/i],
       ['/secrets-broker/provider-connections', /Provider Connections/i],
       ['/secrets-broker/backup-keys', /Backup, restore, and key management/i],

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -102,6 +102,7 @@ test.describe('Secrets Broker browser coverage', () => {
     const navLinks = [
       ['Overview / Setup', /\/secrets-broker$/],
       ['Secrets', /\/secrets-broker\/secrets$/],
+      ['Operational Controls', /\/secrets-broker\/operational-controls$/],
       ['Configuration', /\/secrets-broker\/configuration$/],
       ['Sources / Backends', /\/secrets-broker\/sources$/],
       ['Provider Connections', /\/secrets-broker\/provider-connections$/],
@@ -363,6 +364,10 @@ test.describe('Secrets Broker browser coverage', () => {
   }) => {
     const sections = [
       ['/secrets-broker/single-reveal', /Privileged single-secret reveal/i],
+      [
+        '/secrets-broker/operational-controls',
+        /Operational controls/i,
+      ],
       ['/secrets-broker/sources', /Secret Sources \/ Backends/i],
       ['/secrets-broker/provider-connections', /Provider Connections/i],
       ['/secrets-broker/backup-keys', /Backup, restore, and key management/i],


### PR DESCRIPTION
## Summary
- Adds a dedicated `/secrets-broker/operational-controls` route and sidebar item.
- Moves the operational controls panel out of the overview/setup route so the overview is not a catch-all page.
- Expands legacy hash redirects for formerly anchored sections to canonical sub-page routes.
- Updates route tree, unit route coverage, sidebar coverage, and Playwright Secrets Broker navigation/deep-link coverage.

## Validation
- `npm run build`
- `npm test -- src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx src/features/secrets-broker/secrets-broker-setup.test.tsx`
- `npx playwright test tests/ui/secrets-broker.spec.ts`
- `npm run lint` (passes with existing warnings in `src/features/logs/index.tsx`)
- `git diff --check`

## Demo
- Packaged local Service Admin artifact: `dist/@serviceadmin-win32.zip`.
- Recycled canonical demo with Service Admin installed from local artifact tag `issue-153-local`.
- Runtime: `http://192.168.1.53:17883/api/health` -> 200 ok.
- Service Admin: `http://192.168.1.53:17700/` -> 200.
- New route: `http://192.168.1.53:17700/secrets-broker/operational-controls` -> 200 app shell.

Fixes #153.