### PR TITLE
test(ci): drain jsdom timers after auth cleanup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -74,9 +74,14 @@ beforeEach(() => {
   })
 })
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks()
   cleanup()
+
+  // input-otp schedules unmanaged jsdom timers up to 50 ms after render.
+  // Let them drain before Vitest tears down `window` on fast Linux runners.
+  await new Promise((resolve) => setTimeout(resolve, 60))
+
   window.localStorage?.clear?.()
   window.sessionStorage?.clear?.()
   document.cookie = ''


### PR DESCRIPTION
## Issue
Closes #200

## Summary
- Makes the shared jsdom test cleanup async so unmanaged third-party timers can drain before Vitest destroys `window`.
- Targets the Linux Release failure where `input-otp` fired a delayed timer after `src/test/auth-screens.test.tsx` completed.

## Scope
- In scope: test infrastructure cleanup only.
- Out of scope: production OTP behavior, auth flow behavior, secret/provider UI behavior.

## Spec / Contract / Fixture Impact
- Not required because this is a test-environment cleanup fix only.

## Service Lasso Invariant Impact
- Preserves Service Admin optionality and metadata-only secret/provider boundaries; no runtime/product behavior changed.

## Validation
- PASS `npm run test:unit -- src/test/auth-screens.test.tsx` — 1 file, 4 tests passed; log `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/auth-screens-after.log`
- PASS `npm run test:unit` — 29 files, 163 tests passed; log `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/serviceadmin-test-unit-after.log`
- PASS `npm run lint` — log `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/serviceadmin-lint-after.log`
- PASS `npm run build` — log `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/serviceadmin-build-after.log`

## Demo / Runtime
- Preflight canonical Service Admin `http://192.168.1.53:17700/` returned HTTP 200.
- Preflight runtime `http://192.168.1.53:17883/api/health` returned HTTP 200 with `status: ok`.
- No production code/config/service manifest changed, so no demo recycle was required for this test-only PR.

## Approval Trail
- Required: no, pipeline/test cleanup only.

## Cleanup
- Branch cleanup after merge: delete `fix/200-linux-otp-test-cleanup` and return local checkout to clean `master`.