### PR TITLE
feat: add operations telemetry and audit pages

### DIFF
--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -64,4 +64,19 @@ describe('sidebar optional page classification', () => {
       secretsBrokerGroup?.items.every((item) => !item.url?.includes('#'))
     ).toBe(true)
   })
+
+  it('exposes Operations telemetry and audit pages as first-class routes', () => {
+    const operationsGroup = sidebarData.navGroups.find(
+      (group) => group.title === 'Operations'
+    )
+
+    expect(operationsGroup?.items.map((item) => item.url)).toEqual([
+      '/operations/telemetry',
+      '/operations/audit-logging',
+    ])
+    expect(operationsGroup?.items.map((item) => item.title)).toEqual([
+      'Telemetry',
+      'Audit Logging',
+    ])
+  })
 })

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -2,6 +2,7 @@ import {
   Boxes,
   Command,
   DatabaseZap,
+  FileChartColumn,
   FileKey2,
   GitBranch,
   Globe,
@@ -80,6 +81,21 @@ export const sidebarData: SidebarData = {
           title: 'Network',
           url: '/network',
           icon: Globe,
+        },
+      ],
+    },
+    {
+      title: 'Operations',
+      items: [
+        {
+          title: 'Telemetry',
+          url: '/operations/telemetry',
+          icon: FileChartColumn,
+        },
+        {
+          title: 'Audit Logging',
+          url: '/operations/audit-logging',
+          icon: ScrollText,
         },
       ],
     },

