### PR TITLE
fix(serviceadmin): prevent variables table value overlap

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -587,8 +587,18 @@ function EnvironmentTable({
   variables: ServiceEnvironmentVariable[]
 }) {
   return (
-    <div className='overflow-x-auto rounded-md border'>
-      <Table>
+    <div
+      className='overflow-x-auto rounded-md border'
+      data-testid='service-detail-variables-table'
+    >
+      <Table className='min-w-[860px] table-fixed'>
+        <colgroup>
+          <col className='w-[20%]' />
+          <col className='w-[34%]' />
+          <col className='w-[11%]' />
+          <col className='w-[19%]' />
+          <col className='w-[16%]' />
+        </colgroup>
         <TableHeader>
           <TableRow>
             <TableHead>Key</TableHead>
@@ -602,11 +612,21 @@ function EnvironmentTable({
           {variables.length ? (
             variables.map((variable) => (
               <TableRow key={variable.key}>
-                <TableCell className='font-medium'>{variable.key}</TableCell>
-                <TableCell className='max-w-[360px] text-sm break-all text-muted-foreground'>
-                  {variable.secret ? '••••••••' : variable.value}
+                <TableCell className='min-w-0 align-top font-medium whitespace-normal'>
+                  <div className='truncate' title={variable.key}>
+                    {variable.key}
+                  </div>
                 </TableCell>
-                <TableCell>
+                <TableCell className='min-w-0 align-top text-sm whitespace-normal text-muted-foreground'>
+                  <div
+                    className='leading-relaxed break-all'
+                    data-testid='service-detail-variable-value'
+                    title={variable.secret ? undefined : variable.value}
+                  >
+                    {variable.secret ? '••••••••' : variable.value}
+                  </div>
+                </TableCell>
+                <TableCell className='align-top whitespace-normal'>
                   <Badge
                     variant={
                       variable.scope === 'global' ? 'secondary' : 'outline'
@@ -615,9 +635,19 @@ function EnvironmentTable({
                     {variable.scope}
                   </Badge>
                 </TableCell>
-                <TableCell>{variable.source ?? 'Not recorded'}</TableCell>
-                <TableCell>
-                  <div className='flex flex-wrap gap-2'>
+                <TableCell className='min-w-0 align-top text-sm whitespace-normal text-muted-foreground'>
+                  <div
+                    className='truncate'
+                    title={variable.source ?? 'Not recorded'}
+                  >
+                    {variable.source ?? 'Not recorded'}
+                  </div>
+                </TableCell>
+                <TableCell className='align-top whitespace-normal'>
+                  <div
+                    className='flex min-w-[8.75rem] flex-wrap items-center gap-2'
+                    data-testid='service-detail-variable-actions'
+                  >
                     <CopyValueButton value={variable.value} />
                     <Button variant='outline' size='sm' asChild>
                       <Link

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -298,6 +298,14 @@ const defaultServices: DashboardService[] = [
         scope: 'global',
         source: '.env',
       },
+      {
+        key: 'SERVICE_LASSO_RUNTIME_CONFIG_PATH',
+        value:
+          'C:\\service-lasso\\profiles\\development\\services\\lasso-serviceadmin\\config\\runtime\\resolved\\service-lasso-runtime-config.json',
+        scope: 'service',
+        source:
+          'C:\\service-lasso\\profiles\\development\\services\\lasso-serviceadmin\\service.json',
+      },
     ],
     recentLogs: [
       {

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -119,6 +119,45 @@ test('services table filters and opens service detail', async ({ page }) => {
   await expect(page.getByText('VITE_SERVICE_LASSO_API_BASE_URL')).toBeVisible()
 })
 
+test('service detail variables table keeps long values inside their columns', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1024, height: 768 })
+  await page.goto('/services/@serviceadmin')
+  await page.getByRole('tab', { name: /variables/i }).click()
+
+  const table = page.getByTestId('service-detail-variables-table')
+  const row = table
+    .locator('tbody tr')
+    .filter({ hasText: 'SERVICE_LASSO_RUNTIME_CONFIG_PATH' })
+
+  await expect(row).toBeVisible()
+
+  const cells = row.locator('td')
+  const cellBoxes = await cells.evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect()
+      return {
+        left: rect.left,
+        right: rect.right,
+        width: rect.width,
+      }
+    })
+  )
+
+  expect(cellBoxes[1].right).toBeLessThanOrEqual(cellBoxes[2].left + 1)
+  expect(cellBoxes[2].right).toBeLessThanOrEqual(cellBoxes[3].left + 1)
+  expect(cellBoxes[3].right).toBeLessThanOrEqual(cellBoxes[4].left + 1)
+
+  const valueFitsColumn = await row
+    .getByTestId('service-detail-variable-value')
+    .evaluate((element) => element.scrollWidth <= element.clientWidth + 1)
+  expect(valueFitsColumn).toBe(true)
+
+  await expect(row.getByTestId('service-detail-variable-actions')).toBeVisible()
+  await expect(row.getByRole('link', { name: 'Open variables' })).toBeVisible()
+})
+
 test('runtime, network, installed, and variables tables render', async ({
   page,
 }) => {


### PR DESCRIPTION
## Issue
Closes #207

## Summary
- Fixed the service details Variables table so long values wrap inside a fixed value column instead of pushing into scope/source/action cells.
- Added a long Windows path fixture for the Service Admin service and a Playwright geometry regression for the reported overlap shape.

## Scope
- In scope: Service details Variables tab table layout, stub long-path coverage, focused browser regression.
- Out of scope: Top-level Variables page changes and the separate template/raw value column requested in #202.

## Spec / contract / fixture impact
- Updated: Service Admin stub fixture now includes `SERVICE_LASSO_RUNTIME_CONFIG_PATH` to exercise long Windows path layout.
- Not required because: public API/schema behavior is unchanged.

## Nash invariant impact
- Invariant: secret-sensitive values remain masked; this change does not alter reveal/copy semantics or raw secret rendering.
- Preservation proof: existing secret rows still render `••••••••`; the layout change only constrains column sizing/wrapping.

## Validation
- PASS `npx playwright test tests/ui/service-admin.spec.ts -g "service detail variables table keeps long values inside their columns"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/playwright-issue207-focused-rerun.log`
- PASS `npx playwright test tests/ui/service-admin.spec.ts` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/playwright-service-admin-spec.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/npm-build.log`
- PASS `npm run test:unit` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-0025/npm-test-unit.log`

## Approval trail
- Required: no known mandatory human approval rule discovered before PR creation.
- Evidence: branch created from clean `origin/master`; no open org PRs were present at intake.

## Cleanup
- Branch: `sl-207-variables-table-overlap`
- Post-merge: release/pin/recycle canonical demo if repo rules allow merge and release in this run.
