### PR TITLE
test(nav): document on-prem optional pages

### DIFF
--- a/docs/optional-page-classification.md
+++ b/docs/optional-page-classification.md
@@ -1,6 +1,6 @@
 # Optional Service Admin page classification
 
-Issue: service-lasso/lasso-serviceadmin#107
+Issue: service-lasso/lasso-serviceadmin#158
 
 Parent feedback: service-lasso/lasso-serviceadmin#97
 
@@ -10,15 +10,15 @@ This classification decides which optional Service Admin pages remain in primary
 | --- | --- | --- | --- | --- | --- |
 | ZITADEL Sessions | Defer | `/auth-session` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#65 | The page is a metadata-only trusted identity preview. It should return to navigation only when a consumer app/facade provides trusted ZITADEL session and role metadata. Service Admin must stay optional-auth for local development. |
 | Fleet overview | Defer | `/fleet-overview` | Hide from primary sidebar | service-lasso/lasso-serviceadmin#68; runtime prerequisite service-lasso/service-lasso#494 | The existing page is a planning surface for future multi-instance visibility. On-prem-first operation should prioritize the current local instance until runtime instance identity/registry support is available. |
-| Support Bundle | Keep now | `/support-bundle` | Keep visible under Operations | service-lasso/lasso-serviceadmin#66 | Secret-safe local diagnostics are useful for on-prem support and do not require fleet, hosted support, ZITADEL, or external broker credentials. |
-| Policy Simulation | Keep under Secrets Broker | `/secrets-broker/policy-simulation` | Show as a Secrets Broker sub-page | service-lasso/lasso-serviceadmin#67; broker policy baseline service-lasso/lasso-secretsbroker#56; service-lasso/lasso-serviceadmin#125 | The existing page is a metadata-only dry-run preview and now lives in the Secrets Broker route family so policy evaluation context is grouped with broker sources, audit, diagnostics, and inventory surfaces. |
+| Support Bundle | Keep as embedded diagnostic action | `/support-bundle` redirects to `/secrets-broker/sources` | Hide standalone page from primary sidebar | service-lasso/lasso-serviceadmin#66 | Secret-safe local diagnostics are useful for on-prem support, but the current export is not wired to a real backend endpoint. The retained operator job is the metadata-only support-bundle review embedded in the Secrets Broker diagnostics context, with export disabled until the real redacted export API exists. |
+| Policy Simulation | Keep as operational-control workflow | `/secrets-broker/policy-simulation` redirects to `/secrets-broker/operational-controls` | Hide standalone page from primary sidebar | service-lasso/lasso-serviceadmin#67; broker policy baseline service-lasso/lasso-secretsbroker#56; service-lasso/lasso-serviceadmin#125 | The policy dry-run concept is useful, but it should not appear as a complete first-class page until the broker policy contract is live. The safe operator job is represented in Secrets Broker operational controls instead. |
 
 ## Exact UI changes
 
 - Removed the `Fleet Overview` sidebar item that pointed to `/fleet-overview`.
 - Removed the `ZITADEL Session` sidebar item that pointed to `/auth-session`.
-- Moved the `Policy Simulation` sidebar item under `Secrets Broker` at `/secrets-broker/policy-simulation`.
-- Kept the `Support Bundle` sidebar item pointing to `/support-bundle`.
+- Removed the standalone `Policy Simulation` sidebar item; legacy route `/secrets-broker/policy-simulation` redirects to `/secrets-broker/operational-controls`.
+- Removed the standalone `Support Bundle` sidebar item; legacy route `/support-bundle` redirects to `/secrets-broker/sources`, where the metadata-only support-bundle review remains embedded with export unavailable.
 
 ## Route retention
 
@@ -26,6 +26,7 @@ The deferred routes remain registered:
 
 - `/auth-session`
 - `/fleet-overview`
+- `/support-bundle`
 - `/secrets-broker/policy-simulation`
 
-Keeping the routes lets existing implementation tests prove the metadata-only surfaces remain safe while product navigation stays focused on current operator workflows.
+Keeping the routes as direct pages or compatibility redirects lets existing implementation tests prove the metadata-only surfaces remain safe while product navigation stays focused on current operator workflows.

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -84,6 +84,16 @@ const appScreens: ScreenCase[] = [
     title: 'Service Admin - Secrets Broker Audit Events',
   },
   {
+    path: '/operations/telemetry',
+    heading: /^Telemetry$/i,
+    title: 'Service Admin - Operations Telemetry',
+  },
+  {
+    path: '/operations/audit-logging',
+    heading: /^Audit Logging$/i,
+    title: 'Service Admin - Operations Audit Logging',
+  },
+  {
     path: '/auth-session',
     heading: /^Trusted SSO identity context$/i,
     title: 'Service Admin - Trusted SSO Identity',
@@ -113,6 +123,7 @@ const removedSecretsBrokerRoutes = [
   ['/secrets-broker/workflow-boundaries', '/secrets-broker/sources'],
   ['/secrets-broker/single-reveal', '/secrets-broker/secrets'],
   ['/secrets-broker/policy-simulation', '/secrets-broker/operational-controls'],
+  ['/support-bundle', '/secrets-broker/sources'],
 ] as const
 
 const compatibleSecretsBrokerRoutes: ScreenCase[] = [


### PR DESCRIPTION
## Issue
Closes #158

## Summary
- Updates the optional page classification decision note for the on-prem nav review.
- Adds route-level coverage for Operations telemetry/audit pages and the `/support-bundle` compatibility redirect.

## Scope
- In scope: documentation and route tests for ZITADEL Sessions, Fleet overview, Support Bundle, and Policy Simulation classification.
- Out of scope: changing shipped UI behavior; current primary navigation already hides/de-emphasizes these standalone optional pages.

## Spec / contract / fixture impact
- Updated: `docs/optional-page-classification.md` now references #158 and matches current route behavior.
- Not required because: no public API, manifest, schema, lifecycle, or runtime contract changed.

## Nash invariant impact
- Invariant: primary nav should not present speculative/unimplemented pages as complete first-class product surfaces.
- Preservation proof: sidebar tests still assert Fleet Overview, ZITADEL Session, Support Bundle, and Policy Simulation are absent from primary nav; route tests cover retained/redirected surfaces.

## Validation
- PASS `npm run test -- src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx src/features/operations/operations.test.tsx src/features/support-bundle/support-bundle.test.tsx` — 4 files / 46 tests passed.
- PASS `npm run test` — 29 files / 163 tests passed. Log: `.work-agent/logs/issue-158/npm-test-20260619-0903.log`.
- PASS `npm run lint` — Log: `.work-agent/logs/issue-158/npm-lint-20260619-0903.log`.
- PASS `npm run format:check` — Log: `.work-agent/logs/issue-158/format-check-20260619-0903.log`.
- PASS `npm run build` — Log: `.work-agent/logs/issue-158/npm-build-20260619-0904.log`.
- PASS `npm run demo:verify-canonical` from `C:\projects\service-lasso\service-lasso` — Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200 status `ok`; all pinned baseline services healthy. Log: `.work-agent/logs/issue-158/demo-verify-canonical-20260619-0904.log`.

## Demo / deployment
- Production Service Admin source was not changed; this PR updates docs and route tests only.
- Canonical demo was verified instead of repinning an unchanged UI artifact.

## Approval trail
- Required: no explicit human approval found for this doc/test-only nav classification follow-up.
- Evidence: issue is Ready / Agent lane Ready for Agent on Project #1.

## Cleanup
- Branch: `issue-158-onprem-nav-review`.
- Post-merge: checkout/pull `master`, delete local branch after merge, and verify repo status is clean.