### PR TITLE
feat(secretsbroker): add Providers management foundation

### DIFF
--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -164,9 +164,9 @@ const secretsBrokerSectionMetadata: Record<
       'Inspect policy, audit, telemetry, event filtering, and lockout posture.',
   },
   sources: {
-    title: 'Service Admin - Secrets Broker Sources',
-    heading: 'Secrets Broker sources',
-    description: 'Inspect configured source and backend metadata safely.',
+    title: 'Service Admin - Secrets Broker Providers',
+    heading: 'Secrets Broker providers',
+    description: 'Inspect configured provider metadata safely.',
   },
   'provider-connections': {
     title: 'Service Admin - Secrets Broker Provider Connections',
@@ -2247,9 +2247,7 @@ export function SecretsBrokerSetupWizard({
                     <Link to='/secrets-broker/sources'>View providers</Link>
                   </Button>
                   <Button variant='outline' size='sm' asChild>
-                    <Link to='/secrets-broker/sources'>
-                      View secret sources
-                    </Link>
+                    <Link to='/secrets-broker/sources'>Add provider</Link>
                   </Button>
                   <Button variant='outline' size='sm' asChild>
                     <Link to='/secrets-broker/audit-events'>
@@ -2268,7 +2266,7 @@ export function SecretsBrokerSetupWizard({
             <div className='grid gap-4 md:grid-cols-3'>
               <Card>
                 <CardHeader className='pb-2'>
-                  <CardTitle className='text-base'>Ready sources</CardTitle>
+                  <CardTitle className='text-base'>Ready providers</CardTitle>
                   <CardDescription>
                     Sources that can be saved or retried safely.
                   </CardDescription>

--- a/src/features/secrets-broker/providers-management-page.tsx
+++ b/src/features/secrets-broker/providers-management-page.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useState } from 'react'
+import {
+  ArrowDownUp,
+  DatabaseZap,
+  KeyRound,
+  Plus,
+  Search as SearchIcon,
+  Settings,
+  ShieldCheck,
+} from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  buildProvidersManagementSummary,
+  filterProviderManagementRows,
+  getAddableSecretsBrokerProviders,
+  getConfiguredSecretsBrokerProviders,
+  secretsBrokerSourceBackends,
+  type SecretsBrokerProviderLifecycle,
+  type SecretsBrokerSourceBackend,
+  type SecretsBrokerSourceState,
+} from './source-backends'
+
+type ProviderOrder = 'priority' | 'name' | 'status'
+
+const stateVariant: Record<
+  SecretsBrokerSourceState,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  configured: 'secondary',
+  'not-configured': 'outline',
+  reachable: 'default',
+  failing: 'destructive',
+  untested: 'outline',
+}
+
+const lifecycleVariant: Record<
+  SecretsBrokerProviderLifecycle,
+  'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+  'setup-needed': 'outline',
+  locked: 'secondary',
+  unlocked: 'default',
+  'auth-required': 'destructive',
+  invalid: 'destructive',
+  ready: 'default',
+}
+
+function sortProviders(
+  providers: SecretsBrokerSourceBackend[],
+  order: ProviderOrder
+) {
+  return [...providers].sort((left, right) => {
+    if (order === 'name') return left.title.localeCompare(right.title)
+    if (order === 'status') {
+      return `${left.state}-${left.lifecycle}-${left.title}`.localeCompare(
+        `${right.state}-${right.lifecycle}-${right.title}`
+      )
+    }
+
+    return (left.priority ?? 999) - (right.priority ?? 999)
+  })
+}
+
+function providerTypeLabel(provider: SecretsBrokerSourceBackend) {
+  return provider.type === 'local' ? 'local-encrypted-store' : provider.type
+}
+
+export function ProvidersManagementPage() {
+  const [query, setQuery] = useState('')
+  const [order, setOrder] = useState<ProviderOrder>('priority')
+
+  usePageMetadata({
+    title: 'Service Admin - Secrets Broker Providers',
+    description:
+      'Secrets Broker provider management for configured providers, add-provider options, priority ordering, and metadata-only status.',
+  })
+
+  const configuredProviders = useMemo(
+    () =>
+      sortProviders(
+        filterProviderManagementRows(
+          getConfiguredSecretsBrokerProviders(),
+          query
+        ),
+        order
+      ),
+    [order, query]
+  )
+  const addableProviders = useMemo(
+    () =>
+      filterProviderManagementRows(getAddableSecretsBrokerProviders(), query),
+    [query]
+  )
+  const summary = buildProvidersManagementSummary(secretsBrokerSourceBackends)
+
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <Main id='content' className='space-y-6'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div>
+            <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
+              <KeyRound className='size-5' /> Secrets Broker providers
+            </h1>
+            <p className='mt-1 text-muted-foreground'>
+              Manage configured providers, default/fallback ordering, and
+              addable provider types without rendering credential values.
+            </p>
+          </div>
+          <Badge variant='secondary'>Metadata only</Badge>
+        </div>
+
+        <div className='grid gap-4 md:grid-cols-4'>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Configured providers</CardDescription>
+              <CardTitle className='text-3xl'>
+                {summary.configuredCount}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Healthy / ready</CardDescription>
+              <CardTitle className='text-3xl'>{summary.readyCount}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Needing action</CardDescription>
+              <CardTitle className='text-3xl'>
+                {summary.needsActionCount}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className='pb-2'>
+              <CardDescription>Default / fallback</CardDescription>
+              <CardTitle className='text-xl'>
+                {summary.defaultProvider}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <DatabaseZap className='size-4' /> Configured provider table
+                </CardTitle>
+                <CardDescription>
+                  Only the Local encrypted store is configured by default.
+                  Additional provider types appear in Add Provider until an
+                  operator configures and tests them.
+                </CardDescription>
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                <Badge variant='outline'>No raw values</Badge>
+                <Badge variant='outline'>Credentials as refs only</Badge>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px]'>
+              <label className='relative block'>
+                <span className='sr-only'>Search providers</span>
+                <SearchIcon className='pointer-events-none absolute top-2.5 left-3 size-4 text-muted-foreground' />
+                <Input
+                  aria-label='Search providers'
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  className='pl-9'
+                  placeholder='Search provider name, kind, namespace, status'
+                />
+              </label>
+              <label className='flex items-center gap-2'>
+                <ArrowDownUp className='size-4 text-muted-foreground' />
+                <span className='sr-only'>Provider order</span>
+                <select
+                  aria-label='Provider order'
+                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={order}
+                  onChange={(event) =>
+                    setOrder(event.target.value as ProviderOrder)
+                  }
+                >
+                  <option value='priority'>Resolution priority</option>
+                  <option value='name'>Provider name</option>
+                  <option value='status'>Status</option>
+                </select>
+              </label>
+            </div>
+
+            <div className='overflow-x-auto rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Provider</TableHead>
+                    <TableHead>Configured / enabled</TableHead>
+                    <TableHead>Status / lifecycle</TableHead>
+                    <TableHead>Priority / ownership</TableHead>
+                    <TableHead>Last tested</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {configuredProviders.map((provider) => (
+                    <TableRow key={provider.id}>
+                      <TableCell className='min-w-72 align-top'>
+                        <div className='font-medium'>{provider.title}</div>
+                        <div className='text-sm text-muted-foreground'>
+                          {providerTypeLabel(provider)} · {provider.source}
+                        </div>
+                        <div className='mt-1 text-xs text-muted-foreground'>
+                          {provider.summary}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-44 align-top'>
+                        <div>
+                          {provider.configured ? 'configured' : 'addable'}
+                        </div>
+                        <div className='text-sm text-muted-foreground'>
+                          {provider.enabled ? 'enabled' : 'disabled'}
+                        </div>
+                        <Badge className='mt-2' variant='outline'>
+                          {provider.defaultRole}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className='min-w-48 align-top'>
+                        <Badge variant={stateVariant[provider.state]}>
+                          {provider.state}
+                        </Badge>
+                        <Badge
+                          className='mt-2 ml-2'
+                          variant={lifecycleVariant[provider.lifecycle]}
+                        >
+                          {provider.lifecycle}
+                        </Badge>
+                        <div className='mt-2 text-sm text-muted-foreground'>
+                          {provider.testResult.outcome}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-64 align-top'>
+                        <div>
+                          Priority {provider.priority ?? 'not assigned'}
+                        </div>
+                        <div className='mt-1 text-sm text-muted-foreground'>
+                          Namespaces:{' '}
+                          {provider.namespaces.length
+                            ? provider.namespaces.join(', ')
+                            : 'not mapped'}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-48 align-top'>
+                        <div>{provider.testResult.checkedAt}</div>
+                        <div className='text-sm text-muted-foreground'>
+                          {provider.lastCheckedAt}
+                        </div>
+                      </TableCell>
+                      <TableCell className='min-w-56 align-top'>
+                        <div className='flex flex-wrap gap-2'>
+                          <Button type='button' size='sm' variant='outline'>
+                            <Settings className='size-4' /> Configure
+                          </Button>
+                          <Button type='button' size='sm' variant='outline'>
+                            <ShieldCheck className='size-4' /> Test
+                          </Button>
+                        </div>
+                        <div className='mt-2 text-xs text-muted-foreground'>
+                          {provider.nextAction}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {configuredProviders.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={6} className='h-24 text-center'>
+                        No configured providers match the current filters.
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className='flex flex-wrap items-start justify-between gap-3'>
+              <div>
+                <CardTitle className='flex items-center gap-2'>
+                  <Plus className='size-4' /> Add Provider
+                </CardTitle>
+                <CardDescription>
+                  Supported provider types stay unconfigured until an operator
+                  adds provider-specific metadata, mappings, priority, and a
+                  safe test result.
+                </CardDescription>
+              </div>
+              <Badge variant='outline'>{summary.addableCount} available</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-3'>
+              {addableProviders.map((provider) => (
+                <div
+                  key={provider.id}
+                  className='rounded-md border p-4 text-sm'
+                >
+                  <div className='flex flex-wrap items-start justify-between gap-2'>
+                    <div>
+                      <div className='font-medium'>{provider.title}</div>
+                      <div className='text-xs text-muted-foreground'>
+                        {providerTypeLabel(provider)}
+                      </div>
+                    </div>
+                    <Badge variant='outline'>addable</Badge>
+                  </div>
+                  <p className='mt-3 text-muted-foreground'>
+                    {provider.summary}
+                  </p>
+                  {provider.warnings.length ? (
+                    <div className='mt-3 flex flex-wrap gap-1'>
+                      {provider.warnings.map((warning) => (
+                        <Badge key={warning.code} variant='secondary'>
+                          {warning.title}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                  <div className='mt-3 rounded-md bg-muted/40 p-3'>
+                    {provider.nextAction}
+                  </div>
+                  <Button type='button' className='mt-3' variant='outline'>
+                    <Plus className='size-4' /> Add {provider.title}
+                  </Button>
+                </div>
+              ))}
+            </div>
+            {addableProviders.length === 0 ? (
+              <div className='rounded-md border border-dashed p-6 text-sm text-muted-foreground'>
+                No addable provider options match the current filters.
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </Main>
+    </>
+  )
+}

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -39,6 +39,9 @@ import {
   singleSecretRevealScenarios,
 } from './single-secret-reveal'
 import {
+  buildProvidersManagementSummary,
+  getAddableSecretsBrokerProviders,
+  getConfiguredSecretsBrokerProviders,
   secretsBrokerSourceBackends,
   sourceBackendHasSecretValue,
 } from './source-backends'
@@ -358,11 +361,22 @@ describe('Secrets Broker setup wizard', () => {
     ).toHaveLength(1)
   })
 
-  it('renders secret sources and backends with warning states and metadata-only test results', async () => {
+  it('renders Providers management with local default and addable provider options', async () => {
+    const user = userEvent.setup()
     await renderRoute('/secrets-broker/sources')
 
-    expect(screen.getByText(/Secret Sources \/ Backends/i)).toBeVisible()
+    expect(
+      screen.getByRole('heading', { name: /Secrets Broker providers/i })
+    ).toBeVisible()
     expect(screen.getAllByText(/Metadata only/i)[0]).toBeVisible()
+    expect(screen.getByText(/Configured provider table/i)).toBeVisible()
+    expect(screen.getByText(/^Add Provider$/i)).toBeVisible()
+    expect(screen.getAllByText(/Local encrypted store/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/local-encrypted-store/i)[0]).toBeVisible()
+    expect(screen.getByText(/Priority 1/i)).toBeVisible()
+    expect(screen.getByText(/^default$/i)).toBeVisible()
+    expect(screen.getByRole('button', { name: /Configure/i })).toBeVisible()
+    expect(screen.getByRole('button', { name: /^Test$/i })).toBeVisible()
     expect(screen.getAllByText(/Environment provider/i)[0]).toBeVisible()
     expect(screen.getAllByText(/File provider/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Exec provider/i)[0]).toBeVisible()
@@ -378,18 +392,13 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getByText(/Untrusted command path/i)).toBeVisible()
     expect(screen.getByText(/Missing timeout\/output limits/i)).toBeVisible()
     expect(
-      screen.getAllByRole('button', { name: /Test source/i })[0]
+      screen.getAllByRole('button', { name: /Add Environment provider/i })[0]
     ).toBeVisible()
-    expect(
-      screen.getAllByRole('link', { name: /View diagnostics/i })[0]
-    ).toHaveAttribute('href', '/secrets-broker/sources')
-    expect(
-      screen.getAllByRole('link', { name: /Edit configuration/i })[0]
-    ).toHaveAttribute('href', '/secrets-broker/sources')
-    expect(screen.getByText(/3 keys matched allowlist/i)).toBeVisible()
-    expect(screen.getByText(/path policy denied/i)).toBeVisible()
-    expect(screen.getByText(/command not executed/i)).toBeVisible()
-    expect(screen.getAllByText(/value=hidden/i)[0]).toBeVisible()
+
+    await user.type(screen.getByLabelText(/Search providers/i), 'aws')
+    expect(screen.getByText(/No configured providers match/i)).toBeVisible()
+    expect(screen.getAllByText(/AWS Secrets Manager CLI/i)[0]).toBeVisible()
+    expect(screen.queryByText(/Environment provider/i)).not.toBeInTheDocument()
   })
 
   it('routes the legacy secret-sources hash to the canonical sources page', async () => {
@@ -397,7 +406,7 @@ describe('Secrets Broker setup wizard', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /^Secrets Broker sources$/i })
+        screen.getByRole('heading', { name: /^Secrets Broker providers$/i })
       ).toBeVisible()
     })
 
@@ -424,17 +433,26 @@ describe('Secrets Broker setup wizard', () => {
     })
   })
 
-  it('links source configuration actions to the Providers page', async () => {
+  it('keeps provider management fixtures scoped to one configured default', async () => {
     await renderRoute('/secrets-broker/sources')
 
-    const configurationLinks = screen.getAllByRole('link', {
-      name: /Edit configuration/i,
+    expect(getConfiguredSecretsBrokerProviders()).toHaveLength(1)
+    expect(getConfiguredSecretsBrokerProviders()[0]).toMatchObject({
+      id: 'local-encrypted-store',
+      configured: true,
+      defaultRole: 'default',
+    })
+    expect(getAddableSecretsBrokerProviders().length).toBeGreaterThan(1)
+    expect(buildProvidersManagementSummary()).toMatchObject({
+      configuredCount: 1,
+      readyCount: 1,
+      needsActionCount: 0,
+      defaultProvider: 'Local encrypted store',
     })
 
-    expect(configurationLinks[0]).toHaveAttribute(
-      'href',
-      '/secrets-broker/sources'
-    )
+    expect(
+      screen.getByRole('button', { name: /Add AWS Secrets Manager CLI/i })
+    ).toBeVisible()
   })
 
   it('keeps source backend fixtures free of secret values', () => {

--- a/src/features/secrets-broker/source-backends.ts
+++ b/src/features/secrets-broker/source-backends.ts
@@ -29,6 +29,14 @@ export type SecretsBrokerSourceWarning = {
   description: string
 }
 
+export type SecretsBrokerProviderLifecycle =
+  | 'setup-needed'
+  | 'locked'
+  | 'unlocked'
+  | 'auth-required'
+  | 'invalid'
+  | 'ready'
+
 export type SecretsBrokerSourceTestResult = {
   outcome: 'success' | 'failure' | 'not-run'
   checkedAt: string
@@ -42,6 +50,13 @@ export type SecretsBrokerSourceBackend = {
   provider: string
   source: string
   connection: string
+  configured: boolean
+  enabled: boolean
+  priority: number | null
+  namespaces: string[]
+  defaultRole: 'default' | 'fallback' | 'addable'
+  lifecycle: SecretsBrokerProviderLifecycle
+  nextAction: string
   state: SecretsBrokerSourceState
   mode: string
   lastCheckedAt: string
@@ -63,6 +78,13 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     provider: 'local',
     source: '@secretsbroker/local/default',
     connection: 'Local encrypted vault',
+    configured: true,
+    enabled: true,
+    priority: 1,
+    namespaces: ['default', 'services/*', 'workspaces/*'],
+    defaultRole: 'default',
+    lifecycle: 'unlocked',
+    nextAction: 'Test provider status or open backup and key management.',
     state: 'reachable',
     mode: 'local-first encrypted store',
     lastCheckedAt: '2026-05-07T18:32:00Z',
@@ -91,9 +113,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'Environment provider',
     type: 'env',
     provider: 'env',
-    source: '@secretsbroker/env/service-lasso',
-    connection: 'Process environment',
-    state: 'configured',
+    source: 'addable:env',
+    connection: 'Add provider to choose allowlisted environment keys',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, define an explicit allowlist, then test metadata only.',
+    state: 'not-configured',
     mode: 'read-only allowlist',
     lastCheckedAt: '2026-05-07T18:31:15Z',
     summary:
@@ -125,9 +155,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'File provider',
     type: 'file',
     provider: 'file',
-    source: '@secretsbroker/file/runtime',
-    connection: 'Scoped runtime env file',
-    state: 'failing',
+    source: 'addable:file',
+    connection: 'Add provider to choose scoped file paths',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, restrict root paths, then run path/symlink validation.',
+    state: 'not-configured',
     mode: 'read-only file path',
     lastCheckedAt: '2026-05-07T18:30:40Z',
     summary:
@@ -168,9 +206,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'Exec provider',
     type: 'exec',
     provider: 'exec',
-    source: '@secretsbroker/exec/openclaw',
-    connection: 'OpenClaw SecretRef adapter',
-    state: 'failing',
+    source: 'addable:exec',
+    connection: 'Add provider to choose a trusted resolver command',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, pin trusted command paths, timeout, and output limits.',
+    state: 'not-configured',
     mode: 'allowlisted command',
     lastCheckedAt: '2026-05-07T18:30:05Z',
     summary:
@@ -214,9 +260,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'HashiCorp Vault CLI',
     type: 'vault-cli',
     provider: 'vault',
-    source: '@secretsbroker/external/ops',
-    connection: 'Vault kv/service-lasso',
-    state: 'failing',
+    source: 'addable:vault',
+    connection: 'Add provider to configure Vault/OpenBao metadata',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, capture safe address/mount metadata, and test auth state.',
+    state: 'not-configured',
     mode: 'external cli read',
     lastCheckedAt: '2026-05-07T18:29:40Z',
     summary:
@@ -252,8 +306,16 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'AWS Secrets Manager CLI',
     type: 'aws-secrets-manager-cli',
     provider: 'aws',
-    source: '@secretsbroker/external/aws',
-    connection: 'AWS Secrets Manager CLI',
+    source: 'addable:aws-secrets-manager',
+    connection: 'Add provider to configure AWS metadata',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, choose safe region/profile metadata, then run metadata-only tests.',
     state: 'untested',
     mode: 'external cli metadata probe',
     lastCheckedAt: 'never',
@@ -278,9 +340,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: '1Password CLI',
     type: 'onepassword-cli',
     provider: 'onepassword',
-    source: '@secretsbroker/external/1password',
-    connection: '1Password ops vault',
-    state: 'configured',
+    source: 'addable:onepassword',
+    connection: 'Add provider to configure 1Password item mappings',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, map vault/item metadata, and verify sign-in state.',
+    state: 'not-configured',
     mode: 'external cli metadata probe',
     lastCheckedAt: '2026-05-07T18:28:30Z',
     summary:
@@ -304,8 +374,16 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'Bitwarden / BWS CLI',
     type: 'bitwarden-bws-cli',
     provider: 'bitwarden',
-    source: '@secretsbroker/external/bws',
-    connection: 'Bitwarden Secrets Manager',
+    source: 'addable:bitwarden-bws',
+    connection: 'Add provider to configure BWS project mappings',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, map project/secret ids, and keep tokens as refs only.',
     state: 'not-configured',
     mode: 'external cli metadata probe',
     lastCheckedAt: 'never',
@@ -330,9 +408,17 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     title: 'Docker/Kubernetes mounted secrets',
     type: 'mounted-secrets',
     provider: 'mounted-file',
-    source: '@secretsbroker/mounted/run-secrets',
-    connection: '/run/secrets/*',
-    state: 'configured',
+    source: 'addable:mounted-secrets',
+    connection: 'Add provider to configure mounted path metadata',
+    configured: false,
+    enabled: false,
+    priority: null,
+    namespaces: [],
+    defaultRole: 'addable',
+    lifecycle: 'setup-needed',
+    nextAction:
+      'Add provider, restrict root path and symlink policy, then test metadata only.',
+    state: 'not-configured',
     mode: 'read-only mounted path',
     lastCheckedAt: '2026-05-07T18:27:20Z',
     summary:
@@ -376,6 +462,79 @@ export function countSourceBackendsByState(
       failing: 0,
       untested: 0,
     }
+  )
+}
+
+export function getConfiguredSecretsBrokerProviders(
+  sources: SecretsBrokerSourceBackend[] = secretsBrokerSourceBackends
+) {
+  return sources
+    .filter((source) => source.configured)
+    .sort((left, right) => (left.priority ?? 999) - (right.priority ?? 999))
+}
+
+export function getAddableSecretsBrokerProviders(
+  sources: SecretsBrokerSourceBackend[] = secretsBrokerSourceBackends
+) {
+  return sources
+    .filter((source) => !source.configured)
+    .sort((left, right) => left.title.localeCompare(right.title))
+}
+
+export function buildProvidersManagementSummary(
+  sources: SecretsBrokerSourceBackend[] = secretsBrokerSourceBackends
+) {
+  const configured = getConfiguredSecretsBrokerProviders(sources)
+  const addable = getAddableSecretsBrokerProviders(sources)
+  const ready = configured.filter(
+    (source) =>
+      source.enabled &&
+      ['reachable', 'configured'].includes(source.state) &&
+      ['ready', 'unlocked'].includes(source.lifecycle)
+  )
+  const needsAction = configured.filter(
+    (source) =>
+      !source.enabled ||
+      ['failing', 'untested'].includes(source.state) ||
+      !['ready', 'unlocked'].includes(source.lifecycle)
+  )
+  const defaultProvider =
+    configured.find((source) => source.defaultRole === 'default') ??
+    configured[0]
+
+  return {
+    configuredCount: configured.length,
+    addableCount: addable.length,
+    readyCount: ready.length,
+    needsActionCount: needsAction.length,
+    defaultProvider: defaultProvider?.title ?? 'None',
+  }
+}
+
+export function filterProviderManagementRows(
+  sources: SecretsBrokerSourceBackend[],
+  query: string
+) {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  if (!normalizedQuery) return sources
+
+  return sources.filter((source) =>
+    [
+      source.title,
+      source.type,
+      source.provider,
+      source.source,
+      source.connection,
+      source.state,
+      source.lifecycle,
+      source.namespaces.join(' '),
+      source.defaultRole,
+      source.nextAction,
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedQuery)
   )
 }
 

--- a/src/routes/_authenticated/secrets-broker/sources.tsx
+++ b/src/routes/_authenticated/secrets-broker/sources.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { SecretsBrokerSetupWizard } from '@/features/secrets-broker'
+import { ProvidersManagementPage } from '@/features/secrets-broker/providers-management-page'
 
 export const Route = createFileRoute('/_authenticated/secrets-broker/sources')({
-  component: () => <SecretsBrokerSetupWizard focusSection='sources' />,
+  component: ProvidersManagementPage,
 })

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -65,8 +65,8 @@ const appScreens: ScreenCase[] = [
   },
   {
     path: '/secrets-broker/sources',
-    heading: /^Secrets Broker sources$/i,
-    title: 'Service Admin - Secrets Broker Sources',
+    heading: /^Secrets Broker providers$/i,
+    title: 'Service Admin - Secrets Broker Providers',
   },
   {
     path: '/secrets-broker/operational-controls',

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -80,9 +80,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByRole('link', { name: 'View providers' })
     ).toBeVisible()
-    await expect(
-      page.getByRole('link', { name: 'View secret sources' })
-    ).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Add provider' })).toBeVisible()
     await expect(
       page.getByRole('link', { name: 'View audit/events' })
     ).toBeVisible()
@@ -242,7 +240,7 @@ test.describe('Secrets Broker browser coverage', () => {
   }) => {
     const sections = [
       ['/secrets-broker/operational-controls', /Operational controls/i],
-      ['/secrets-broker/sources', /Secret Sources \/ Backends/i],
+      ['/secrets-broker/sources', /Secrets Broker providers/i],
       ['/secrets-broker/backup-keys', /Backup, restore, and key management/i],
       ['/secrets-broker/topology', /Secrets Broker topology/i],
       ['/secrets-broker/audit-events', /Audit and events/i],


### PR DESCRIPTION
## Issue
Closes #187

## Summary
- Replaced `/secrets-broker/sources` with a dedicated Providers management page.
- Models only `Local encrypted store` as configured by default; every other supported provider is listed through Add Provider until configured.
- Added provider search, priority/status ordering, summary cards, configured-provider table actions, and addable provider option cards.
- Updated overview labels and route/page tests from Sources to Providers.

## Scope
- In scope: Service Admin Secrets Broker Providers UI foundation and safe fixture model.
- Out of scope: live backend mutation, persisted provider creation, provider-specific configuration implementation for #188-#192.

## Spec / contract / fixture impact
- Updated: `src/features/secrets-broker/source-backends.ts` provider fixture contract adds configured/enabled/priority/namespaces/default/lifecycle/next-action metadata.
- Not required: no public API schema or backend contract changes.

## Nash invariant impact
- Invariant: provider credentials, raw secret values, key material, command output, and source values must not render in UI fixtures, logs, routes, or tests.
- Preservation proof: focused unit tests include provider fixture no-secret checks; Playwright Secrets Broker coverage also ran with no forbidden secret material.

## Validation
- PASS `npm run lint` — `.work-agent/logs/issue-187/lint-20260618-2134.log`
- PASS `npm run build` — `.work-agent/logs/issue-187/build-20260618-2134.log`
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx src/features/secrets-broker/provider-configuration.test.tsx src/test/app-screens.test.tsx` — 3 files / 69 tests passed, `.work-agent/logs/issue-187/unit-focused-20260618-2134.log`
- PASS `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — 5 Playwright tests passed, `.work-agent/logs/issue-187/playwright-secrets-broker-20260618-2136.log`
- PASS canonical demo recycle: copied committed build `1aa43dd` into live extracted `@serviceadmin` dist, restarted through runtime API, verified `http://192.168.1.53:17700/` HTTP 200 and `http://192.168.1.53:17883/api/health` status `ok` — `.work-agent/logs/issue-187/demo-recycle-20260618-2138.log`

## Approval trail
- Required: no human approval required before PR review.
- Evidence: issue #187 ready lane; #193 dependency already merged before branch start.

## Cleanup
- Branch: `feat/issue-187-providers-foundation`
- Commit: `1aa43dd`
- Local repo clean after push.
- Canonical demo is serving the branch build for validation.
