### PR TITLE
fix(network): hide docs/download URLs from service endpoints

### DIFF
--- a/src/features/network/index.tsx
+++ b/src/features/network/index.tsx
@@ -49,6 +49,73 @@ type NetworkRow = {
   url: string
 }
 
+const nonServiceEndpointLabelTerms = [
+  'artifact',
+  'download',
+  'docs',
+  'documentation',
+  'homepage',
+  'metadata',
+  'release',
+  'source',
+  'vendor',
+]
+
+const nonServiceEndpointPathTerms = [
+  '/artifact',
+  '/artifacts',
+  '/download',
+  '/downloads',
+  '/docs',
+  '/documentation',
+  '/manual',
+  '/metadata',
+  '/release',
+  '/releases',
+]
+
+const artifactExtensions = new Set([
+  '.7z',
+  '.deb',
+  '.dmg',
+  '.exe',
+  '.gz',
+  '.msi',
+  '.pkg',
+  '.rpm',
+  '.tar',
+  '.tgz',
+  '.zip',
+])
+
+function isOperatorNetworkEndpoint(
+  endpoint: DashboardService['endpoints'][number]
+) {
+  const label = endpoint.label.toLowerCase()
+
+  if (nonServiceEndpointLabelTerms.some((term) => label.includes(term))) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(endpoint.url)
+    const pathname = parsed.pathname.toLowerCase()
+    const urlParts = `${pathname}${parsed.search.toLowerCase()}${parsed.hash.toLowerCase()}`
+
+    if (nonServiceEndpointPathTerms.some((term) => urlParts.includes(term))) {
+      return false
+    }
+
+    if (artifactExtensions.has(pathname.slice(pathname.lastIndexOf('.')))) {
+      return false
+    }
+  } catch {
+    return true
+  }
+
+  return true
+}
+
 function NetworkLoading() {
   return (
     <div className='flex flex-1 flex-col gap-4'>
@@ -176,12 +243,14 @@ export function Network() {
 
   const rows = useMemo<NetworkRow[]>(() => {
     return (servicesQuery.data ?? []).flatMap((service) =>
-      service.endpoints.map((endpoint, index) => ({
-        id: `${service.id}-${endpoint.label}-${index}`,
-        service,
-        endpoint,
-        url: renderServiceEndpointUrl(endpoint),
-      }))
+      service.endpoints
+        .filter(isOperatorNetworkEndpoint)
+        .map((endpoint, index) => ({
+          id: `${service.id}-${endpoint.label}-${index}`,
+          service,
+          endpoint,
+          url: renderServiceEndpointUrl(endpoint),
+        }))
     )
   }, [servicesQuery.data])
 

--- a/src/features/network/network.test.tsx
+++ b/src/features/network/network.test.tsx
@@ -17,6 +17,60 @@ vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
             protocol: 'http',
             exposure: 'local',
           },
+          {
+            label: 'api',
+            url: 'http://127.0.0.1:17883/api',
+            bind: '127.0.0.1',
+            port: 17883,
+            protocol: 'http',
+            exposure: 'local',
+          },
+          {
+            label: 'health',
+            url: 'http://127.0.0.1:17883/api/health',
+            bind: '127.0.0.1',
+            port: 17883,
+            protocol: 'http',
+            exposure: 'local',
+          },
+        ],
+      },
+      {
+        id: '@archive',
+        name: 'Archive',
+        endpoints: [
+          {
+            label: 'vendor download',
+            url: 'https://www.7-zip.org/download.html',
+            bind: 'metadata',
+            port: 443,
+            protocol: 'https',
+            exposure: 'public',
+          },
+          {
+            label: 'release asset',
+            url: 'https://github.com/ip7z/7zip/releases/download/24.09/7z2409-x64.exe',
+            bind: 'metadata',
+            port: 443,
+            protocol: 'https',
+            exposure: 'public',
+          },
+          {
+            label: 'docs',
+            url: 'https://www.7-zip.org/',
+            bind: 'metadata',
+            port: 443,
+            protocol: 'https',
+            exposure: 'public',
+          },
+          {
+            label: 'route',
+            url: 'https://archive.service-lasso.local',
+            bind: '0.0.0.0',
+            port: 443,
+            protocol: 'https',
+            exposure: 'lan',
+          },
         ],
       },
     ],
