### PR TITLE
fix(urls): render service links using browser access host

### DIFF
--- a/src/features/network/index.tsx
+++ b/src/features/network/index.tsx
@@ -16,6 +16,7 @@ import {
 import { Copy, ExternalLink } from 'lucide-react'
 import { copyText } from '@/lib/copy-text'
 import { usePageMetadata } from '@/lib/page-metadata'
+import { renderServiceEndpointUrl } from '@/lib/service-lasso-dashboard/access-host-urls'
 import { useServices } from '@/lib/service-lasso-dashboard/hooks'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
@@ -45,6 +46,7 @@ type NetworkRow = {
   id: string
   service: DashboardService
   endpoint: DashboardService['endpoints'][number]
+  url: string
 }
 
 function NetworkLoading() {
@@ -89,14 +91,14 @@ const columns: ColumnDef<NetworkRow>[] = [
   },
   {
     id: 'url',
-    accessorFn: (row) => row.endpoint.url,
+    accessorFn: (row) => row.url,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title='URL' />
     ),
     cell: ({ row }) => (
       <div className='flex items-start gap-2'>
         <span className='max-w-[360px] text-sm break-all text-muted-foreground'>
-          {row.original.endpoint.url}
+          {row.original.url}
         </span>
         <Button
           type='button'
@@ -104,7 +106,7 @@ const columns: ColumnDef<NetworkRow>[] = [
           size='icon'
           className='size-7 shrink-0'
           title='Copy URL'
-          onClick={() => void copyText(row.original.endpoint.url)}
+          onClick={() => void copyText(row.original.url)}
         >
           <Copy className='size-3.5' />
         </Button>
@@ -114,7 +116,7 @@ const columns: ColumnDef<NetworkRow>[] = [
           className='size-7 shrink-0'
           asChild
         >
-          <a href={row.original.endpoint.url} target='_blank' rel='noreferrer'>
+          <a href={row.original.url} target='_blank' rel='noreferrer'>
             <ExternalLink className='size-3.5' />
           </a>
         </Button>
@@ -178,6 +180,7 @@ export function Network() {
         id: `${service.id}-${endpoint.label}-${index}`,
         service,
         endpoint,
+        url: renderServiceEndpointUrl(endpoint),
       }))
     )
   }, [servicesQuery.data])

--- a/src/features/services/components/data-table-row-actions.tsx
+++ b/src/features/services/components/data-table-row-actions.tsx
@@ -2,6 +2,7 @@ import { DotsHorizontalIcon } from '@radix-ui/react-icons'
 import { Link } from '@tanstack/react-router'
 import { type Row } from '@tanstack/react-table'
 import { ExternalLink, ScrollText, Star } from 'lucide-react'
