### PR TITLE
fix(ui): gate stub-only secret surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Current UI runtime behavior:
 - dashboard service status, health, runtime actions, and logs are read from the live Service Lasso runtime API by default
 - if `VITE_SERVICE_LASSO_API_BASE_URL` is set, API calls target that runtime URL
 - if `VITE_SERVICE_LASSO_API_BASE_URL` is missing, API calls use same-origin `/api/*` so packaged Service Admin can proxy to the runtime API
-- local dashboard stub data is available only in Vite development mode when `VITE_SERVICE_LASSO_ENABLE_STUB_DATA=true`
+- local dashboard, Secrets Broker preview, and Secret Inventory fixture data is available only in Vite development mode when `VITE_SERVICE_LASSO_ENABLE_STUB_DATA=true`
+- when that stub flag is absent or false, pages without a live API contract must render unavailable/setup-needed states instead of deterministic sample rows or stub controls
 - lifecycle and favorite changes are persisted in browser local storage during demo/stub development sessions
 - a missing, misconfigured, or unavailable runtime API is treated as an error instead of falling back to sample status
 - favorites editing is only enabled when `VITE_SERVICE_LASSO_FAVORITES_ENABLED=true`

--- a/src/features/secret-inventory/index.tsx
+++ b/src/features/secret-inventory/index.tsx
@@ -1,6 +1,7 @@
 import { getRouteApi } from '@tanstack/react-router'
 import { DatabaseZap, ShieldCheck } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
