### PR TITLE
feat(topology): add search to Secrets Broker topology

### DIFF
--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -974,6 +974,7 @@ describe('Secrets Broker setup wizard', () => {
   })
 
   it('renders Secrets Broker topology graph and variable mapping table', async () => {
+    const user = userEvent.setup()
     await renderRoute('/secrets-broker/topology')
 
     expect(
@@ -998,10 +999,41 @@ describe('Secrets Broker setup wizard', () => {
       screen.getAllByRole('link', { name: /^Diagnostics$/i })[0]
     ).toBeVisible()
 
+    const graphSearch = screen.getByLabelText(/Search topology/i)
+    expect(graphSearch).toBeVisible()
+    expect(
+      screen.getByText(/Showing \d+ of \d+ nodes and \d+ of \d+ relationships/i)
+    ).toBeVisible()
+
+    await user.type(graphSearch, 'telegram')
+    expect(graphSearch).toHaveValue('telegram')
+    expect(screen.getByText('TELEGRAM_BOT_TOKEN')).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /Clear topology search/i })
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole('button', { name: /Clear topology search/i })
+    )
+    expect(graphSearch).toHaveValue('')
+    expect(screen.getByText('SESSION_SECRET')).toBeVisible()
+
+    await user.type(graphSearch, 'zz-no-match')
+    expect(
+      screen.getByText(/No topology nodes or relationships match/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/No secret variable mappings match the current filters/i)
+    ).toBeVisible()
+
+    await user.keyboard('{Escape}')
+    expect(graphSearch).toHaveValue('')
+    expect(screen.getByText('SESSION_SECRET')).toBeVisible()
+
     const tableSearch = screen.getByPlaceholderText(
       /Search services, variables, refs, sources, and status/i
     )
-    await userEvent.type(tableSearch, 'telegram')
+    await user.type(tableSearch, 'telegram')
     expect(tableSearch).toHaveValue('telegram')
     expect(screen.getByText('TELEGRAM_BOT_TOKEN')).toBeVisible()
     expect(

--- a/src/features/secrets-broker/topology-page.tsx
+++ b/src/features/secrets-broker/topology-page.tsx
@@ -13,7 +13,14 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table'
-import { Activity, AlertTriangle, Network, ShieldCheck } from 'lucide-react'
+import {
+  Activity,
+  AlertTriangle,
+  Network,
+  Search as SearchIcon,
+  ShieldCheck,
+  X,
+} from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import { cn } from '@/lib/utils'
@@ -21,6 +28,7 @@ import { useTableUrlState } from '@/hooks/use-table-url-state'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
@@ -45,6 +53,7 @@ import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
   buildSecretsBrokerTopology,
+  filterSecretsBrokerTopology,
   type SecretVariableMappingRow,
   type SecretVariableMappingStatus,
   toReactFlowSecretsBrokerTopology,
@@ -344,17 +353,25 @@ export function SecretsBrokerTopologyPage() {
   })
 
   const servicesQuery = useServices()
+  const [topologySearchQuery, setTopologySearchQuery] = useState('')
   const topology = useMemo(
     () => buildSecretsBrokerTopology(servicesQuery.data ?? []),
     [servicesQuery.data]
   )
+  const filteredTopology = useMemo(
+    () => filterSecretsBrokerTopology(topology, topologySearchQuery),
+    [topology, topologySearchQuery]
+  )
   const graph = useMemo(
-    () => toReactFlowSecretsBrokerTopology(topology),
-    [topology]
+    () => toReactFlowSecretsBrokerTopology(filteredTopology),
+    [filteredTopology]
   )
   const unmappedCount = topology.rows.filter(
     (row) => row.status !== 'mapped'
   ).length
+  const hasTopologySearch = topologySearchQuery.trim().length > 0
+  const topologyHasMatches =
+    filteredTopology.nodes.length > 0 || filteredTopology.rows.length > 0
 
   return (
     <>
@@ -423,16 +440,73 @@ export function SecretsBrokerTopologyPage() {
 
             <Card>
               <CardHeader className='space-y-1'>
-                <div className='flex flex-wrap items-center justify-between gap-2'>
+                <div className='flex flex-wrap items-center justify-between gap-3'>
                   <div className='flex items-center gap-2 font-semibold'>
                     <Network className='size-4' />
                     Mapping graph
                   </div>
-                  <Badge variant='secondary'>Derived from table rows</Badge>
+                  <div className='flex flex-wrap items-center gap-2'>
+                    <Badge variant='secondary'>Derived from table rows</Badge>
+                    {hasTopologySearch ? (
+                      <Badge variant='outline'>
+                        {filteredTopology.nodes.length} of{' '}
+                        {topology.nodes.length} nodes
+                      </Badge>
+                    ) : null}
+                  </div>
+                </div>
+                <div className='flex flex-col gap-2 pt-2 sm:flex-row sm:items-end sm:justify-between'>
+                  <div className='min-w-0 flex-1 space-y-1'>
+                    <label
+                      htmlFor='secrets-topology-search'
+                      className='text-xs font-medium text-muted-foreground'
+                    >
+                      Search topology
+                    </label>
+                    <div className='relative max-w-xl'>
+                      <SearchIcon className='pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground' />
+                      <Input
+                        id='secrets-topology-search'
+                        value={topologySearchQuery}
+                        onChange={(event) =>
+                          setTopologySearchQuery(event.target.value)
+                        }
+                        onKeyDown={(event) => {
+                          if (event.key === 'Escape') {
+                            setTopologySearchQuery('')
+                          }
+                        }}
+                        placeholder='Search services, refs, providers, routes, or variables...'
+                        className='ps-9 pe-10'
+                        aria-describedby='secrets-topology-search-summary'
+                      />
+                      {hasTopologySearch ? (
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='icon'
+                          className='absolute end-1 top-1/2 size-7 -translate-y-1/2'
+                          onClick={() => setTopologySearchQuery('')}
+                          aria-label='Clear topology search'
+                        >
+                          <X className='size-4' />
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                  <p
+                    id='secrets-topology-search-summary'
+                    className='text-sm text-muted-foreground'
+                  >
+                    Showing {filteredTopology.nodes.length} of{' '}
+                    {topology.nodes.length} nodes and{' '}
+                    {filteredTopology.edges.length} of {topology.edges.length}{' '}
+                    relationships.
+                  </p>
                 </div>
               </CardHeader>
               <CardContent>
-                {topology.rows.length ? (
+                {topology.rows.length && topologyHasMatches ? (
                   <DependencyGraphCanvas
                     nodes={graph.nodes}
                     edges={graph.edges}
@@ -450,6 +524,10 @@ export function SecretsBrokerTopologyPage() {
                       { label: 'unknown', color: '#64748b', dashed: true },
                     ]}
                   />
+                ) : hasTopologySearch ? (
+                  <div className='flex min-h-[240px] items-center justify-center rounded-md border text-sm text-muted-foreground'>
+                    No topology nodes or relationships match the current search.
+                  </div>
                 ) : (
                   <div className='flex min-h-[240px] items-center justify-center rounded-md border text-sm text-muted-foreground'>
                     No secret-like service variables were reported by the
@@ -467,7 +545,7 @@ export function SecretsBrokerTopologyPage() {
               </div>
             ) : null}
 
-            <SecretsBrokerTopologyTable rows={topology.rows} />
+            <SecretsBrokerTopologyTable rows={filteredTopology.rows} />
           </>
         )}
       </Main>


### PR DESCRIPTION
## Issue
Refs #157

## Summary
- Added a topology search input on `/secrets-broker/topology` for services, refs, providers, routes, variables, and relationship metadata.
- Reused the existing topology filter to isolate matching graph nodes/edges and mirror the filtered rows in the mapping table.
- Added empty-result, clear button, and Escape reset behavior.

## Scope
- In scope: Service Admin Secrets Broker topology page search/filter UI and route test coverage.
- Out of scope: backend topology API changes, raw secret reveal/export, graph layout persistence changes.

## Spec / contract / fixture impact
- Updated: no public API/schema/manifest contract change.
- Not required because this is a client-side UI filtering slice over existing safe topology metadata.

## Nash invariant impact
- Invariant: raw secret values and provider credentials stay out of topology/search surfaces.
- Preservation proof: topology still builds from safe metadata only; existing secret leak assertions remain in the route test and passed.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — `.work-agent/logs/157/vitest-secrets-broker-setup.log`, 40 tests passed.
- PASS `npm run lint` — `.work-agent/logs/157/npm-lint.log`, 0 errors; 3 existing warnings in `src/features/logs/index.tsx`.
- PASS `npm run build` — `.work-agent/logs/157/npm-build.log`.
- PASS canonical reachability check — `.work-agent/logs/157/canonical-demo-health-post-change.log`, Service Admin HTTP 200 and runtime health `status=ok`.

## Demo / deployment
- Canonical LAN demo was checked healthy after the code change: `http://192.168.1.53:17700/` HTTP 200 and `http://192.168.1.53:17883/api/health` status `ok`.
- The live canonical `@serviceadmin` service is still pinned to release artifact `2026.6.6-6715d14`; this branch is not claimed as deployed current until merge/release/recycle.

## Approval trail
- Required: no branch protection or required review on `master`; CI passed before merge.
- Evidence: this PR and issue #157 start/progress comments.

## Cleanup
- After merge/release: recycle canonical demo to the merged/released Service Admin artifact, verify LAN URLs, then close issue/project item.
