### PR TITLE
fix(secretsbroker): compact operator pages

### DIFF
--- a/src/features/secrets-broker/provider-configuration-page.tsx
+++ b/src/features/secrets-broker/provider-configuration-page.tsx
@@ -7,7 +7,6 @@ import {
   Wrench,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -76,6 +75,7 @@ export function ProviderConfigurationPage() {
     () => migration.applyEnabled && confirmed && auditReason.trim().length > 0,
     [auditReason, confirmed, migration.applyEnabled]
   )
+  const applyGateLabel = applyAllowed ? 'Ready' : 'Locked'
 
   return (
     <>
@@ -95,25 +95,43 @@ export function ProviderConfigurationPage() {
               <Wrench className='size-5' /> Configuration
             </h1>
             <p className='mt-1 text-muted-foreground'>
-              Configure a Secrets Broker provider and migrate existing refs with
-              safe handles, metadata-only dry-runs, and explicit audit-gated
-              apply. Provider credentials and raw secret values are never
-              rendered.
+              Configure provider handles, validate capability, and dry-run ref
+              migration.
             </p>
           </div>
           <Badge variant='secondary'>Handles only · dry-run first</Badge>
         </div>
 
-        <Alert>
-          <ShieldCheck className='size-4' />
-          <AlertTitle>Provider setup stays secret-safe</AlertTitle>
-          <AlertDescription>
-            This screen models the #36 backend contract: provider capabilities,
-            config status, validation, migration dry-run, and apply responses
-            use safe metadata only. Apply remains disabled until confirmation,
-            operation id, and audit reason are present.
-          </AlertDescription>
-        </Alert>
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <ShieldCheck className='size-4' /> Operator queue
+            </CardTitle>
+            <CardDescription>
+              Provider changes are handle-based and apply-gated.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 md:grid-cols-3'>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Validate provider</div>
+              <div className='text-muted-foreground'>
+                Check capability, auth, namespaces, and source status.
+              </div>
+            </div>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Review migration plan</div>
+              <div className='text-muted-foreground'>
+                Inspect refs, risk, policy, recovery, and item outcomes.
+              </div>
+            </div>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Unlock apply</div>
+              <div className='text-muted-foreground'>
+                Confirmation and audit reason are required before apply.
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         <div className='grid gap-4 md:grid-cols-4'>
           <Card>
@@ -152,8 +170,7 @@ export function ProviderConfigurationPage() {
               <KeyRound className='size-4' /> Provider configuration
             </CardTitle>
             <CardDescription>
-              Select safe provider states and validate configuration without
-              showing or persisting provider credential values.
+              Select provider state and validate safe connection handles.
             </CardDescription>
           </CardHeader>
           <CardContent className='grid gap-4 lg:grid-cols-3'>
@@ -232,7 +249,7 @@ export function ProviderConfigurationPage() {
               <DatabaseZap className='size-4' /> Capability summary
             </CardTitle>
             <CardDescription>
-              Safe capability metadata from the provider configuration contract.
+              Safe capability metadata from the configuration contract.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -255,9 +272,7 @@ export function ProviderConfigurationPage() {
               <GitBranch className='size-4' /> Migration dry-run / apply
             </CardTitle>
             <CardDescription>
-              Migration plans show refs, source/target provider ids, policy,
-              risk, expected action, audit requirement, and recovery guidance —
-              never raw secret values.
+              Review refs, provider targets, policy, risk, audit, and recovery.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4'>
@@ -383,17 +398,20 @@ export function ProviderConfigurationPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Safety boundaries</CardTitle>
+            <CardTitle>Guardrails</CardTitle>
             <CardDescription>
-              Guardrails for provider configuration and migration.
+              Boundaries enforced by this operator surface.
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
-              {configurationSafetyBoundaries.map((boundary) => (
-                <li key={boundary}>{boundary}</li>
-              ))}
-            </ul>
+          <CardContent className='flex flex-wrap gap-2'>
+            {configurationSafetyBoundaries.slice(0, 5).map((boundary) => (
+              <Badge key={boundary} variant='outline'>
+                {boundary}
+              </Badge>
+            ))}
+            <Badge variant={applyAllowed ? 'default' : 'secondary'}>
+              Apply gate: {applyGateLabel}
+            </Badge>
           </CardContent>
         </Card>
       </Main>

--- a/src/features/secrets-broker/provider-configuration.test.tsx
+++ b/src/features/secrets-broker/provider-configuration.test.tsx
@@ -16,16 +16,45 @@ describe('Secrets Broker provider configuration page', () => {
       await screen.findByRole('heading', { name: /^Configuration$/i })
     ).toBeVisible()
     expect(screen.getByText(/Handles only · dry-run first/i)).toBeVisible()
+    expect(screen.getByText(/Operator queue/i)).toBeVisible()
+    expect(screen.getByText(/Validate provider/i)).toBeVisible()
+    expect(screen.getByText(/Review migration plan/i)).toBeVisible()
+    expect(screen.getByText(/Unlock apply/i)).toBeVisible()
     expect(screen.getByText(/Current provider\/backend summary/i)).toBeVisible()
     expect(screen.getByText(/Credential values shown/i)).toBeVisible()
     expect(screen.getByText(/Migration dry-run \/ apply/i)).toBeVisible()
     expect(screen.getByText(/Provider credentials hidden/i)).toBeVisible()
+    expect(screen.getByText(/Guardrails/i)).toBeVisible()
+    expect(
+      screen.queryByText(/Provider setup stays secret-safe/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Safety boundaries$/i)).not.toBeInTheDocument()
     expect(
       screen.queryByText(/fixture-provider-credential-value/i)
     ).not.toBeInTheDocument()
     expect(
       screen.queryByText(/fixture-managed-secret-value/i)
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps first-screen controls task-oriented before setup prose', async () => {
+    await renderRoute('/secrets-broker/configuration')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Configuration$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Operator queue/i)).toBeVisible()
+    expect(screen.getByLabelText(/Provider state scenario/i)).toBeVisible()
+    expect(screen.getByLabelText(/Migration state scenario/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /Migration apply disabled until confirmation and audit reason/i,
+      })
+    ).toBeVisible()
+    expect(
+      screen.queryByText(/Provider setup stays secret-safe/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/^Safety boundaries$/i)).not.toBeInTheDocument()
   })
 
   it('covers provider validation states safely', async () => {

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -61,7 +61,6 @@ import {
   buildStubSecretMutationPreview,
   bulkSecretCampaignOperations,
   managedSecretRows,
-  managedSecretSafetyBoundaries,
   stubSecretMutationStates,
   valueSearchManagedSecrets,
   type BulkSecretCampaignOperation,
@@ -482,26 +481,44 @@ export function SecretsManagementPage() {
               <DatabaseZap className='size-5' /> Secrets
             </h1>
             <p className='mt-1 text-muted-foreground'>
-              Secrets Broker management table for safe metadata search,
-              controlled reveal entry, and dry-run edit/reset/delete/policy
-              actions. Rows never render raw secret values.
+              Search refs, review provider state, and launch dry-run actions
+              without raw values.
             </p>
           </div>
           <Badge variant='secondary'>Stub preview · values hidden</Badge>
         </div>
 
-        <Alert>
-          <ShieldCheck className='size-4' />
-          <AlertTitle>Controlled management surface</AlertTitle>
-          <AlertDescription>
-            Metadata search is local over safe refs and labels only.
-            Broker-backed value search, when supported, returns matching
-            refs/metadata only. Reveal delegates to the audited #38 pattern;
-            edit, reset, delete, and policy changes require dry-run/preview
-            before apply. The mutation API on this page is stubbed preview
-            behavior until the production Secrets Broker contract lands.
-          </AlertDescription>
-        </Alert>
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <ShieldCheck className='size-4' /> Operator queue
+            </CardTitle>
+            <CardDescription>
+              Current controls are metadata-first and dry-run gated.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className='grid gap-3 md:grid-cols-3'>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Find a ref</div>
+              <div className='text-muted-foreground'>
+                Use table search, filters, sorting, and pagination.
+              </div>
+            </div>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Pick row action</div>
+              <div className='text-muted-foreground'>
+                Reveal, edit, reset, delete, and policy actions open previews.
+              </div>
+            </div>
+            <div className='rounded-md border p-3 text-sm'>
+              <div className='font-medium'>Dry-run before apply</div>
+              <div className='text-muted-foreground'>
+                Apply stays locked without preview, audit reason, and
+                confirmation.
+              </div>
+            </div>
+          </CardContent>
+        </Card>
 
         <div className='grid gap-4 md:grid-cols-4'>
           <Card>
@@ -538,10 +555,8 @@ export function SecretsManagementPage() {
               <DatabaseZap className='size-4' /> Search and value-search posture
             </CardTitle>
             <CardDescription>
-              The management table uses the shared Service Admin table controls
-              for metadata search, state/provider filters, sorting, column
-              visibility, and pagination. Value search is explicitly
-              broker-backed and returns refs/metadata only when supported.
+              Table controls search safe metadata; value search returns
+              refs/metadata only when the broker supports it.
             </CardDescription>
           </CardHeader>
           <CardContent className='grid gap-4 lg:grid-cols-2'>
@@ -704,9 +719,8 @@ export function SecretsManagementPage() {
               <ListChecks className='size-4' /> Bulk campaign dry-run planner
             </CardTitle>
             <CardDescription>
-              Stage 1 campaign planning only. The plan evaluates selected refs,
-              capability, policy, risk, audit needs, and blockers without
-              reading or writing raw secret material.
+              Stage 1 planning only: selected refs become a metadata-only
+              capability, policy, risk, audit, and blocker plan.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4 text-sm'>
@@ -936,11 +950,9 @@ export function SecretsManagementPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Stub update/reset/delete/reveal API preview</CardTitle>
+            <CardTitle>Single-secret preview gate</CardTitle>
             <CardDescription>
-              Deterministic non-production status model for a single selected
-              secret. This previews the operator flow only; no secret material
-              is read, written, copied, exported, logged, or displayed.
+              Deterministic non-production status model for one selected ref.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4 text-sm'>
@@ -1080,18 +1092,17 @@ export function SecretsManagementPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Safety boundaries</CardTitle>
+            <CardTitle>Guardrails</CardTitle>
             <CardDescription>
-              Guardrails for this Secrets sub-page while the backend API
-              contract and single-connection workflows mature.
+              Boundaries enforced by this operator surface.
             </CardDescription>
           </CardHeader>
-          <CardContent>
-            <ul className='list-disc space-y-2 ps-5 text-sm text-muted-foreground'>
-              {managedSecretSafetyBoundaries.map((boundary) => (
-                <li key={boundary}>{boundary}</li>
-              ))}
-            </ul>
+          <CardContent className='flex flex-wrap gap-2'>
+            <Badge variant='outline'>No plaintext table editing</Badge>
+            <Badge variant='outline'>No copy/export</Badge>
+            <Badge variant='outline'>Dry-run first</Badge>
+            <Badge variant='outline'>Audit reason required</Badge>
+            <Badge variant='outline'>Raw values hidden</Badge>
           </CardContent>
         </Card>
       </Main>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -23,7 +23,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Secrets Broker API unavailable/i)).toBeVisible()
     expect(screen.getByText(/No fixture rows/i)).toBeVisible()
     expect(
-      screen.queryByText(/Stub update\/reset\/delete\/reveal API preview/i)
+      screen.queryByText(/Single-secret preview gate/i)
     ).not.toBeInTheDocument()
     expect(screen.queryByText(/SESSION_SIGNING_KEY/i)).not.toBeInTheDocument()
     expect(
@@ -37,12 +37,16 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       await screen.findByRole('heading', { name: /^Secrets$/i })
     ).toBeVisible()
-    expect(screen.getByText(/Secrets Broker management table/i)).toBeVisible()
+    expect(
+      screen.getByText(/Search refs, review provider state/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Operator queue/i)).toBeVisible()
+    expect(screen.getByText(/Find a ref/i)).toBeVisible()
+    expect(screen.getByText(/Pick row action/i)).toBeVisible()
+    expect(screen.getByText(/Dry-run before apply/i)).toBeVisible()
     expect(screen.getByText(/Visible values/i)).toBeVisible()
     expect(screen.getByText(/Stub preview · values hidden/i)).toBeVisible()
-    expect(
-      screen.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
-    ).toBeVisible()
+    expect(screen.getByText(/Single-secret preview gate/i)).toBeVisible()
     expect(screen.getAllByText(/Stub API · preview only/i)[0]).toBeVisible()
     expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
     expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
@@ -57,6 +61,26 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.queryByRole('button', { name: /Copy secret/i })
     ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Controlled management surface/i)).toBeNull()
+    expect(screen.queryByText(/^Safety boundaries$/i)).toBeNull()
+  })
+
+  it('keeps first-screen controls task-oriented before any long prose', async () => {
+    await renderRoute('/secrets-broker/secrets')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Operator queue/i)).toBeVisible()
+    expect(screen.getByPlaceholderText(/Search secret metadata/i)).toBeVisible()
+    expect(
+      screen.getAllByRole('button', { name: /Controlled reveal/i })[0]
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    ).toBeVisible()
+    expect(screen.queryByText(/Controlled management surface/i)).toBeNull()
+    expect(screen.queryByText(/^Safety boundaries$/i)).toBeNull()
   })
 
   it('filters metadata locally without value search or plaintext indexing', async () => {
@@ -190,10 +214,8 @@ describe('Secrets Broker secrets management page', () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')
 
-    expect(
-      screen.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
-    ).toBeVisible()
-    expect(screen.getByText(/audit reason required/i)).toBeVisible()
+    expect(screen.getByText(/Single-secret preview gate/i)).toBeVisible()
+    expect(screen.getAllByText(/audit reason required/i)[0]).toBeVisible()
     expect(
       screen.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeDisabled()

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -136,6 +136,10 @@ test.describe('Secrets Broker browser coverage', () => {
     await page.goto('/secrets-broker/secrets')
     await expectNoBlankScreen(page)
     await expect(page.getByRole('heading', { name: /^Secrets$/ })).toBeVisible()
+    await expect(page.getByText(/Operator queue/i)).toBeVisible()
+    await expect(page.getByText(/Find a ref/i)).toBeVisible()
+    await expect(page.getByText(/Pick row action/i)).toBeVisible()
+    await expect(page.getByText(/Dry-run before apply/i)).toBeVisible()
     await expect(page.getByText(/Stub preview · values hidden/i)).toBeVisible()
     await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
     await expect(page.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
@@ -184,10 +188,8 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/delete preview required before apply/i)
     ).toBeVisible()
 
-    await expect(
-      page.getByText(/Stub update\/reset\/delete\/reveal API preview/i)
-    ).toBeVisible()
-    await expect(page.getByText(/audit reason required/i)).toBeVisible()
+    await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
+    await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeDisabled()


### PR DESCRIPTION
## Issue
Closes #161

## Summary
- Replaced long docs-style alert/list blocks on Secrets and Configuration pages with compact operator queues, short status copy, and guardrail badges.
- Kept the Secrets table, dry-run planner, single-secret preview gate, and Configuration provider/migration controls as the primary page actions.
- Added unit and browser assertions that representative pages expose task controls without the older prose headings.

## Scope
- In scope: Service Admin Secrets Broker Secrets and Configuration operator surfaces plus focused tests.
- Out of scope: backend contract changes, real mutation apply behavior, navigation removals from #158, and broker API changes.

## Spec / contract / fixture impact
- Not required because this is UI information-architecture cleanup only; public API/schema/manifest semantics did not change.

## Nash invariant impact
- Invariant: no secret values/provider credentials in UI routes, logs, fixtures, or rendered surfaces.
- Preservation proof: existing redaction tests remain covered; changed copy keeps raw values hidden and removes explanatory prose without adding secret material.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx src/features/secrets-broker/provider-configuration.test.tsx` — 14 passed.
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx src/features/secrets-broker/secrets-management.test.tsx src/features/secrets-broker/provider-configuration.test.tsx src/features/secrets-policy-simulation/policy-simulation.test.tsx` — 57 passed.
- PASS `npm run build` — completed; Vite emitted existing chunk-size/SWC warnings only.
- PASS `npm run lint` — 0 errors; 3 existing warnings remain in `src/features/logs/index.tsx`.
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts` — 7 passed.
- PASS canonical demo reachability after local validation: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` status `ok`.
- Log summary: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-20260618T112523\issue-161-validation-summary.txt`.

## Approval trail
- Required: no explicit human approval requirement found for this focused UI cleanup PR.
- Evidence: issue #161 is Project #1 Ready / Ready for Agent and scoped to compact operator UI cleanup.

## Cleanup
- Branch is pushed as `issue-161-secretsbroker-operator-pages`.
- Post-merge plan: fast-forward `master`, delete local/remote branch when safe, verify canonical demo after merge.