--- a/src/features/operations/index.tsx
+++ b/src/features/operations/index.tsx
@@ -1,0 +1,648 @@
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import {
+  type ColumnDef,
+  type ColumnFiltersState,
+  type SortingState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { Activity, ClipboardCheck, FileChartColumn } from 'lucide-react'
+import { usePageMetadata } from '@/lib/page-metadata'
+import { useServices } from '@/lib/service-lasso-dashboard/hooks'
+import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ConfigDrawer } from '@/components/config-drawer'
+import {
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+} from '@/components/data-table'
+import { Header } from '@/components/layout/header'
+import { Main } from '@/components/layout/main'
+import { ProfileDropdown } from '@/components/profile-dropdown'
+import { Search } from '@/components/search'
+import { ThemeSwitch } from '@/components/theme-switch'
+import {
+  auditEventTypeLabel,
+  secretsBrokerAuditEvents,
+  type SecretsBrokerAuditEvent,
+} from '@/features/secrets-broker/audit-events'
+
+type OperationsSource = 'Service Lasso' | 'Secrets Broker'
+type OperationsState = 'available' | 'degraded' | 'unavailable'
+
+type TelemetryRow = {
+  id: string
+  signal: string
+  source: OperationsSource
+  owner: string
+  state: OperationsState
+  lastSample: string
+  value: string
+  nextAction: string
+}
+
+type AuditLogRow = {
+  id: string
+  event: string
+  source: OperationsSource
+  actor: string
+  outcome: string
+  policy: string
+  tamperEvidence: string
+  recordedAt: string
+  safeSummary: string
+}
+
+const stateVariant: Record<
+  OperationsState,
+  'default' | 'secondary' | 'outline' | 'destructive'
+> = {
+  available: 'default',
+  degraded: 'secondary',
+  unavailable: 'outline',
+}
+
+const sourceOptions = [
+  { label: 'Service Lasso', value: 'Service Lasso' },
+  { label: 'Secrets Broker', value: 'Secrets Broker' },
+]
+
+function stateLabel(state: OperationsState) {
+  return state.replace('-', ' ')
+}
+
+function operationStateForService(service: DashboardService): OperationsState {
+  if (service.status === 'running' || service.status === 'available') {
+    return 'available'
+  }
+  if (service.status === 'degraded') return 'degraded'
+  return 'unavailable'
+}
+
+function buildTelemetryRows(services: DashboardService[]): TelemetryRow[] {
+  const serviceRows: TelemetryRow[] = services.slice(0, 6).map((service) => ({
+    id: `service-${service.id}`,
+    signal: service.name,
+    source: 'Service Lasso',
+    owner: service.id,
+    state: operationStateForService(service),
+    lastSample: service.runtimeHealth.lastCheckAt,
+    value: service.runtimeHealth.summary,
+    nextAction:
+      service.status === 'running'
+        ? 'Runtime telemetry source is reporting.'
+        : 'Check runtime state before treating this signal as healthy.',
+  }))
+
+  return [
+    ...serviceRows,
+    {
+      id: 'runtime-health',
+      signal: 'Runtime API health',
+      source: 'Service Lasso',
+      owner: 'service-lasso-runtime',
+      state: services.length ? 'available' : 'unavailable',
+      lastSample: services[0]?.runtimeHealth.lastCheckAt ?? 'Not sampled',
+      value: services.length
+        ? `${services.length} service records available`
+        : 'Runtime service list is unavailable in this environment.',
+      nextAction: services.length
+        ? 'Use Runtime or Logs for service-level details.'
+        : 'Verify Service Lasso runtime health endpoint before operating.',
+    },
+    {
+      id: 'secretsbroker-audit-metadata',
+      signal: 'Secrets Broker audit metadata',
+      source: 'Secrets Broker',
+      owner: '@secretsbroker',
+      state: 'available',
+      lastSample: secretsBrokerAuditEvents[0]?.timestamp ?? 'Not sampled',
+      value: `${secretsBrokerAuditEvents.length} metadata-only audit events loaded`,
+      nextAction: 'Use Audit Logging for policy, outcome, and chain status.',
+    },
+    {
+      id: 'secretsbroker-telemetry-endpoint',
+      signal: 'Secrets Broker telemetry endpoint',
+      source: 'Secrets Broker',
+      owner: '@secretsbroker',
+      state: 'unavailable',
+      lastSample: 'Not configured',
+      value: 'Broker metrics endpoint is not configured in the current demo.',
+      nextAction:
+        'Keep this explicit instead of presenting missing telemetry as success.',
+    },
+  ]
+}
+
+function buildAuditRows(): AuditLogRow[] {
+  const brokerRows = secretsBrokerAuditEvents.map(
+    (event: SecretsBrokerAuditEvent): AuditLogRow => ({
+      id: event.id,
+      event: auditEventTypeLabel(event.type),
+      source: 'Secrets Broker',
+      actor: `${event.actorType}: ${event.actorId}`,
+      outcome: event.outcome,
+      policy: event.policyDecision,
+      tamperEvidence: event.tamperEvidence.status,
+      recordedAt: event.timestamp,
+      safeSummary: event.normalizedReason,
+    })
+  )
+
+  return [
+    {
+      id: 'service-lasso-runtime-check',
+      event: 'runtime health checked',
+      source: 'Service Lasso',
+      actor: 'serviceadmin:operator-view',
+      outcome: 'success',
+      policy: 'metadata-only runtime status read',
+      tamperEvidence: 'unavailable',
+      recordedAt: '2026-05-07T18:21:00Z',
+      safeSummary:
+        'Runtime health and service status were viewed without log payloads or secret values.',
+    },
+    {
+      id: 'service-lasso-log-viewer-opened',
+      event: 'log viewer opened',
+      source: 'Service Lasso',
+      actor: 'serviceadmin:operator-view',
+      outcome: 'granted',
+      policy: 'server resolves log paths before browser access',
+      tamperEvidence: 'unavailable',
+      recordedAt: '2026-05-07T18:20:30Z',
+      safeSummary:
+        'Log access surface keeps browser requests scoped to service id and log type.',
+    },
+    ...brokerRows,
+  ]
+}
+
+function OperationsLoading() {
+  return (
+    <div className='flex flex-1 flex-col gap-4'>
+      <Skeleton className='h-10 w-full max-w-xl' />
+      <Skeleton className='h-[420px] w-full' />
+      <Skeleton className='mt-auto h-9 w-full max-w-md' />
+    </div>
+  )
+}
+
+function OperationsStateBadge({ state }: { state: OperationsState }) {
+  return <Badge variant={stateVariant[state]}>{stateLabel(state)}</Badge>
+}
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  if (['success', 'granted'].includes(outcome)) {
+    return (
+      <Badge className='bg-emerald-600 hover:bg-emerald-600'>{outcome}</Badge>
+    )
+  }
+  if (outcome === 'denied') return <Badge variant='secondary'>{outcome}</Badge>
+  if (outcome === 'failure')
+    return <Badge variant='destructive'>{outcome}</Badge>
+  return <Badge variant='outline'>{outcome}</Badge>
+}
+
+const telemetryColumns: ColumnDef<TelemetryRow>[] = [
+  {
+    accessorKey: 'signal',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Signal' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex max-w-[240px] min-w-0 flex-col'>
+        <span className='truncate font-medium' title={row.original.signal}>
+          {row.original.signal}
+        </span>
+        <span className='truncate text-xs text-muted-foreground'>
+          {row.original.owner}
+        </span>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'source',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Source' />
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'state',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='State' />
+    ),
+    cell: ({ row }) => <OperationsStateBadge state={row.original.state} />,
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'lastSample',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Last sample' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[180px] truncate whitespace-nowrap'>
+        {row.original.lastSample}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'value',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Value' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[320px] truncate' title={row.original.value}>
+        {row.original.value}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'nextAction',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Next action' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[360px] truncate' title={row.original.nextAction}>
+        {row.original.nextAction}
+      </div>
+    ),
+  },
+]
+
+const auditColumns: ColumnDef<AuditLogRow>[] = [
+  {
+    accessorKey: 'event',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Event' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex max-w-[240px] min-w-0 flex-col'>
+        <span className='truncate font-medium' title={row.original.event}>
+          {row.original.event}
+        </span>
+        <span className='truncate text-xs text-muted-foreground'>
+          {row.original.id}
+        </span>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: 'source',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Source' />
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'outcome',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Outcome' />
+    ),
+    cell: ({ row }) => <OutcomeBadge outcome={row.original.outcome} />,
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'actor',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Actor' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[220px] truncate' title={row.original.actor}>
+        {row.original.actor}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'policy',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Policy' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[320px] truncate' title={row.original.policy}>
+        {row.original.policy}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'tamperEvidence',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Chain' />
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    accessorKey: 'recordedAt',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Recorded' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[180px] truncate whitespace-nowrap'>
+        {row.original.recordedAt}
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'safeSummary',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Safe summary' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[360px] truncate' title={row.original.safeSummary}>
+        {row.original.safeSummary}
+      </div>
+    ),
+  },
+]
+
+function OperationsTable<TData>({
+  data,
+  columns,
+  searchKey,
+  searchPlaceholder,
+  filters,
+  emptyMessage,
+}: {
+  data: TData[]
+  columns: ColumnDef<TData>[]
+  searchKey: string
+  searchPlaceholder: string
+  filters: {
+    columnId: string
+    title: string
+    options: { label: string; value: string }[]
+  }[]
+  emptyMessage: string
+}) {
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, columnFilters },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
+
+  return (
+    <div className='flex flex-1 flex-col gap-4'>
+      <DataTableToolbar
+        table={table}
+        searchKey={searchKey}
+        searchPlaceholder={searchPlaceholder}
+        filters={filters}
+      />
+      <div className='overflow-hidden rounded-md border'>
+        <Table className='table-fixed'>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className='min-w-0'>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className='h-24 text-center'
+                >
+                  {emptyMessage}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <DataTablePagination table={table} className='mt-auto' />
+    </div>
+  )
+}
+
+function OperationsHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <>
+      <Header fixed>
+        <Search />
+        <div className='ms-auto flex items-center space-x-4'>
+          <ThemeSwitch />
+          <ConfigDrawer />
+          <ProfileDropdown />
+        </div>
+      </Header>
+
+      <div className='flex flex-wrap items-end justify-between gap-2'>
+        <div>
+          <h2 className='text-2xl font-bold tracking-tight'>{title}</h2>
+          <p className='text-muted-foreground'>{description}</p>
+        </div>
+        <div className='flex flex-wrap gap-2'>
+          <Button variant='outline' size='sm' asChild>
+            <Link to='/runtime'>Runtime</Link>
+          </Button>
+          <Button variant='outline' size='sm' asChild>
+            <Link to='/secrets-broker/audit-events'>Secrets audit</Link>
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export function OperationsTelemetry() {
+  usePageMetadata({
+    title: 'Service Admin - Operations Telemetry',
+    description:
+      'Operations telemetry across Service Lasso and Secrets Broker sources.',
+  })
+
+  const servicesQuery = useServices()
+  const rows = useMemo(
+    () => buildTelemetryRows(servicesQuery.data ?? []),
+    [servicesQuery.data]
+  )
+
+  return (
+    <>
+      <OperationsHeader
+        title='Telemetry'
+        description='Service Lasso runtime and Secrets Broker telemetry status, with missing sources shown explicitly.'
+      />
+      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='grid gap-4 md:grid-cols-3'>
+          <div className='rounded-md border p-4'>
+            <div className='flex items-center gap-2 text-sm font-medium'>
+              <Activity className='size-4' /> Service Lasso signals
+            </div>
+            <div className='mt-2 text-2xl font-bold'>
+              {rows.filter((row) => row.source === 'Service Lasso').length}
+            </div>
+            <p className='text-xs text-muted-foreground'>
+              Runtime-backed rows use service metadata and health summaries.
+            </p>
+          </div>
+          <div className='rounded-md border p-4'>
+            <div className='flex items-center gap-2 text-sm font-medium'>
+              <FileChartColumn className='size-4' /> Secrets Broker signals
+            </div>
+            <div className='mt-2 text-2xl font-bold'>
+              {rows.filter((row) => row.source === 'Secrets Broker').length}
+            </div>
+            <p className='text-xs text-muted-foreground'>
+              Broker rows are metadata-only and mark unavailable telemetry.
+            </p>
+          </div>
+          <div className='rounded-md border p-4'>
+            <div className='flex items-center gap-2 text-sm font-medium'>
+              <ClipboardCheck className='size-4' /> Safety boundary
+            </div>
+            <div className='mt-2 text-2xl font-bold'>No values</div>
+            <p className='text-xs text-muted-foreground'>
+              No secret values, tokens, credentials, or raw log payloads are
+              shown.
+            </p>
+          </div>
+        </div>
+
+        {servicesQuery.isLoading ? (
+          <OperationsLoading />
+        ) : (
+          <OperationsTable
+            data={rows}
+            columns={telemetryColumns}
+            searchKey='signal'
+            searchPlaceholder='Search telemetry signals...'
+            filters={[
+              { columnId: 'source', title: 'Source', options: sourceOptions },
+              {
+                columnId: 'state',
+                title: 'State',
+                options: [
+                  { label: 'Available', value: 'available' },
+                  { label: 'Degraded', value: 'degraded' },
+                  { label: 'Unavailable', value: 'unavailable' },
+                ],
+              },
+            ]}
+            emptyMessage='No telemetry rows match the current filters.'
+          />
+        )}
+      </Main>
+    </>
+  )
+}
+
+export function OperationsAuditLogging() {
+  usePageMetadata({
+    title: 'Service Admin - Operations Audit Logging',
+    description:
+      'Operations audit logging across Service Lasso and Secrets Broker sources.',
+  })
+
+  const rows = useMemo(() => buildAuditRows(), [])
+  const outcomes = useMemo(
+    () =>
+      Array.from(new Set(rows.map((row) => row.outcome)))
+        .sort()
+        .map((outcome) => ({ label: outcome, value: outcome })),
+    [rows]
+  )
+  const chainStates = useMemo(
+    () =>
+      Array.from(new Set(rows.map((row) => row.tamperEvidence)))
+        .sort()
+        .map((status) => ({ label: status, value: status })),
+    [rows]
+  )
+
+  return (
+    <>
+      <OperationsHeader
+        title='Audit Logging'
+        description='Metadata-only operation events for Service Lasso and Secrets Broker, including explicit unavailable chain proof states.'
+      />
+      <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='rounded-md border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground'>
+          Audit rows use safe identifiers, policy metadata, outcomes, and
+          tamper-evidence status only. Secret values, provider credentials,
+          tokens, private keys, raw response bodies, and recovery material are
+          outside this surface.
+        </div>
+        <OperationsTable
+          data={rows}
+          columns={auditColumns}
+          searchKey='event'
+          searchPlaceholder='Search audit events...'
+          filters={[
+            { columnId: 'source', title: 'Source', options: sourceOptions },
+            { columnId: 'outcome', title: 'Outcome', options: outcomes },
+            {
+              columnId: 'tamperEvidence',
+              title: 'Chain',
+              options: chainStates,
+            },
+          ]}
+          emptyMessage='No audit rows match the current filters.'
+        />
+      </Main>
+    </>
+  )
+}