+import { renderServiceLinkUrl } from '@/lib/service-lasso-dashboard/access-host-urls'
 import { type DashboardService } from '@/lib/service-lasso-dashboard/types'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,6 +21,7 @@ type DataTableRowActionsProps = {
 export function DataTableRowActions({ row }: DataTableRowActionsProps) {
   const service = row.original
   const primaryLink = service.links[0]
+  const primaryUrl = primaryLink ? renderServiceLinkUrl(primaryLink) : undefined
 
   return (
     <DropdownMenu modal={false}>
@@ -49,11 +51,11 @@ export function DataTableRowActions({ row }: DataTableRowActionsProps) {
             </DropdownMenuShortcut>
           </Link>
         </DropdownMenuItem>
-        {primaryLink ? (
+        {primaryLink && primaryUrl ? (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
-              <a href={primaryLink.url} target='_blank' rel='noreferrer'>
+              <a href={primaryUrl} target='_blank' rel='noreferrer'>
                 Open {primaryLink.label}
                 <DropdownMenuShortcut>
                   <ExternalLink size={16} />

--- a/src/features/services/components/services-columns.tsx
+++ b/src/features/services/components/services-columns.tsx
@@ -10,6 +10,7 @@ import {
   Square,
   Star,
 } from 'lucide-react'
+import { renderServiceLinkUrl } from '@/lib/service-lasso-dashboard/access-host-urls'
 import { lifecycleActionButtonClass } from '@/lib/service-lasso-dashboard/action-styles'
 import {
   useFavoriteFeatureState,
@@ -235,19 +236,23 @@ export const servicesColumns: ColumnDef<DashboardService>[] = [
       const service = row.original
       return (
         <div className='flex flex-wrap items-center gap-2'>
-          {service.links.slice(0, 2).map((link) => (
-            <Button
-              key={`${service.id}-${link.label}`}
-              asChild
-              size='sm'
-              variant='outline'
-            >
-              <a href={link.url} target='_blank' rel='noreferrer'>
-                {link.label}
-                <ExternalLink className='ml-2 size-3.5' />
-              </a>
-            </Button>
-          ))}
+          {service.links.slice(0, 2).map((link) => {
+            const url = renderServiceLinkUrl(link)
+
+            return (
+              <Button
+                key={`${service.id}-${link.label}`}
+                asChild
+                size='sm'
+                variant='outline'
+              >
+                <a href={url} target='_blank' rel='noreferrer'>
+                  {link.label}
+                  <ExternalLink className='ml-2 size-3.5' />
+                </a>
+              </Button>
+            )
+          })}
           {service.links.length > 2 ? (
             <span className='text-xs text-muted-foreground'>
               +{service.links.length - 2} more

--- a/src/lib/service-lasso-dashboard/access-host-urls.test.ts
+++ b/src/lib/service-lasso-dashboard/access-host-urls.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import {
+  renderAccessHostUrl,
+  renderServiceEndpointUrl,
+  renderServiceLinkUrl,
+} from './access-host-urls'
+import type { ServiceEndpoint, ServiceLink } from './types'
+
+const remoteIp = {
+  protocol: 'http:',
+  hostname: '192.168.1.53',
+  host: '192.168.1.53:17700',
+} as Location
+
+const remoteHostname = {
+  protocol: 'https:',
+  hostname: 'admin.service-lasso.lan',
+  host: 'admin.service-lasso.lan',
+} as Location
+
+const localHost = {
+  protocol: 'http:',
+  hostname: 'localhost',
+  host: 'localhost:17700',
+} as Location
+
+function endpoint(url: string): ServiceEndpoint {
+  return {
+    label: 'ui',
+    url,
+    bind: '0.0.0.0',
+    port: 17700,
+    protocol: 'http',
+    exposure: 'local',
+  }
+}
+
+function link(url: string, kind: ServiceLink['kind'] = 'local'): ServiceLink {
+  return {
+    label: 'Local',
+    url,
+    kind,
+  }
+}
+
+describe('access host URL rendering', () => {
+  it('rewrites loopback service endpoints to the browser access IP', () => {
+    expect(
+      renderServiceEndpointUrl(
+        endpoint('http://127.0.0.1:17700/services?tab=all#top'),
+        remoteIp
+      )
+    ).toBe('http://192.168.1.53:17700/services?tab=all#top')
+  })
+
+  it('rewrites loopback service links to the browser access hostname', () => {
+    expect(
+      renderServiceLinkUrl(
+        link('http://localhost:17883/api/health'),
+        remoteHostname
+      )
+    ).toBe('http://admin.service-lasso.lan:17883/api/health')
+  })
+
+  it('keeps loopback URLs unchanged when Service Admin is opened locally', () => {
+    expect(renderAccessHostUrl('http://127.0.0.1:17700', localHost)).toBe(
+      'http://127.0.0.1:17700'
+    )
+  })
+
+  it('does not rewrite external service URLs', () => {
+    expect(renderAccessHostUrl('https://traefik.localtest.me', remoteIp)).toBe(
+      'https://traefik.localtest.me'
+    )
+  })
+
+  it('does not rewrite documentation or download links', () => {
+    expect(
+      renderServiceLinkUrl(
+        link('http://127.0.0.1:8080/download.html', 'docs'),
+        remoteIp
+      )
+    ).toBe('http://127.0.0.1:8080/download.html')
+  })
+})

--- a/src/lib/service-lasso-dashboard/access-host-urls.ts
+++ b/src/lib/service-lasso-dashboard/access-host-urls.ts
@@ -1,0 +1,72 @@
+import type { ServiceEndpoint, ServiceLink } from './types'
+
+type AccessLocation = Pick<Location, 'protocol' | 'hostname' | 'host'>
+
+const loopbackHosts = new Set(['localhost', '127.0.0.1', '::1', '[::1]'])
+
+function currentAccessLocation(): AccessLocation | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.location
+}
+
+function normalizeHostname(hostname: string) {
+  return hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, '$1')
+}
+
+function isLoopbackHost(hostname: string) {
+  return loopbackHosts.has(normalizeHostname(hostname))
+}
+
+function isHttpUrl(url: URL) {
+  return url.protocol === 'http:' || url.protocol === 'https:'
+}
+
+function shouldRewriteAccessHost(
+  url: URL,
+  accessLocation: AccessLocation | undefined
+) {
+  if (!accessLocation) return false
+  if (!isHttpUrl(url)) return false
+  if (!isLoopbackHost(url.hostname)) return false
+  return !isLoopbackHost(accessLocation.hostname)
+}
+
+export function renderAccessHostUrl(
+  url: string,
+  accessLocation = currentAccessLocation()
+) {
+  try {
+    const parsed = new URL(url)
+
+    if (!accessLocation || !shouldRewriteAccessHost(parsed, accessLocation)) {
+      return url
+    }
+
+    parsed.hostname = accessLocation.hostname
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+function isServiceLink(link: ServiceLink) {
+  return link.kind !== 'docs'
+}
+
+export function renderServiceLinkUrl(
+  link: ServiceLink,
+  accessLocation = currentAccessLocation()
+) {
+  if (!isServiceLink(link)) return link.url
+  return renderAccessHostUrl(link.url, accessLocation)
+}
+
+export function renderServiceEndpointUrl(
+  endpoint: ServiceEndpoint,
+  accessLocation = currentAccessLocation()
+) {
+  return renderAccessHostUrl(endpoint.url, accessLocation)
+}


### PR DESCRIPTION
## Issue
Closes #179

## Summary
- Added shared access-host URL rendering for browser-facing service URLs.
- Wired Services link buttons, Services row actions, and Network table display/copy/open URLs through the helper.
- Preserves local localhost/127.0.0.1 behavior and avoids rewriting docs links or external URLs.

## Scope
- In scope: Services and Network operator-facing URL rendering for loopback HTTP(S) service URLs when Service Admin is accessed through a remote IP/hostname.
- Out of scope: Filtering docs/download URLs out of Network entirely; that remains #180.

## Spec / contract / fixture impact
- Updated: no public API/schema contract changes.
- Not required because: this is client-side presentation of existing service link/endpoint metadata.

## Nash invariant impact
- Invariant: remote operators should get usable Service Admin links without hiding original bind/port metadata.
- Preservation proof: helper rewrites only loopback HTTP(S) URLs for non-loopback browser hosts, keeps localhost sessions unchanged, and skips docs/external URLs.

## Validation
- PASS `npm run test:unit -- src/lib/service-lasso-dashboard/access-host-urls.test.ts src/features/network/network.test.tsx src/features/services/components/services-columns.test.ts` — 3 files / 8 tests passed.
- PASS `npm run build` — TypeScript and Vite build passed.
- PASS `npm run lint` — ESLint passed.
- PASS canonical demo deploy/recycle — built `dist` overlaid into `service-lasso/services/@serviceadmin/.state/extracted/current/dist`, restarted `@serviceadmin` via runtime API; Service Admin HTTP 200 and runtime health HTTP 200 status ok.
- PASS LAN browser smoke — Playwright against `http://192.168.1.53:17700/services` and `/network`; service hrefs/text used `192.168.1.53`, no loopback URL text was present.

## Approval trail
- Required: no, normal PR review/checks only.
- Evidence: issue #179 selected from Project #1 Ready / Ready for Agent; start comment added.

## Cleanup
- Branch: `fix/179-access-host-urls`.
- Post-merge: delete branch and keep canonical demo on merged Service Admin build.