@@ -42,7 +96,29 @@ describe('network page', () => {
     expect(
       screen.getByRole('columnheader', { name: /exposure/i })
     ).toBeVisible()
-    expect(screen.getByRole('link', { name: /Service Admin/i })).toBeVisible()
+    expect(
+      screen.getAllByRole('link', { name: /Service Admin/i })[0]
+    ).toBeVisible()
     expect(screen.getByText('http://127.0.0.1:17700')).toBeVisible()
+  })
+
+  it('only shows operator service endpoints in the network table', async () => {
+    await renderRoute('/network')
+
+    await waitFor(() => {
+      expect(screen.getByText('http://127.0.0.1:17883/api')).toBeVisible()
+    })
+
+    expect(screen.getByText('http://127.0.0.1:17883/api/health')).toBeVisible()
+    expect(
+      screen.getByText('https://archive.service-lasso.local')
+    ).toBeVisible()
+    expect(screen.queryByText('https://www.7-zip.org/download.html')).toBeNull()
+    expect(
+      screen.queryByText(
+        'https://github.com/ip7z/7zip/releases/download/24.09/7z2409-x64.exe'
+      )
+    ).toBeNull()
+    expect(screen.queryByRole('cell', { name: /^docs$/i })).toBeNull()
   })
 })


### PR DESCRIPTION
## Issue
Closes #180

## Summary
- Filters Network table rows so vendor docs/download/release-artifact metadata URLs are not shown as service endpoints.
- Keeps operator-facing UI/API/health/route endpoints visible in the Network table.
- Adds focused Network page coverage for the reported 7-Zip download URL, release asset URLs, docs-labeled rows, and valid route/API/health rows.

## Scope
- In scope: Network page endpoint row classification and tests.
- Out of scope: changing service manifest/source metadata shape or hiding metadata from service detail pages.

## Spec / contract / fixture impact
- Not required because this is a UI filtering bug fix on existing dashboard service endpoint data.

## Nash invariant impact
- Invariant: Service Admin Network shows operator service endpoints only and does not promote vendor/download/source metadata as routes.
- Preservation proof: tests assert UI/API/health/route rows remain visible while docs/download/release rows are absent.

## Validation
- PASS `npm run format:check` — `.work-agent/logs/issue-180/format-check.log`
- PASS `npm test -- src/features/network/network.test.tsx` — `.work-agent/logs/issue-180/network-test.log`
- PASS `npm run lint` — `.work-agent/logs/issue-180/lint.log`
- PASS `npm run build` — `.work-agent/logs/issue-180/build.log`
- PASS `powershell -ExecutionPolicy Bypass -File scripts\package.ps1` — `.work-agent/logs/issue-180/package.log`
- PASS GitHub `install-lint-build` — https://github.com/service-lasso/lasso-serviceadmin/actions/runs/27750500381/job/82099491296
- PASS canonical demo deploy evidence — `.work-agent/logs/issue-180/demo-deploy-evidence.log`
- PASS `npm run demo:verify-canonical` from `service-lasso/service-lasso` — `.work-agent/logs/issue-180/demo-verify-canonical.log`

Demo evidence:
- Branch/package deployed to canonical `@serviceadmin` extracted runtime: `fix/180-network-service-endpoint-filter` @ `f8f91033cbf296823ec05d554a6e5c75538ebe49`
- Deployed index hash matched package index hash.
- `http://192.168.1.53:17700/` returned HTTP 200.
- `http://192.168.1.53:17883/api/health` returned status `ok`.

## Approval trail
- Required: no review decision/requirement reported by `gh pr view`; PR merge state clean and check green.
- Evidence: `install-lint-build` passed and PR was mergeable.

## Cleanup
- Merge when green, then return local checkout to current `master` and delete the issue branch when safe.