--- a/src/features/operations/operations.test.tsx
+++ b/src/features/operations/operations.test.tsx
@@ -1,0 +1,40 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+describe('Operations pages', () => {
+  it('renders telemetry rows for Service Lasso and Secrets Broker with explicit unavailable state', async () => {
+    const { container } = await renderRoute('/operations/telemetry')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Telemetry$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Service Lasso runtime/i)).toBeVisible()
+    expect(
+      await screen.findByText(/Secrets Broker telemetry endpoint/i)
+    ).toBeVisible()
+    expect(
+      await screen.findByText(/not configured in the current demo/i)
+    ).toBeVisible()
+    expect(screen.getByText(/No values/i)).toBeVisible()
+    expect(container).not.toHaveTextContent(/BEGIN PRIVATE KEY/i)
+    expect(container).not.toHaveTextContent(/CLIENT_SECRET=/i)
+    expect(container).not.toHaveTextContent(/REFRESH_TOKEN=/i)
+  })
+
+  it('renders audit logging rows from both operation sources without secret payloads', async () => {
+    const { container } = await renderRoute('/operations/audit-logging')
+
+    expect(
+      await screen.findByRole('heading', { name: /Audit Logging/i })
+    ).toBeVisible()
+    expect(screen.getByText(/runtime health checked/i)).toBeVisible()
+    expect(screen.getByText(/resolve granted/i)).toBeVisible()
+    expect(screen.getAllByText(/Service Lasso/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Secrets Broker/i)[0]).toBeVisible()
+    expect(screen.getByText(/tamper-evidence status only/i)).toBeVisible()
+    expect(container).not.toHaveTextContent(/DEMO_REVEAL_VALUE_42/i)
+    expect(container).not.toHaveTextContent(/ACTUAL_SECRET/i)
+    expect(container).not.toHaveTextContent(/BOT_TOKEN=/i)
+  })
+})

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -65,6 +65,8 @@ import { Route as AuthenticatedSecretsBrokerConfigurationRouteImport } from './r
 import { Route as AuthenticatedSecretsBrokerBackupKeysRouteImport } from './routes/_authenticated/secrets-broker/backup-keys'
 import { Route as AuthenticatedSecretsBrokerAuditEventsRouteImport } from './routes/_authenticated/secrets-broker/audit-events'
 import { Route as AuthenticatedSecretsBrokerConnectionIdRouteImport } from './routes/_authenticated/secrets-broker.$connectionId'
