### PR TITLE
feat(#155): tighten service routes inventory

### DIFF
--- a/src/features/service-routes/index.tsx
+++ b/src/features/service-routes/index.tsx
@@ -13,7 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { ExternalLink, ShieldCheck } from 'lucide-react'
+import { ExternalLink, ShieldAlert, ShieldCheck } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import type {
@@ -56,11 +56,16 @@ type ServiceRouteRow = {
   serviceStatus: DashboardService['status']
   routeLabel: string
   url: string
+  routeHost: string
+  routePath: string
   bind: string
   port: number
   protocol: ServiceEndpoint['protocol']
   exposure: ServiceEndpoint['exposure']
-  routeKind: 'Local' | 'LAN' | 'Traefik / public'
+  provider: 'Service Lasso runtime' | 'Traefik'
+  routeState: 'Active' | 'Degraded' | 'Invalid route' | 'Unavailable'
+  configSource: string
+  target: string
   searchText: string
 }
 
@@ -71,22 +76,64 @@ const statusLabels: Record<DashboardService['status'], string> = {
   stopped: 'Stopped',
 }
 
-const exposureLabels: Record<ServiceEndpoint['exposure'], string> = {
-  lan: 'LAN',
-  local: 'Local',
-  public: 'Public',
+const routeStateLabels: Record<ServiceRouteRow['routeState'], string> = {
+  Active: 'Active',
+  Degraded: 'Degraded',
+  'Invalid route': 'Invalid route',
+  Unavailable: 'Unavailable',
 }
 
-function routeKindForExposure(exposure: ServiceEndpoint['exposure']) {
-  if (exposure === 'public') return 'Traefik / public'
-  if (exposure === 'lan') return 'LAN'
-  return 'Local'
+function providerForExposure(exposure: ServiceEndpoint['exposure']) {
+  return exposure === 'public' ? 'Traefik' : 'Service Lasso runtime'
+}
+
+function routeStateForEndpoint(
+  serviceStatus: DashboardService['status'],
+  hasValidUrl: boolean
+): ServiceRouteRow['routeState'] {
+  if (!hasValidUrl) return 'Invalid route'
+  if (serviceStatus === 'degraded') return 'Degraded'
+  if (serviceStatus === 'stopped') return 'Unavailable'
+  return 'Active'
+}
+
+function parseRouteUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    const routePath = `${parsed.pathname || '/'}${parsed.search}`
+
+    return {
+      hasValidUrl: true,
+      routeHost: parsed.host,
+      routePath,
+    }
+  } catch {
+    return {
+      hasValidUrl: false,
+      routeHost: 'Invalid URL',
+      routePath: '-',
+    }
+  }
+}
+
+function fileNameFromPath(path?: string) {
+  if (!path) return 'Runtime metadata'
+
+  const parts = path.split(/[\\/]/).filter(Boolean)
+  const fileName = parts[parts.length - 1]
+
+  return fileName ? `${fileName} via runtime metadata` : 'Runtime metadata'
 }
 
 function buildServiceRouteRows(services: DashboardService[]) {
   return services.flatMap((service) =>
     service.endpoints.map((endpoint) => {
-      const routeKind = routeKindForExposure(endpoint.exposure)
+      const provider = providerForExposure(endpoint.exposure)
+      const parsedRoute = parseRouteUrl(endpoint.url)
+      const routeState = routeStateForEndpoint(
+        service.status,
+        parsedRoute.hasValidUrl
+      )
       const row: ServiceRouteRow = {
         id: `${service.id}:${endpoint.label}:${endpoint.url}`,
         serviceId: service.id,
@@ -94,11 +141,16 @@ function buildServiceRouteRows(services: DashboardService[]) {
         serviceStatus: service.status,
         routeLabel: endpoint.label,
         url: endpoint.url,
+        routeHost: parsedRoute.routeHost,
+        routePath: parsedRoute.routePath,
         bind: endpoint.bind,
         port: endpoint.port,
         protocol: endpoint.protocol,
         exposure: endpoint.exposure,
-        routeKind,
+        provider,
+        routeState,
+        configSource: fileNameFromPath(service.metadata.configPath),
+        target: `${service.id}:${endpoint.port}`,
         searchText: '',
       }
 
@@ -109,11 +161,16 @@ function buildServiceRouteRows(services: DashboardService[]) {
           service.name,
           endpoint.label,
           endpoint.url,
+          parsedRoute.routeHost,
+          parsedRoute.routePath,
           endpoint.bind,
           endpoint.port,
           endpoint.protocol,
           endpoint.exposure,
-          routeKind,
+          provider,
+          routeState,
+          row.configSource,
+          row.target,
         ]
           .join(' ')
           .toLowerCase(),
@@ -156,6 +213,27 @@ function ExposureBadge({
   return <Badge variant='outline'>Local</Badge>
 }
 
+function RouteStateBadge({ state }: { state: ServiceRouteRow['routeState'] }) {
+  if (state === 'Active') {
+    return <Badge className='bg-emerald-600 hover:bg-emerald-600'>Active</Badge>
+  }
+
+  if (state === 'Degraded') {
+    return <Badge variant='secondary'>Degraded</Badge>
+  }
+
+  if (state === 'Invalid route') {
+    return (
+      <Badge variant='destructive' className='gap-1'>
+        <ShieldAlert className='size-3' />
+        Invalid route
+      </Badge>
+    )
+  }
+
+  return <Badge variant='outline'>Unavailable</Badge>
+}
+
 const serviceRouteColumns: ColumnDef<ServiceRouteRow>[] = [
   {
     accessorKey: 'serviceName',
@@ -187,52 +265,82 @@ const serviceRouteColumns: ColumnDef<ServiceRouteRow>[] = [
       <div className='flex min-w-0 flex-col gap-1'>
         <span className='font-medium'>{row.original.routeLabel}</span>
         <span className='text-xs text-muted-foreground'>
-          {row.original.routeKind}
+          {row.original.protocol.toUpperCase()} / {row.original.exposure}
         </span>
       </div>
     ),
   },
   {
+    accessorKey: 'routeHost',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Host / path' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex min-w-0 flex-col gap-1'>
+        <LongText className='font-mono text-xs'>
+          {row.original.routeHost}
+        </LongText>
+        <LongText className='font-mono text-xs text-muted-foreground'>
+          {row.original.routePath}
+        </LongText>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'target',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Target' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex min-w-0 flex-col gap-1'>
+        <code className='rounded bg-muted px-1.5 py-0.5 text-xs'>
+          {row.original.target}
+        </code>
+        <span className='text-xs text-muted-foreground'>
+          {row.original.bind}:{row.original.port}
+        </span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'routeState',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Routing' />
+    ),
+    cell: ({ row }) => <RouteStateBadge state={row.original.routeState} />,
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
     accessorKey: 'serviceStatus',
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Status' />
+      <DataTableColumnHeader column={column} title='Service status' />
     ),
     cell: ({ row }) => <StatusBadge status={row.original.serviceStatus} />,
     filterFn: (row, id, value) => value.includes(row.getValue(id)),
   },
   {
-    accessorKey: 'protocol',
+    accessorKey: 'provider',
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Protocol' />
-    ),
-    cell: ({ row }) => row.original.protocol.toUpperCase(),
-    filterFn: (row, id, value) => value.includes(row.getValue(id)),
-  },
-  {
-    accessorKey: 'bind',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Bind' />
+      <DataTableColumnHeader column={column} title='Provider' />
     ),
     cell: ({ row }) => (
-      <code className='rounded bg-muted px-1.5 py-0.5 text-xs'>
-        {row.original.bind}
-      </code>
+      <div className='flex flex-col gap-1'>
+        <span>{row.original.provider}</span>
+        <ExposureBadge exposure={row.original.exposure} />
+      </div>
     ),
-  },
-  {
-    accessorKey: 'port',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Port' />
-    ),
-    cell: ({ row }) => row.original.port,
-  },
-  {
-    accessorKey: 'exposure',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Exposure' />
-    ),
-    cell: ({ row }) => <ExposureBadge exposure={row.original.exposure} />,
     filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'configSource',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Config source' />
+    ),
+    cell: ({ row }) => (
+      <LongText className='text-sm text-muted-foreground'>
+        {row.original.configSource}
+      </LongText>
+    ),
   },
   {
     accessorKey: 'url',
@@ -297,9 +405,9 @@ function ServiceRoutesTable({ rows }: { rows: ServiceRouteRow[] }) {
     pagination: { defaultPage: 1, defaultPageSize: 10 },
     globalFilter: { key: 'route' },
     columnFilters: [
+      { columnId: 'routeState', searchKey: 'routing', type: 'array' },
       { columnId: 'serviceStatus', searchKey: 'status', type: 'array' },
-      { columnId: 'protocol', searchKey: 'protocol', type: 'array' },
-      { columnId: 'exposure', searchKey: 'exposure', type: 'array' },
+      { columnId: 'provider', searchKey: 'provider', type: 'array' },
     ],
   })
 
@@ -340,6 +448,14 @@ function ServiceRoutesTable({ rows }: { rows: ServiceRouteRow[] }) {
         searchPlaceholder='Search services, URLs, binds, ports, and route labels...'
         filters={[
           {
+            columnId: 'routeState',
+            title: 'Routing',
+            options: Object.entries(routeStateLabels).map(([value, label]) => ({
+              value,
+              label,
+            })),
+          },
+          {
             columnId: 'serviceStatus',
             title: 'Status',
             options: Object.entries(statusLabels).map(([value, label]) => ({
@@ -348,21 +464,15 @@ function ServiceRoutesTable({ rows }: { rows: ServiceRouteRow[] }) {
             })),
           },
           {
-            columnId: 'protocol',
-            title: 'Protocol',
+            columnId: 'provider',
+            title: 'Provider',
             options: [
-              { label: 'HTTP', value: 'http' },
-              { label: 'HTTPS', value: 'https' },
-              { label: 'TCP', value: 'tcp' },
+              {
+                label: 'Service Lasso runtime',
+                value: 'Service Lasso runtime',
+              },
+              { label: 'Traefik', value: 'Traefik' },
             ],
-          },
-          {
-            columnId: 'exposure',
-            title: 'Exposure',
-            options: Object.entries(exposureLabels).map(([value, label]) => ({
-              value,
-              label,
-            })),
           },
         ]}
       />
@@ -419,7 +529,9 @@ function ServiceRoutesTable({ rows }: { rows: ServiceRouteRow[] }) {
                   colSpan={serviceRouteColumns.length}
                   className='h-24 text-center'
                 >
-                  No service routes match the current filters.
+                  {rows.length === 0
+                    ? 'No routes are available from runtime metadata.'
+                    : 'No service routes match the current filters.'}
                 </TableCell>
               </TableRow>
             )}

--- a/src/features/service-routes/service-routes.test.tsx
+++ b/src/features/service-routes/service-routes.test.tsx
@@ -1,31 +1,74 @@
 import { renderRoute } from '@/test/render-route'
 import { screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+
+const routeService = (overrides: Partial<DashboardService>): DashboardService =>
+  ({
+    id: '@traefik',
+    name: 'Traefik',
+    status: 'running',
+    favorite: true,
+    note: 'Ingress is healthy.',
+    installed: true,
+    role: 'Edge router',
+    links: [],
+    runtimeHealth: {
+      state: 'running',
+      health: 'healthy',
+      uptime: '4d',
+      lastCheckAt: '2026-06-12T05:00:00Z',
+      summary: 'Healthy',
+    },
+    endpoints: [
+      {
+        label: 'Local dashboard',
+        url: 'https://traefik.localtest.me/dashboard',
+        bind: '127.0.0.1',
+        port: 443,
+        protocol: 'https',
+        exposure: 'public',
+      },
+    ],
+    metadata: {
+      serviceType: 'core-platform',
+      runtime: 'docker',
+      version: 'v3.1.2',
+      build: 'sha256:traefik-demo',
+      configPath: 'C:\\service-lasso\\traefik\\traefik.yml',
+    },
+    dependencies: [],
+    dependents: [],
+    environmentVariables: [
+      {
+        key: 'SESSION_SECRET',
+        value: 'secret://services/admin/session',
+        secret: true,
+        scope: 'service',
+        source: '@secretsbroker/local/default',
+      },
+    ],
+    recentLogs: [],
+    actions: [],
+    ...overrides,
+  }) satisfies DashboardService
+
+const mockState = vi.hoisted(() => ({
+  services: [] as DashboardService[],
+}))
 
 vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
   useServices: () => ({
-    data: [
-      {
-        id: '@traefik',
-        name: 'Traefik',
-        status: 'running',
-        endpoints: [
-          {
-            label: 'Local dashboard',
-            url: 'https://traefik.localtest.me',
-            bind: '127.0.0.1',
-            port: 443,
-            protocol: 'https',
-            exposure: 'public',
-          },
-        ],
-      },
-    ],
+    data: mockState.services,
     isLoading: false,
   }),
 }))
 
 describe('service routes page', () => {
+  beforeEach(() => {
+    mockState.services = [routeService({})]
+  })
+
   it('renders service endpoint inventory without secret material', async () => {
     await renderRoute('/service-routes')
 
@@ -38,12 +81,87 @@ describe('service routes page', () => {
     expect(screen.queryByText('Route inventory')).not.toBeInTheDocument()
     expect(screen.queryByText('LAN routes')).not.toBeInTheDocument()
     expect(screen.queryByText('Local endpoints')).not.toBeInTheDocument()
-    expect(screen.getByRole('columnheader', { name: /service/i })).toBeVisible()
-    expect(screen.getByRole('columnheader', { name: /route/i })).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /^service$/i })
+    ).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /^route$/i })).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /host \/ path/i })
+    ).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /target/i })).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /config source/i })
+    ).toBeVisible()
     expect(screen.getByRole('columnheader', { name: /url/i })).toBeVisible()
     expect(screen.getByText('Local dashboard')).toBeVisible()