+import { isServiceAdminStubModeEnabled } from '@/lib/service-lasso-dashboard/stub'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import {
@@ -28,6 +29,7 @@ const route = getRouteApi('/_authenticated/secrets-broker/secret-inventory')
 export function SecretInventoryPage() {
   const search = route.useSearch()
   const navigate = route.useNavigate()
+  const stubModeEnabled = isServiceAdminStubModeEnabled()
   const counts = countSecretInventoryByState()
 
   usePageMetadata({
@@ -35,6 +37,62 @@ export function SecretInventoryPage() {
     description:
       'Metadata-only Secrets Broker inventory for refs, ownership, state, and rotation planning.',
   })
+
+  if (!stubModeEnabled) {
+    return (
+      <>
+        <Header fixed>
+          <Search />
+          <div className='ms-auto flex items-center space-x-4'>
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
+        </Header>
+
+        <Main id='content' className='space-y-6'>
+          <div className='flex flex-wrap items-start justify-between gap-4'>
+            <div>
+              <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+                <DatabaseZap className='size-5' /> Secret inventory
+              </h1>
+              <p className='mt-1 text-muted-foreground'>
+                Advanced Secrets Broker planning view for ref metadata,
+                ownership, state, expiry, and rotation readiness.
+              </p>
+            </div>
+            <Badge variant='outline'>Live API required</Badge>
+          </div>
+
+          <Alert>
+            <ShieldCheck className='size-4' />
+            <AlertTitle>Secret inventory unavailable</AlertTitle>
+            <AlertDescription>
+              No local sample metadata is rendered because Service Admin stub
+              mode is disabled. Connect a live inventory API or enable the
+              explicit local developer stub flag for fixture previews.
+            </AlertDescription>
+          </Alert>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Metadata table unavailable</CardTitle>
+              <CardDescription>
+                The live inventory API is not connected in this UI build, so
+                local fixture rows and planning-only sample metadata stay hidden
+                by default.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='flex flex-wrap gap-2 text-sm text-muted-foreground'>
+              <Badge variant='outline'>No fixture rows</Badge>
+              <Badge variant='outline'>No sample metadata</Badge>
+              <Badge variant='outline'>No privileged actions</Badge>
+            </CardContent>
+          </Card>
+        </Main>
+      </>
+    )
+  }
 
   return (
     <>

--- a/src/features/secret-inventory/secret-inventory.test.tsx
+++ b/src/features/secret-inventory/secret-inventory.test.tsx
@@ -10,6 +10,23 @@ import {
 } from './secret-inventory'
 
 describe('secret inventory metadata view', () => {
+  it('hides deterministic fixture metadata when stub mode is disabled', async () => {
+    await renderRoute('/secrets-broker/secret-inventory', { stubData: false })
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secret inventory$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Secret inventory unavailable/i)).toBeVisible()
+    expect(screen.getByText(/No fixture rows/i)).toBeVisible()
+    expect(
+      screen.queryByText(/Deterministic local fixture/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('local/serviceadmin')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('secret://local/serviceadmin/session-signing')
+    ).not.toBeInTheDocument()
+  })
+
   it('renders deterministic local fixture metadata without plaintext controls', async () => {
     await renderRoute('/secrets-broker/secret-inventory')
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
+import { isServiceAdminStubModeEnabled } from '@/lib/service-lasso-dashboard/stub'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -62,6 +63,7 @@ const stateVariant: Record<
 }
 
 export function SecretsManagementPage() {
+  const stubModeEnabled = isServiceAdminStubModeEnabled()
   const [metadataQuery, setMetadataQuery] = useState('')
   const [stateFilter, setStateFilter] = useState<ManagedSecretState | 'all'>(
     'all'
@@ -126,6 +128,63 @@ export function SecretsManagementPage() {
       ),
     [bulkOperation, bulkSelectedIds]
   )
+
+  if (!stubModeEnabled) {
+    return (
+      <>
+        <Header fixed>
+          <Search />
+          <div className='ms-auto flex items-center space-x-4'>
+            <ThemeSwitch />
+            <ConfigDrawer />
+            <ProfileDropdown />
+          </div>
+        </Header>
+
+        <Main id='content' className='space-y-6'>
+          <div className='flex flex-wrap items-start justify-between gap-4'>
+            <div>
+              <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+                <DatabaseZap className='size-5' /> Secrets
+              </h1>
+              <p className='mt-1 text-muted-foreground'>
+                Secrets Broker management table for safe metadata search,
+                controlled reveal entry, and dry-run edit/reset/delete/policy
+                actions. Rows never render raw secret values.
+              </p>
+            </div>
+            <Badge variant='outline'>Live API required</Badge>
+          </div>
+
+          <Alert>
+            <ShieldCheck className='size-4' />
+            <AlertTitle>Secrets Broker API unavailable</AlertTitle>
+            <AlertDescription>
+              No local stub data is rendered because Service Admin stub mode is
+              disabled. Connect a live Secrets Broker API or enable the explicit
+              local developer stub flag for fixture previews.
+            </AlertDescription>
+          </Alert>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Secrets management unavailable</CardTitle>
+              <CardDescription>
+                The production mutation contract is not connected in this UI
+                build, so fixture rows, stub previews, and simulated apply
+                controls stay hidden by default.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className='flex flex-wrap gap-2 text-sm text-muted-foreground'>
+              <Badge variant='outline'>No fixture rows</Badge>
+              <Badge variant='outline'>No simulated mutations</Badge>
+              <Badge variant='outline'>No raw values</Badge>
+            </CardContent>
+          </Card>
+        </Main>
+      </>
+    )
+  }
 
   function chooseAction(rowId: string, action: ManagedSecretAction) {
     setSelectedRowId(rowId)

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -14,6 +14,23 @@ import {
 } from './secrets-management'
 
 describe('Secrets Broker secrets management page', () => {
+  it('hides stub previews and fixture rows when stub mode is disabled', async () => {
+    await renderRoute('/secrets-broker/secrets', { stubData: false })
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Secrets Broker API unavailable/i)).toBeVisible()
+    expect(screen.getByText(/No fixture rows/i)).toBeVisible()
+    expect(
+      screen.queryByText(/Stub update\/reset\/delete\/reveal API preview/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/SESSION_SIGNING_KEY/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /Simulate stub apply/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('renders the Secrets sub-page table with metadata rows and no raw values', async () => {
     await renderRoute('/secrets-broker/secrets')
 

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -16,6 +16,13 @@ export const stubDashboardDataEnabled =
   import.meta.env.DEV &&
   import.meta.env.VITE_SERVICE_LASSO_ENABLE_STUB_DATA === 'true'
 
+export function isServiceAdminStubModeEnabled() {
+  return (
+    import.meta.env.DEV &&
+    import.meta.env.VITE_SERVICE_LASSO_ENABLE_STUB_DATA === 'true'
+  )
+}
+
 export const favoritesFeatureEnabled =
   import.meta.env.VITE_SERVICE_LASSO_FAVORITES_ENABLED === 'true'
 

--- a/src/test/render-route.tsx
+++ b/src/test/render-route.tsx
@@ -11,8 +11,18 @@ import { DirectionProvider } from '@/context/direction-provider'
 import { FontProvider } from '@/context/font-provider'
 import { ThemeProvider } from '@/context/theme-provider'
 
-export async function renderRoute(path: string) {
-  vi.stubEnv('VITE_SERVICE_LASSO_ENABLE_STUB_DATA', 'true')
+type RenderRouteOptions = {
+  stubData?: boolean
+}
+
+export async function renderRoute(
+  path: string,
+  options: RenderRouteOptions = {}
+) {
+  vi.stubEnv(
+    'VITE_SERVICE_LASSO_ENABLE_STUB_DATA',
+    options.stubData === false ? 'false' : 'true'
+  )
 
   const queryClient = new QueryClient({
     defaultOptions: {


### PR DESCRIPTION
## Issue
Closes #165

## Summary
- Adds a central Service Admin stub-mode helper for route surfaces that need runtime fixture gating.
- Hides Secrets Broker Secrets stub mutation previews and fixture rows when `VITE_SERVICE_LASSO_ENABLE_STUB_DATA` is absent or false.
- Hides Secret Inventory deterministic fixture metadata when stub mode is absent or false.
- Keeps existing local/admin fixture behavior available when explicit stub mode is enabled.
- Documents the no-stubs-by-default rule in the README.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-management.test.tsx src/features/secret-inventory/secret-inventory.test.tsx` -> 14 passed.
- PASS `npm run build`.
- PASS `npm run lint` with 3 existing warnings in `src/features/logs/index.tsx`.
- PASS `git diff --check`.

## Demo / Deployment Evidence
- Packaged local win32 artifact: `dist/@serviceadmin-win32.zip`.
- Local-artifact recycle to `issue-165-local` completed with endpoints healthy during the recycle: `.work-agent/logs/issue-165/20260612-003611-demo-recycle-local-artifact.log`.
- Restoring the temporary canonical manifest override caused the runtime to reload `@serviceadmin` as not installed/running, so the demo was recovered to the canonical release artifact for safety.
- Canonical release recovery passed verifier and LAN checks: `.work-agent/logs/issue-165/20260612-003722-demo-recover-verify.log`, `.work-agent/logs/issue-165/20260612-003722-demo-recover-lan.log`.

## Follow-up Required
- Review the local-artifact canonical demo deployment flow before merge/closure. The code validation passed, but the updated branch artifact is not the currently persisted canonical demo after manifest restoration.