### PR TITLE
fix(secretsbroker): scope backup keys under local store

### DIFF
--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -43,10 +43,11 @@ describe('sidebar optional page classification', () => {
     expect(titles).not.toContain('Diagnostics')
     expect(titles).not.toContain('Secret Inventory')
     expect(titles).not.toContain('Policy Simulation')
+    expect(titles).not.toContain('Backup / Keys')
     expect(titles).toContain('Providers')
   })
 
-  it('links visible Secrets Broker sub-items to route-backed pages only', () => {
+  it('links visible Secrets Broker sub-items without presenting Backup / Keys as a separate page', () => {
     const secretsBrokerGroup = sidebarData.navGroups.find(
       (group) => group.title === 'Secrets Broker'
     )
@@ -56,7 +57,6 @@ describe('sidebar optional page classification', () => {
       '/secrets-broker/secrets',
       '/secrets-broker/operational-controls',
       '/secrets-broker/sources',
-      '/secrets-broker/backup-keys',
       '/secrets-broker/topology',
       '/secrets-broker/audit-events',
     ])

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -3,7 +3,6 @@ import {
   Command,
   DatabaseZap,
   FileChartColumn,
-  FileKey2,
   GitBranch,
   Globe,
   Network,
@@ -121,11 +120,6 @@ export const sidebarData: SidebarData = {
           title: 'Providers',
           url: '/secrets-broker/sources',
           icon: DatabaseZap,
-        },
-        {
-          title: 'Backup / Keys',
-          url: '/secrets-broker/backup-keys',
-          icon: FileKey2,
         },
         {
           title: 'Topology',

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -74,11 +74,6 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Operational Controls',
   },
   {
-    path: '/secrets-broker/backup-keys',
-    heading: /^Local encrypted store$/i,
-    title: 'Service Admin - Local Encrypted Store',
-  },
-  {
     path: '/secrets-broker/topology',
     heading: /^Secrets Broker topology$/i,
     title: 'Service Admin - Secrets Broker Topology',
@@ -120,6 +115,14 @@ const removedSecretsBrokerRoutes = [
   ['/secrets-broker/policy-simulation', '/secrets-broker/operational-controls'],
 ] as const
 
+const compatibleSecretsBrokerRoutes: ScreenCase[] = [
+  {
+    path: '/secrets-broker/backup-keys',
+    heading: /^Local encrypted store$/i,
+    title: 'Service Admin - Local Encrypted Store',
+  },
+]
+
 describe('app screens', () => {
   it.each(appScreens)('renders $path', async ({ path, heading, title }) => {
     await renderRoute(path)
@@ -143,6 +146,23 @@ describe('app screens', () => {
       await waitFor(() => {
         expect(router.state.location.pathname).toBe(redirectedPath)
       })
+    }
+  )
+
+  it.each(compatibleSecretsBrokerRoutes)(
+    'keeps legacy Secrets Broker route $path compatible',
+    async ({ path, heading, title }) => {
+      await renderRoute(path)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: heading })).toBeVisible()
+      })
+
+      if (title) {
+        await waitFor(() => {
+          expect(document.title).toBe(title)
+        })
+      }
     }
   )
 })

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -102,10 +102,15 @@ test.describe('Secrets Broker browser coverage', () => {
       ['Secrets', /\/secrets-broker\/secrets$/],
       ['Operational Controls', /\/secrets-broker\/operational-controls$/],
       ['Providers', /\/secrets-broker\/sources$/],
-      ['Backup / Keys', /\/secrets-broker\/backup-keys$/],
       ['Topology', /\/secrets-broker\/topology$/],
       ['Audit / Events', /\/secrets-broker\/audit-events$/],
     ] as const
+
+    await expect(
+      page
+        .locator('[data-sidebar="menu-button"]')
+        .filter({ hasText: 'Backup / Keys' })
+    ).toHaveCount(0)
 
     for (const [name, urlPattern] of navLinks) {
       await page


### PR DESCRIPTION
## Issue
Closes #184

## Summary
- Removed `Backup / Keys` from the primary Secrets Broker sidebar navigation.
- Kept `/secrets-broker/backup-keys` route compatible by rendering the Local encrypted store detail.
- Updated route/sidebar/unit and Playwright coverage to prove the legacy route still works without promoting it as a separate top-level page.

## Scope
- In scope: Service Admin sidebar nav, route compatibility tests, Secrets Broker Playwright nav/deep-link coverage.
- Out of scope: changing broker backend contracts, changing Local encrypted store backup/key metadata, removing the legacy route.

## Spec / contract / fixture impact
- Updated: tests now document `Backup / Keys` as legacy route compatibility rather than a first-class nav item.
- Not required because: no API/schema/service manifest behavior changed.

## Service Lasso invariant impact
- Invariant: Secrets Broker backup/key controls remain local-store scoped and metadata-only.
- Preservation proof: route still renders Local encrypted store detail; tests cover no secret material in browser flow.

## Validation
- PASS `npm run test:unit -- src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx` — 2 files / 38 tests, `.work-agent/logs/issue-184/unit-focused-20260619-0037.log`
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — 34 tests, `.work-agent/logs/issue-184/unit-secrets-broker-20260619-0029.log`
- PASS `npm run test:unit` — 29 files / 160 tests, `.work-agent/logs/issue-184/unit-full-20260619-0031.log`
- PASS `npm run lint` — `.work-agent/logs/issue-184/lint-20260619-0029.log`
- PASS `npm run build` — `.work-agent/logs/issue-184/build-20260619-0030.log`
- PASS `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — 5 Playwright tests, `.work-agent/logs/issue-184/playwright-secrets-broker-20260619-0030.log`

## Approval trail
- Required: no explicit approval requirement found for this focused UI nav fix.
- Evidence: Project #1 Ready / Agent lane Ready for Agent; issue has `agent-ready`; #185 dependency is closed/validated.

## Cleanup
- Branch cleanup after merge: delete `fix/issue-184-backup-keys-local-store`, checkout/pull `master`, verify clean status.
- Demo plan: after merge, rebuild/recycle canonical LAN Service Admin and verify Service Admin/runtime URLs before final closure.