### PR TITLE
fix(serviceadmin): remove header instance selector

### DIFF
--- a/src/components/instance-selector.test.tsx
+++ b/src/components/instance-selector.test.tsx
@@ -24,6 +24,24 @@ describe('instance selector shell control', () => {
     expect(screen.queryByText(/No active session/i)).not.toBeInTheDocument()
   })
 
+  it('keeps the instance selector out of the page header controls', async () => {
+    await renderRoute('/')
+
+    const header = document.querySelector('header')
+
+    expect(header).not.toBeNull()
+    expect(
+      within(header!).queryByRole('button', {
+        name: /Service Lasso instance selector/i,
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: /Service Lasso instance selector/i,
+      })
+    ).toBeVisible()
+  })
+
   it('opens local metadata and a setup-needed remote connect affordance', async () => {
     const user = userEvent.setup()
     await renderRoute('/')

--- a/src/components/profile-dropdown.tsx
+++ b/src/components/profile-dropdown.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { SidebarMenuButton } from '@/components/ui/sidebar'
-import { InstanceSelector } from '@/components/instance-selector'
 import { SignOutDialog } from '@/components/sign-out-dialog'
 
 export function ProfileDropdown() {
@@ -21,7 +20,6 @@ export function ProfileDropdown() {
 
   return (
     <>
-      {!authUser ? <InstanceSelector align='end' /> : null}
       {authUser ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Issue
Closes #204

## Summary
- Removed the unauthenticated Service Lasso instance selector from the right side of the page header.
- Kept the existing shell/sidebar instance selector so local instance context remains available outside the header.
- Added focused coverage proving the header no longer contains the selector while the shell still exposes it.

## Scope
- In scope: right-header selector removal and header-state test coverage.
- Out of scope: changing active instance data, sidebar instance selector behavior, authentication/user dropdown behavior, or runtime data loading.

## Spec / contract / fixture impact
- Updated: no public API/schema/contract change.
- Not required because this is a Service Admin presentation-only UI adjustment.

## Service Lasso invariant impact
- Invariant: active instance context remains available for diagnostics without exposing secret material.
- Preservation proof: the sidebar `InstanceSelector` remains rendered, existing no-secret selector test remains in place, and the new test asserts only the header copy was removed.

## Validation
- PASS `npm run test -- src/components/instance-selector.test.tsx` — 1 file / 5 tests passed; log `.work-agent/logs/204/vitest-instance-selector.log`.
- PASS `npm run build` — TypeScript + Vite production build passed; log `.work-agent/logs/204/npm-build.log`.
- PASS isolated preview proof on `http://127.0.0.1:4177/` — `headerSelectorCount=0`, `shellSelectorCount=1`; screenshot `.work-agent/logs/204/header-no-selector.png`, log `.work-agent/logs/204/preview-header-proof.log`.
- PASS canonical demo preflight before selection — Service Admin `http://192.168.1.53:17700/` HTTP 200 and runtime `http://192.168.1.53:17883/api/health` HTTP 200 with `status=ok`.

## Release / demo gate
- This PR changes a demo-consumed service package but has not been merged or released yet.
- Expected demo-consumed Service Admin commit after merge/release: `9666ca0` or its merge commit/release artifact.
- Live canonical demo is healthy but still running the previously installed Service Admin artifact; exact release-to-demo consumption remains the required post-merge step.

## Approval trail
- Required: normal repo PR review/checks before merge.
- Evidence: this PR and linked issue comment trail.

## Cleanup
- Branch: `sl-204-remove-header-instance-selector`.
- Local worktree should be cleaned after PR merge/release and canonical demo recycle.