-    expect(screen.getByText('https://traefik.localtest.me')).toBeVisible()
+    expect(screen.getByText('traefik.localtest.me')).toBeVisible()
+    expect(screen.getByText('/dashboard')).toBeVisible()
+    expect(screen.getByText('@traefik:443')).toBeVisible()
+    expect(screen.getByText('127.0.0.1:443')).toBeVisible()
+    expect(screen.getAllByText('Traefik')).toHaveLength(2)
+    expect(screen.getByText('traefik.yml via runtime metadata')).toBeVisible()
+    expect(
+      screen.getByText('https://traefik.localtest.me/dashboard')
+    ).toBeVisible()
     expect(screen.queryByText(/secret:\/\//i)).not.toBeInTheDocument()
     expect(screen.queryByText(/SESSION_SECRET/i)).not.toBeInTheDocument()
+  })
+
+  it('renders an empty route inventory state', async () => {
+    mockState.services = [routeService({ endpoints: [] })]
+
+    await renderRoute('/service-routes')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No routes are available from runtime metadata.')
+      ).toBeVisible()
+    })
+  })
+
+  it('marks invalid and unavailable route rows safely', async () => {
+    mockState.services = [
+      routeService({
+        id: '@invalid',
+        name: 'Broken route',
+        status: 'degraded',
+        endpoints: [
+          {
+            label: 'Broken public route',
+            url: 'not a route url',
+            bind: '0.0.0.0',
+            port: 17700,
+            protocol: 'http',
+            exposure: 'public',
+          },
+        ],
+      }),
+      routeService({
+        id: 'dagu',
+        name: 'Dagu',
+        status: 'stopped',
+        endpoints: [
+          {
+            label: 'Workflow UI',
+            url: 'http://localhost:8082',
+            bind: '127.0.0.1',
+            port: 8082,
+            protocol: 'http',
+            exposure: 'local',
+          },
+        ],
+      }),
+    ]
+
+    await renderRoute('/service-routes')
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid URL')).toBeVisible()
+    })
+
+    expect(screen.getByText('Invalid route')).toBeVisible()
+    expect(screen.getByText('Unavailable')).toBeVisible()
+    expect(screen.getByText('Service Lasso runtime')).toBeVisible()
+    expect(screen.queryByText(/secret:\/\//i)).not.toBeInTheDocument()
   })
 })

