### PR TITLE
fix(serviceadmin): clean up collapsed instance selector

### DIFF
--- a/src/components/instance-selector.test.tsx
+++ b/src/components/instance-selector.test.tsx
@@ -44,6 +44,32 @@ describe('instance selector shell control', () => {
     expect(screen.getByText(/Setup needed/i)).toBeVisible()
   })
 
+  it('renders as an icon-only affordance when the desktop sidebar is collapsed', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/')
+
+    const sidebarTrigger = document.querySelector<HTMLButtonElement>(
+      '[data-sidebar="trigger"]'
+    )
+
+    expect(sidebarTrigger).not.toBeNull()
+    await user.click(sidebarTrigger!)
+
+    const [selector] = await screen.findAllByRole('button', {
+      name: /Service Lasso instance selector/i,
+    })
+
+    expect(within(selector).queryByText('Local')).not.toBeInTheDocument()
+    expect(
+      within(selector).queryByText(activeInstanceSelectorState.endpoint)
+    ).not.toBeInTheDocument()
+
+    await user.click(selector)
+
+    expect(screen.getByText(/Service Lasso instance/i)).toBeVisible()
+    expect(screen.getByText(/Local on-prem control is selected/i)).toBeVisible()
+  })
+
   it('keeps selector metadata free of secret material', () => {
     expect(instanceSelectorHasSecretMaterial()).toBe(false)
   })

--- a/src/components/instance-selector.tsx
+++ b/src/components/instance-selector.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { SidebarMenuButton } from '@/components/ui/sidebar'
+import { SidebarMenuButton, useSidebar } from '@/components/ui/sidebar'
 import { activeInstanceSelectorState } from '@/components/instance-selector-model'
 import type { FleetInstanceSummary } from '@/features/fleet-overview/fleet-overview'
 
@@ -29,28 +29,42 @@ export function InstanceSelector({
 }: InstanceSelectorProps) {
   const { endpoint, instance, label, remoteConnectState } =
     activeInstanceSelectorState
+  const { isMobile, state } = useSidebar()
+  const isCollapsed = state === 'collapsed' && !isMobile
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <SidebarMenuButton
           size='lg'
-          aria-label='Service Lasso instance selector'
+          aria-label={`Service Lasso instance selector: ${label} (${endpoint})`}
+          tooltip={
+            isCollapsed
+              ? {
+                  children: `${label} - ${endpoint}`,
+                }
+              : undefined
+          }
           className={cn(
-            'h-9 min-w-[220px] border bg-background px-2 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+            'h-9 border bg-background data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+            isCollapsed ? 'min-w-0 justify-center px-0' : 'min-w-[220px] px-2',
             className
           )}
         >
           <div className='flex size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground'>
             <Monitor className='size-4' />
           </div>
-          <div className='grid flex-1 text-left text-sm leading-tight'>
-            <span className='truncate font-medium'>{label}</span>
-            <span className='truncate text-xs text-muted-foreground'>
-              {endpoint}
-            </span>
-          </div>
-          <ChevronsUpDown className='ml-auto size-4' />
+          {!isCollapsed && (
+            <>
+              <div className='grid flex-1 text-left text-sm leading-tight'>
+                <span className='truncate font-medium'>{label}</span>
+                <span className='truncate text-xs text-muted-foreground'>
+                  {endpoint}
+                </span>
+              </div>
+              <ChevronsUpDown className='ml-auto size-4' />
+            </>
+          )}
         </SidebarMenuButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent


### PR DESCRIPTION
## Issue
Closes #205

## Summary
- Make the sidebar instance selector render as a compact icon-only trigger when the desktop sidebar is collapsed.
- Preserve the expanded selector label/address, dropdown metadata, and remote-connect affordance.
- Add regression coverage for the collapsed selector state.

## Scope
- In scope: `InstanceSelector` collapsed desktop rendering and focused component test coverage.
- Out of scope: right-header selector removal tracked by #204, broader sidebar/navigation redesign.

## Spec / contract / fixture impact
- Not required because this is a focused UI layout fix with no public API/schema/config contract change.

## Nash invariant impact
- Invariant: instance metadata remains metadata-only and does not expose secret material.
- Preservation proof: existing `instanceSelectorHasSecretMaterial()` test remains covered, and the collapsed trigger removes endpoint text from the compact sidebar control.

## Validation
- PASS `npm run test -- src/components/instance-selector.test.tsx` — 4 tests passed.
- PASS `npm run lint` — ESLint completed cleanly.
- PASS `npm run build` — TypeScript and Vite build completed.
- PASS temporary Playwright screenshot/assertion — collapsed trigger bounding box 32x32; `Local` and `127.0.0.1:17700` text nodes inside selector were both 0. Evidence: `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/run-20260619-212604/issue-205-playwright-screenshot-2.log` and `issue-205-collapsed-sidebar.png`.

## Approval trail
- Required: no explicit human approval found for this focused UI bugfix.
- Evidence: Project #1 marked Ready / Ready for Agent.

## Cleanup
- Branch pushed as `fix/205-collapsed-instance-selector`.
- Canonical demo recycle/verification will be completed after merge/release or reported as a blocker if deployment cannot consume this exact commit.