+import { Route as AuthenticatedOperationsTelemetryRouteImport } from './routes/_authenticated/operations/telemetry'
+import { Route as AuthenticatedOperationsAuditLoggingRouteImport } from './routes/_authenticated/operations/audit-logging'
 import { Route as AuthenticatedErrorsErrorRouteImport } from './routes/_authenticated/errors/$error'
 
 const ClerkRouteRoute = ClerkRouteRouteImport.update({
@@ -378,6 +380,18 @@ const AuthenticatedSecretsBrokerConnectionIdRoute =
     path: '/secrets-broker/$connectionId',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedOperationsTelemetryRoute =
+  AuthenticatedOperationsTelemetryRouteImport.update({
+    id: '/operations/telemetry',
+    path: '/operations/telemetry',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
+const AuthenticatedOperationsAuditLoggingRoute =
+  AuthenticatedOperationsAuditLoggingRouteImport.update({
+    id: '/operations/audit-logging',
+    path: '/operations/audit-logging',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedErrorsErrorRoute =
   AuthenticatedErrorsErrorRouteImport.update({
     id: '/errors/$error',
@@ -400,6 +414,8 @@ export interface FileRoutesByFullPath {
   '/500': typeof errors500Route
   '/503': typeof errors503Route
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/operations/audit-logging': typeof AuthenticatedOperationsAuditLoggingRoute
+  '/operations/telemetry': typeof AuthenticatedOperationsTelemetryRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/secrets-broker/audit-events': typeof AuthenticatedSecretsBrokerAuditEventsRoute
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
@@ -455,6 +471,8 @@ export interface FileRoutesByTo {
   '/503': typeof errors503Route
   '/': typeof AuthenticatedIndexRoute
   '/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/operations/audit-logging': typeof AuthenticatedOperationsAuditLoggingRoute
+  '/operations/telemetry': typeof AuthenticatedOperationsTelemetryRoute
   '/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/secrets-broker/audit-events': typeof AuthenticatedSecretsBrokerAuditEventsRoute
   '/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
@@ -515,6 +533,8 @@ export interface FileRoutesById {
   '/(errors)/503': typeof errors503Route
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/_authenticated/errors/$error': typeof AuthenticatedErrorsErrorRoute
+  '/_authenticated/operations/audit-logging': typeof AuthenticatedOperationsAuditLoggingRoute
+  '/_authenticated/operations/telemetry': typeof AuthenticatedOperationsTelemetryRoute
   '/_authenticated/secrets-broker/$connectionId': typeof AuthenticatedSecretsBrokerConnectionIdRoute
   '/_authenticated/secrets-broker/audit-events': typeof AuthenticatedSecretsBrokerAuditEventsRoute
   '/_authenticated/secrets-broker/backup-keys': typeof AuthenticatedSecretsBrokerBackupKeysRoute
@@ -573,6 +593,8 @@ export interface FileRouteTypes {
     | '/500'
     | '/503'
     | '/errors/$error'
+    | '/operations/audit-logging'
+    | '/operations/telemetry'
     | '/secrets-broker/$connectionId'
     | '/secrets-broker/audit-events'
     | '/secrets-broker/backup-keys'
@@ -628,6 +650,8 @@ export interface FileRouteTypes {
     | '/503'
     | '/'
     | '/errors/$error'
+    | '/operations/audit-logging'
+    | '/operations/telemetry'
     | '/secrets-broker/$connectionId'
     | '/secrets-broker/audit-events'
     | '/secrets-broker/backup-keys'
@@ -687,6 +711,8 @@ export interface FileRouteTypes {
     | '/(errors)/503'
     | '/_authenticated/'
     | '/_authenticated/errors/$error'
+    | '/_authenticated/operations/audit-logging'
+    | '/_authenticated/operations/telemetry'
     | '/_authenticated/secrets-broker/$connectionId'
     | '/_authenticated/secrets-broker/audit-events'
     | '/_authenticated/secrets-broker/backup-keys'
@@ -1138,6 +1164,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSecretsBrokerConnectionIdRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/operations/telemetry': {
+      id: '/_authenticated/operations/telemetry'
+      path: '/operations/telemetry'
+      fullPath: '/operations/telemetry'
+      preLoaderRoute: typeof AuthenticatedOperationsTelemetryRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
+    '/_authenticated/operations/audit-logging': {
+      id: '/_authenticated/operations/audit-logging'
+      path: '/operations/audit-logging'
+      fullPath: '/operations/audit-logging'
+      preLoaderRoute: typeof AuthenticatedOperationsAuditLoggingRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/errors/$error': {
       id: '/_authenticated/errors/$error'
       path: '/errors/$error'
@@ -1175,6 +1215,8 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedSettingsRouteRoute: typeof AuthenticatedSettingsRouteRouteWithChildren
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
   AuthenticatedErrorsErrorRoute: typeof AuthenticatedErrorsErrorRoute
+  AuthenticatedOperationsAuditLoggingRoute: typeof AuthenticatedOperationsAuditLoggingRoute
+  AuthenticatedOperationsTelemetryRoute: typeof AuthenticatedOperationsTelemetryRoute
   AuthenticatedSecretsBrokerConnectionIdRoute: typeof AuthenticatedSecretsBrokerConnectionIdRoute
   AuthenticatedSecretsBrokerAuditEventsRoute: typeof AuthenticatedSecretsBrokerAuditEventsRoute
   AuthenticatedSecretsBrokerBackupKeysRoute: typeof AuthenticatedSecretsBrokerBackupKeysRoute
@@ -1213,6 +1255,9 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedSettingsRouteRoute: AuthenticatedSettingsRouteRouteWithChildren,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
   AuthenticatedErrorsErrorRoute: AuthenticatedErrorsErrorRoute,
+  AuthenticatedOperationsAuditLoggingRoute:
+    AuthenticatedOperationsAuditLoggingRoute,
+  AuthenticatedOperationsTelemetryRoute: AuthenticatedOperationsTelemetryRoute,
   AuthenticatedSecretsBrokerConnectionIdRoute:
     AuthenticatedSecretsBrokerConnectionIdRoute,
   AuthenticatedSecretsBrokerAuditEventsRoute:

--- a/src/routes/_authenticated/operations/audit-logging.tsx
+++ b/src/routes/_authenticated/operations/audit-logging.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { OperationsAuditLogging } from '@/features/operations'
+
+export const Route = createFileRoute(
+  '/_authenticated/operations/audit-logging'
+)({
+  component: OperationsAuditLogging,
+})

--- a/src/routes/_authenticated/operations/telemetry.tsx
+++ b/src/routes/_authenticated/operations/telemetry.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { OperationsTelemetry } from '@/features/operations'
+
+export const Route = createFileRoute('/_authenticated/operations/telemetry')({
+  component: OperationsTelemetry,
+})


### PR DESCRIPTION
## Issue
Closes #159

## Summary
- Adds an Operations navigation section with Telemetry and Audit Logging routes.
- Surfaces Service Lasso runtime telemetry rows and Secrets Broker metadata-only audit/telemetry state.
- Keeps unavailable/config-missing telemetry explicit and excludes secret values, tokens, credentials, raw log payloads, and recovery material.

## Scope
- In scope: Service Admin navigation, operations routes/pages, table/list rendering, route generation, and focused tests.
- Out of scope: new backend telemetry ingestion, broker metrics endpoint implementation, tamper-proof audit storage changes.

## Spec / contract / fixture impact
- Updated: Service Admin UI behavior and route surface.
- Not required because: no public API, manifest schema, runtime lifecycle, or backend contract changed.

## Nash invariant impact
- Invariant: Service Admin stays optional and Service Lasso-facing; Secrets Broker surfaces remain metadata-only and do not expose secrets.
- Preservation proof: tests assert redaction boundaries and the operations UI labels unavailable broker telemetry as not configured.

## Validation
- PASS `npm run format:check` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/lasso-serviceadmin-format-check.log`
- PASS `npm run lint` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/lasso-serviceadmin-lint.log`
- PASS `npm run test` - 29 files / 160 tests - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/lasso-serviceadmin-test.log`
- PASS `npm run build` - existing Vite chunk-size warning only - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/lasso-serviceadmin-build.log`
- PASS `npm run test:ui` - 8 Playwright tests - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/lasso-serviceadmin-ui.log`
- PASS canonical demo preflight: `http://192.168.1.53:17700/` HTTP 200 and `http://192.168.1.53:17883/api/health` HTTP 200/status ok before PR.

## Approval trail
- Required: no explicit reviewer requirement observed before PR creation.
- Evidence: open PR will use hosted checks before merge.

## Cleanup
- Branch tracks `origin/issue-159-operations-telemetry-audit`; cleanup after merge will return local repo to clean `master` and delete the issue branch when safe.