--- a/src/routes/_authenticated/service-routes/index.tsx
+++ b/src/routes/_authenticated/service-routes/index.tsx
@@ -6,9 +6,9 @@ const serviceRoutesSearchSchema = z.object({
   page: z.number().optional().catch(undefined),
   pageSize: z.number().optional().catch(undefined),
   route: z.string().optional().catch(''),
+  routing: z.array(z.string()).optional().catch(undefined),
   status: z.array(z.string()).optional().catch(undefined),
-  protocol: z.array(z.string()).optional().catch(undefined),
-  exposure: z.array(z.string()).optional().catch(undefined),
+  provider: z.array(z.string()).optional().catch(undefined),
 })
 
 export const Route = createFileRoute('/_authenticated/service-routes/')({


### PR DESCRIPTION
## Summary
- tightens the existing Service Routes page into a route inventory table with host/path, target, provider, routing state, config-source, and URL metadata
- derives invalid/unavailable routing states from endpoint URL validity and service state without rendering secret-bearing environment values
- updates route search params and focused tests for rendered rows, empty metadata, invalid route, unavailable route, and redaction boundaries

## Validation
- `npm run test:unit -- src/features/service-routes/service-routes.test.tsx` -> 3 passed
- `npm run test:unit -- src/test/app-screens.test.tsx src/features/service-routes/service-routes.test.tsx` -> 36 passed
- `npm run build` -> passed, existing Vite chunk-size/deprecated esbuild warnings only
- `npm run lint` -> passed with existing warnings in `src/features/logs/index.tsx`
- `npm run format:check` -> passed
- `git diff --check` -> passed

## Canonical demo
- Recycled canonical demo after packaging `dist/@serviceadmin-win32.zip`
- Artifact tag: `issue-155-4f5af7a183a0`
- SHA256: `10e5a9fb79830a27d8bb25d198ddf6ca0db1de2c5c721121f3f47c4fc717471a`
- Runtime installed artifact checksum expected/actual match
- Verified LAN URLs:
  - `http://192.168.1.53:17700/` -> 200
  - `http://192.168.1.53:17700/service-routes` -> 200
  - `http://192.168.1.53:17883/api/health` -> 200 ok
  - `http://192.168.1.53:17883/api/services/%40serviceadmin` -> 200, running=true, healthy=true

Closes #155