### PR TITLE
feat(logs): make service logs visible per service

### DIFF
--- a/src/features/logs/index.tsx
+++ b/src/features/logs/index.tsx
@@ -47,6 +47,8 @@ import {
   debugLogs,
   fetchServiceLogChunk,
   fetchServiceLogInfo,
+  fetchServiceLogsOverview,
+  type ServiceLogOverview,
   type ServiceLogInfo,
 } from './provider'
 
@@ -191,6 +193,132 @@ function RealServiceLogViewer({
   )
 }
 
+function buildLogEmptyState(
+  service: DashboardService,
+  logInfo: ServiceLogInfo | null
+) {
+  if (!service.installed) {
+    return {
+      title: 'No logs because the service is not installed yet',
+      description:
+        'The runtime knows about this service, but install/config/start has not produced a current log file in this environment.',
+    }
+  }
+
+  const isProvider =
+    service.role === 'provider' || service.metadata.serviceType === 'provider'
+
+  if (isProvider) {
+    return {
+      title: 'Provider service has no daemon log entries',
+      description:
+        'Provider-role services may only emit install or configuration events. They can be valid even when no long-running process writes stdout or stderr.',
+    }
+  }
+
+  if (service.status === 'stopped') {
+    return {
+      title: 'No current logs because the service is stopped',
+      description:
+        'Start or restart the service to create new runtime output. Existing archived logs appear when the runtime reports them.',
+    }
+  }
+
+  return {
+    title: 'No current log entries yet',
+    description: logInfo?.path
+      ? 'The runtime resolved a log file, but there are no entries in the selected tail window yet.'
+      : 'The runtime has not resolved a current log source for this service yet.',
+  }
+}
+
+function ServiceLogsOverviewPanel({
+  overview,
+}: {
+  overview: ServiceLogOverview | null
+}) {
+  if (!overview) return null
+
+  const archiveCount = overview.archives.length
+  const paths = [
+    { label: 'Service log', value: overview.logPath },
+    { label: 'Stdout', value: overview.stdoutPath },
+    { label: 'Stderr', value: overview.stderrPath },
+  ].filter((item) => Boolean(item.value))
+
+  return (
+    <div className='space-y-3 rounded-md border bg-muted/20 p-3 text-sm'>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <div className='font-medium'>Runtime log overview</div>
+        <div className='text-xs text-muted-foreground'>
+          {overview.entries.length.toLocaleString()} current entries ·{' '}
+          {archiveCount.toLocaleString()} archives
+        </div>
+      </div>
+      {paths.length ? (
+        <div className='grid gap-2 md:grid-cols-3'>
+          {paths.map((item) => (
+            <div key={item.label} className='min-w-0'>
+              <div className='text-xs font-medium'>{item.label}</div>
+              <div className='truncate text-xs text-muted-foreground'>
+                {item.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function ServiceLogEmptyState({
+  service,
+  logInfo,
+  overview,
+}: {
+  service: DashboardService
+  logInfo: ServiceLogInfo | null
+  overview: ServiceLogOverview | null
+}) {
+  const state = buildLogEmptyState(service, logInfo)
+  const entries = overview?.entries.slice(0, 5) ?? []
+
+  return (
+    <div className='space-y-3'>
+      <div className='rounded-md border border-dashed bg-muted/20 p-6'>
+        <div className='font-medium'>{state.title}</div>
+        <p className='mt-1 text-sm text-muted-foreground'>
+          {state.description}
+        </p>
+      </div>
+      {entries.length ? (
+        <div className='overflow-hidden rounded-md border'>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Level</TableHead>
+                <TableHead>Recent runtime event</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {entries.map((entry, index) => (
+                <TableRow key={`${entry.level}-${index}`}>
+                  <TableCell className='w-28'>
+                    <Badge variant='outline'>{entry.level}</Badge>
+                  </TableCell>
+                  <TableCell className='text-sm text-muted-foreground'>
+                    {entry.message}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
 function ServiceLazyLogViewer({
   service,
   paused,
@@ -199,6 +327,9 @@ function ServiceLazyLogViewer({
   paused: boolean
 }) {
   const [logInfo, setLogInfo] = useState<ServiceLogInfo | null>(null)
+  const [logOverview, setLogOverview] = useState<ServiceLogOverview | null>(
+    null
+  )
   const [loading, setLoading] = useState(false)
   const [loadingOlder, setLoadingOlder] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -259,6 +390,7 @@ function ServiceLazyLogViewer({
       if (!service) {
         debugLogs('loadInitial skipped because no service is selected')
         setLogInfo(null)
+        setLogOverview(null)
         setLines([])
         setHasMore(false)
         setNextBefore(null)
@@ -277,7 +409,7 @@ function ServiceLazyLogViewer({
       try {
         setLoading(true)
         setError(null)
-        const [info, chunk] = await Promise.all([
+        const [info, chunk, overview] = await Promise.all([
           fetchServiceLogInfo(service, 'default'),
           fetchServiceLogChunk(
             service,
@@ -285,11 +417,13 @@ function ServiceLazyLogViewer({
             undefined,
             DEFAULT_LOG_CHUNK_SIZE
           ),
+          fetchServiceLogsOverview(service).catch(() => null),
         ])
 
         if (cancelled) return
 
         setLogInfo(info)
+        setLogOverview(overview)
         setLines(chunk.lines)
         setHasMore(chunk.hasMore)
         setNextBefore(chunk.nextBefore)
@@ -311,6 +445,7 @@ function ServiceLazyLogViewer({
         })
         setError('Unable to load log content right now.')
         setLogInfo(null)
+        setLogOverview(null)
         setLines([])
         setHasMore(false)
         setNextBefore(null)
@@ -326,7 +461,7 @@ function ServiceLazyLogViewer({
     return () => {
       cancelled = true
     }
-  }, [paused, service?.id])
+  }, [paused, service])
 
   useLayoutEffect(() => {
     const adjustment = prependAdjustmentRef.current
@@ -413,6 +548,7 @@ function ServiceLazyLogViewer({
       loading,
       loadingOlder,
       logPath: logInfo?.path ?? null,
+      overviewEntries: logOverview?.entries.length ?? null,
       lineCount: lines.length,
       hasMore,
       nextBefore,
@@ -425,6 +561,7 @@ function ServiceLazyLogViewer({
     loading,
     loadingOlder,
     logInfo?.path,
+    logOverview?.entries.length,
     nextBefore,
     service,
     totalLines,
@@ -452,6 +589,7 @@ function ServiceLazyLogViewer({
 
   return (
     <div className='space-y-3'>
+      <ServiceLogsOverviewPanel overview={logOverview} />
       <div className='space-y-1 text-xs text-muted-foreground'>
         <div
           className='truncate whitespace-nowrap'
@@ -476,17 +614,25 @@ function ServiceLazyLogViewer({
           {totalLines.toLocaleString()} lines
         </div>
       </div>
-      <div ref={viewerRef}>
-        <RealServiceLogViewer
-          key={`${service.id}:${logInfo?.path ?? 'default'}`}
+      {lines.length ? (
+        <div ref={viewerRef}>
+          <RealServiceLogViewer
+            key={`${service.id}:${logInfo?.path ?? 'default'}`}
+            service={service}
+            paused={paused}
+            lines={lines}
+            loadingOlder={loadingOlder}
+            hasMore={hasMore}
+            onScroll={handleViewerScroll}
+          />
+        </div>
+      ) : (
+        <ServiceLogEmptyState
           service={service}
-          paused={paused}
-          lines={lines}
-          loadingOlder={loadingOlder}
-          hasMore={hasMore}
-          onScroll={handleViewerScroll}
+          logInfo={logInfo}
+          overview={logOverview}
         />
-      </div>
+      )}
     </div>
   )
 }
@@ -504,7 +650,7 @@ export function Logs() {
   const [serviceQuery, setServiceQuery] = useState('')
   const [selectedServiceId, setSelectedServiceId] = useState('')
 
-  const services = servicesQuery.data ?? []
+  const services = useMemo(() => servicesQuery.data ?? [], [servicesQuery.data])
   const effectiveSelectedServiceId = searchState.service ?? selectedServiceId
 
   const filteredServices = useMemo(() => {

--- a/src/features/logs/logs-page.test.tsx
+++ b/src/features/logs/logs-page.test.tsx
@@ -1,0 +1,113 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('logs page operator states', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('explains an empty current log while still showing runtime overview entries', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url, 'http://localhost')
+
+        if (parsed.pathname === '/api/services/log-info') {
+          return new Response(
+            JSON.stringify({
+              serviceId: '@serviceadmin',
+              type: 'default',
+              path: 'C:\\runtime\\@serviceadmin\\service.log',
+              availableTypes: ['default'],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/logs/read') {
+          return new Response(
+            JSON.stringify({
+              serviceId: '@serviceadmin',
+              type: 'default',
+              path: 'C:\\runtime\\@serviceadmin\\service.log',
+              totalLines: 0,
+              start: 0,
+              end: 0,
+              hasMore: false,
+              nextBefore: 0,
+              limit: 100,
+              lines: [],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/services/%40serviceadmin/logs') {
+          return new Response(
+            JSON.stringify({
+              logs: {
+                serviceId: '@serviceadmin',
+                logPath: 'C:\\runtime\\@serviceadmin\\service.log',
+                stdoutPath: 'C:\\runtime\\@serviceadmin\\stdout.log',
+                stderrPath: 'C:\\runtime\\@serviceadmin\\stderr.log',
+                entries: [
+                  {
+                    level: 'stdout',
+                    message:
+                      '@serviceadmin listening on http://0.0.0.0:17700 token=hidden-value',
+                  },
+                ],
+                archives: [],
+                retention: { maxArchives: 3 },
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        return new Response('not found', { status: 404 })
+      })
+    )
+
+    await renderRoute('/logs?service=@serviceadmin')
+
+    await waitFor(() => {
+      expect(screen.getByText('Runtime log overview')).toBeVisible()
+    })
+
+    expect(screen.getByText('No current log entries yet')).toBeVisible()
+    expect(
+      screen.getByText(/@serviceadmin listening on http:\/\/0\.0\.0\.0:17700/)
+    ).toBeVisible()
+    expect(screen.getByText(/token=\[redacted\]/)).toBeVisible()
+  })
+
+  it('exposes Logs actions from the services table', async () => {
+    await renderRoute('/services')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Services' })).toBeVisible()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Service Admin UI')).toBeVisible()
+    })
+
+    const logLinks = screen
+      .getAllByRole('link', { name: /^Logs$/i })
+      .map((link) => link.getAttribute('href'))
+
+    expect(logLinks).toContain('/logs?service=%40serviceadmin')
+  })
+})

--- a/src/features/logs/provider.runtime.test.ts
+++ b/src/features/logs/provider.runtime.test.ts
@@ -104,6 +104,55 @@ describe('logs provider configured api mode', () => {
     ).rejects.toThrow('Live logs are unavailable right now.')
   })
 
+  it('loads service log overview through the service-specific runtime endpoint and redacts sensitive text', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: 'http://api.test',
+    }))
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          logs: {
+            serviceId: '@serviceadmin',
+            logPath: 'C:\\runtime\\@serviceadmin\\service.log',
+            stdoutPath: 'C:\\runtime\\@serviceadmin\\stdout.log',
+            stderrPath: 'C:\\runtime\\@serviceadmin\\stderr.log',
+            entries: [
+              {
+                level: 'stdout',
+                message: 'started with token=super-secret-value',
+              },
+              {
+                level: 'stderr',
+                message: 'Authorization: Bearer abc.def.ghi',
+              },
+            ],
+            archives: [],
+            retention: { maxArchives: 3 },
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchServiceLogsOverview } = await import('./provider')
+
+    const overview = await fetchServiceLogsOverview(service as never)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://api.test/api/services/%40serviceadmin/logs'
+    )
+    expect(overview.entries.map((entry) => entry.message)).toEqual([
+      'started with token=[redacted]',
+      'Authorization: [redacted]',
+    ])
+  })
+
   it('reads runtime logs for Traefik, Service Admin, and Service Broker', async () => {
     vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
       serviceLassoApiBaseUrl: 'http://api.test',
@@ -187,5 +236,41 @@ describe('logs provider configured api mode', () => {
       expect(info.path).toBe(`C:\\runtime\\${serviceId}.log`)
       expect(chunk.lines).toEqual(serviceLogs.get(serviceId))
     }
+  })
+
+  it('redacts sensitive values from log chunks before rendering callers receive them', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: 'http://api.test',
+    }))
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            serviceId: '@serviceadmin',
+            type: 'default',
+            path: 'C:\\runtime\\@serviceadmin.log',
+            totalLines: 2,
+            start: 0,
+            end: 2,
+            hasMore: false,
+            nextBefore: 0,
+            limit: 100,
+            lines: ['password=hunter2', 'Bearer abc.def.ghi'],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      })
+    )
+
+    const { fetchServiceLogChunk } = await import('./provider')
+
+    const chunk = await fetchServiceLogChunk(service as never, 'default')
+
+    expect(chunk.lines).toEqual(['password=[redacted]', 'Bearer [redacted]'])
   })
 })

--- a/src/features/logs/provider.stub.test.ts
+++ b/src/features/logs/provider.stub.test.ts
@@ -81,4 +81,37 @@ describe('logs provider relative api mode', () => {
     expect(chunk.lines).toHaveLength(100)
     expect(chunk.hasMore).toBe(true)
   })
+
+  it('requests service log overview through a relative service endpoint when no api base is configured', async () => {
+    vi.doMock('@/lib/service-lasso-dashboard/stub', () => ({
+      serviceLassoApiBaseUrl: null,
+    }))
+
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          logs: {
+            serviceId: '@serviceadmin',
+            logPath: 'C:\\runtime\\@serviceadmin.log',
+            entries: [],
+            archives: [],
+            retention: { maxArchives: 3 },
+          },
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchServiceLogsOverview } = await import('./provider')
+
+    const overview = await fetchServiceLogsOverview(service as never)
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/services/%40serviceadmin/logs')
+    expect(overview.serviceId).toBe('@serviceadmin')
+  })
 })

--- a/src/features/logs/provider.ts
+++ b/src/features/logs/provider.ts
@@ -26,6 +26,41 @@ export type ServiceLogChunk = {
   lines: string[]
 }
 
+export type ServiceLogOverviewEntry = {
+  timestamp?: string
+  level: string
+  message: string
+}
+
+export type ServiceLogOverview = {
+  serviceId: string
+  logPath?: string
+  stdoutPath?: string
+  stderrPath?: string
+  entries: ServiceLogOverviewEntry[]
+  archives: unknown[]
+  retention?: {
+    maxArchives?: number
+  }
+}
+
+type ServiceLogOverviewResponse = {
+  logs: ServiceLogOverview
+}
+
+export function redactLogLine(line: string) {
+  return line
+    .replace(
+      /\b(authorization)(\s*[:=]\s*)Bearer\s+([A-Za-z0-9._~+/-]+=*)/gi,
+      '$1$2[redacted]'
+    )
+    .replace(
+      /\b(password|passwd|pwd|secret|token|api[_-]?key|private[_-]?key|cookie|authorization)(\s*[:=]\s*)([^\s,;]+)/gi,
+      '$1$2[redacted]'
+    )
+    .replace(/\b(Bearer)\s+([A-Za-z0-9._~+/-]+=*)/gi, '$1 [redacted]')
+}
+
 export function debugLogs(message: string, details?: Record<string, unknown>) {
   if (!logsDebugEnabled) return
   // eslint-disable-next-line no-console
@@ -50,11 +85,18 @@ function resolveLogsApiBaseUrl() {
   return serviceLassoApiBaseUrl ?? relativeLogsApiBaseUrl
 }
 
-function buildLogsApiUrl(
-  pathname: '/api/services/log-info' | '/api/logs/read',
-  params: URLSearchParams
-) {
+function buildLogsApiUrl(pathname: string, params: URLSearchParams) {
   return `${resolveLogsApiBaseUrl()}${pathname}?${params.toString()}`
+}
+
+function encodeServiceId(serviceId: string) {
+  return encodeURIComponent(serviceId)
+}
+
+function buildServiceLogsOverviewUrl(serviceId: string) {
+  return `${resolveLogsApiBaseUrl()}/api/services/${encodeServiceId(
+    serviceId
+  )}/logs`
 }
 
 export async function fetchServiceLogInfo(
@@ -86,6 +128,27 @@ export async function fetchServiceLogInfo(
   return info
 }
 
+export async function fetchServiceLogsOverview(service: DashboardService) {
+  const overviewUrl = buildServiceLogsOverviewUrl(service.id)
+
+  debugLogs('requesting service logs overview', {
+    serviceId: service.id,
+    overviewUrl,
+  })
+
+  const response = await fetch(overviewUrl)
+  const payload = await parseJsonResponse<ServiceLogOverviewResponse>(response)
+  const overview = payload.logs
+
+  return {
+    ...overview,
+    entries: overview.entries.map((entry) => ({
+      ...entry,
+      message: redactLogLine(entry.message),
+    })),
+  }
+}
+
 export async function fetchServiceLogChunk(
   service: DashboardService,
   type: 'default' | 'access' | 'error',
@@ -114,17 +177,21 @@ export async function fetchServiceLogChunk(
 
   const response = await fetch(chunkUrl)
   const chunk = await parseJsonResponse<ServiceLogChunk>(response)
+  const safeChunk = {
+    ...chunk,
+    lines: chunk.lines.map(redactLogLine),
+  }
 
   debugLogs('log chunk loaded', {
-    serviceId: chunk.serviceId,
-    type: chunk.type,
+    serviceId: safeChunk.serviceId,
+    type: safeChunk.type,
     before: before ?? null,
-    lineCount: chunk.lines.length,
-    totalLines: chunk.totalLines,
-    hasMore: chunk.hasMore,
-    nextBefore: chunk.nextBefore,
-    firstLinePreview: chunk.lines[0]?.slice(0, 120) ?? null,
+    lineCount: safeChunk.lines.length,
+    totalLines: safeChunk.totalLines,
+    hasMore: safeChunk.hasMore,
+    nextBefore: safeChunk.nextBefore,
+    firstLinePreview: safeChunk.lines[0]?.slice(0, 120) ?? null,
   })
 
-  return chunk
+  return safeChunk
 }

--- a/src/features/services/components/data-table-row-actions.tsx
+++ b/src/features/services/components/data-table-row-actions.tsx
@@ -1,7 +1,7 @@
 import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { Link } from '@tanstack/react-router'
 import { type Row } from '@tanstack/react-table'
-import { ExternalLink, Star } from 'lucide-react'
+import { ExternalLink, ScrollText, Star } from 'lucide-react'
 import { type DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Button } from '@/components/ui/button'
 import {
@@ -38,6 +38,14 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
             View details
             <DropdownMenuShortcut>
               <ExternalLink size={16} />
+            </DropdownMenuShortcut>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to='/logs' search={{ service: service.id }}>
+            Open logs
+            <DropdownMenuShortcut>
+              <ScrollText size={16} />
             </DropdownMenuShortcut>
           </Link>
         </DropdownMenuItem>

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -6,6 +6,7 @@ import {
   Play,
   RotateCcw,
   Search,
+  ScrollText,
   Square,
   Star,
 } from 'lucide-react'
@@ -267,14 +268,26 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
   {
     id: 'open',
     header: 'Open',
-    cell: ({ row }) => (
-      <Button size='sm' variant='outline' asChild>
-        <Link to='/services/$serviceId' params={{ serviceId: row.original.id }}>
-          <Search className='mr-2 size-3.5' />
-          Details
-        </Link>
-      </Button>
-    ),
+    cell: ({ row }) => {
+      const service = row.original
+
+      return (
+        <div className='flex flex-wrap gap-2'>
+          <Button size='sm' variant='outline' asChild>
+            <Link to='/logs' search={{ service: service.id }}>
+              <ScrollText className='mr-2 size-3.5' />
+              Logs
+            </Link>
+          </Button>
+          <Button size='sm' variant='outline' asChild>
+            <Link to='/services/$serviceId' params={{ serviceId: service.id }}>
+              <Search className='mr-2 size-3.5' />
+              Details
+            </Link>
+          </Button>
+        </div>
+      )
+    },
     enableSorting: false,
   },
   {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -120,9 +120,65 @@ function normalizeLogReadBefore(value: string | null, totalLines: number) {
 function attachLogMiddlewares(middlewares: {
   use: (
     path: string,
-    handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>
+    handler: (
+      req: IncomingMessage,
+      res: ServerResponse,
+      next?: () => void
+    ) => void | Promise<void>
   ) => void
 }) {
+  middlewares.use('/api/services', async (req, res, next) => {
+    try {
+      const requestUrl = new URL(req.url ?? '', 'http://localhost')
+      const match = requestUrl.pathname.match(/^\/([^/]+)\/logs$/)
+      if (!match) {
+        next?.()
+        return
+      }
+
+      const serviceId = decodeURIComponent(match[1])
+      const logInfo = await resolveStubServiceLogInfo(serviceId, 'default')
+      if (!logInfo?.path) {
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Unknown service log target' }))
+        return
+      }
+
+      const logData = await readResolvedLogLines(logInfo.path)
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          logs: {
+            serviceId,
+            logPath: logInfo.path,
+            stdoutPath: logInfo.path,
+            stderrPath: logInfo.path,
+            entries: logData.lines.slice(-20).map((line) => ({
+              level: 'info',
+              message: line,
+            })),
+            archives: [],
+            retention: { maxArchives: 3 },
+          },
+        })
+      )
+    } catch (error) {
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to read service log overview',
+        })
+      )
+    }
+  })
+
   middlewares.use('/api/services/log-info', async (req, res) => {
     try {
       const requestUrl = new URL(req.url ?? '', 'http://localhost')


### PR DESCRIPTION
## Issue
Closes #170

## Summary
- Adds an obvious per-service Logs action from the Services table and row menu.
- Loads the runtime service-specific `/api/services/{id}/logs` overview on the Logs page, alongside the existing `/api/services/log-info` and `/api/logs/read` chunk reader.
- Adds explicit empty-log states for not-installed, provider-role, stopped, and no-current-entry services.
- Redacts common credential-bearing log fragments before rendering chunk lines or overview entries.

## Scope
- In scope: Service Admin log discoverability, log overview metadata, empty-state UX, and UI-side log redaction guardrails.
- Out of scope: backend log API changes, archived log browsing, and changing Service Lasso release pins.

## Spec / contract / fixture impact
- Updated: Service Admin Vite local middleware now mirrors `/api/services/{id}/logs` for local/dev log fixtures.
- Not required: no public schema change; this consumes an existing runtime endpoint.

## Service Lasso invariant impact
- Invariant: log UI must not expose raw secrets or provider credentials.
- Preservation proof: `src/features/logs/provider.runtime.test.ts` covers redaction for token/password/Bearer-style log material before UI callers receive it.

## Validation
- PASS `npm run lint`
- PASS `npm run test:unit` — 27 files, 169 tests
- PASS `npm run build`
- PASS `npx playwright test tests/ui/service-admin.spec.ts` — 3 tests
- PASS package `npm run build; .\scripts\package.ps1` — created `dist\@serviceadmin-win32.zip`

## Demo Evidence
- Deployed branch/commit: `issue-170-service-logs` / `8fdc18e`
- Local PR artifact installed into canonical demo: `C:\projects\service-lasso\service-lasso\services\@serviceadmin\.state\artifacts\local-issue-170-8fdc18e\@serviceadmin-win32.zip`
- Runtime health: `http://192.168.1.53:17883/api/health` returned `status: ok`
- Service Admin LAN: `http://192.168.1.53:17700/` returned HTTP 200 and `<title>Service Admin UI</title>`
- `@serviceadmin` runtime: running `true`, healthy `true`
- Log overview API: `/api/services/@serviceadmin/logs` returned current entries
- Evidence log: `.work-agent/logs/issue-170/canonical-demo-deploy.log`
- `npm run demo:verify-canonical` result: expected FAIL because the canonical manifest was restored to release tag `2026.6.18-e01fc36` while the running demo is intentionally installed from local PR artifact tag `local-issue-170-8fdc18e`; all LAN reachability, runtime roots, ports, running, and health checks were OK.

## Approval Trail
- Required: no explicit human approval known for this UI slice before PR.
- Evidence: Issue is Ready for Agent in Project #1 and start comment was posted on #170.

## Cleanup
- Core `service-lasso` repo manifest restored and clean after the temporary local artifact deploy.
- This branch is pushed; local Service Admin checkout is clean.