### PR TITLE
feat(secrets): add bulk campaign confirmation gate

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -57,13 +57,16 @@ import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
   buildBulkSecretCampaignPlan,
+  buildBulkSecretCampaignApplyGate,
   buildManagedSecretActionPreview,
   buildStubSecretMutationPreview,
   bulkSecretCampaignOperations,
+  bulkSecretCampaignRevalidationStates,
   managedSecretRows,
   stubSecretMutationStates,
   valueSearchManagedSecrets,
   type BulkSecretCampaignOperation,
+  type BulkSecretCampaignRevalidationState,
   type ManagedSecretAction,
   type ManagedSecretRow,
   type ManagedSecretState,
@@ -110,6 +113,11 @@ export function SecretsManagementPage() {
   const [bulkOperation, setBulkOperation] =
     useState<BulkSecretCampaignOperation>('rotate-reset')
   const [bulkPlanGenerated, setBulkPlanGenerated] = useState(false)
+  const [bulkAuditReason, setBulkAuditReason] = useState('')
+  const [bulkConfirmation, setBulkConfirmation] = useState('')
+  const [bulkRevalidationState, setBulkRevalidationState] =
+    useState<BulkSecretCampaignRevalidationState>('ready')
+  const [bulkRevalidated, setBulkRevalidated] = useState(false)
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = useState('')
@@ -158,6 +166,17 @@ export function SecretsManagementPage() {
       ),
     [bulkOperation, bulkSelectedIds]
   )
+  const bulkApplyGate = buildBulkSecretCampaignApplyGate(
+    bulkPlan,
+    bulkAuditReason,
+    bulkConfirmation,
+    bulkRevalidationState,
+    bulkRevalidated
+  )
+
+  function resetBulkApplyGate() {
+    setBulkRevalidated(false)
+  }
 
   function chooseAction(rowId: string, action: ManagedSecretAction) {
     setSelectedRowId(rowId)
@@ -166,6 +185,7 @@ export function SecretsManagementPage() {
 
   function toggleBulkSelection(rowId: string, checked: boolean) {
     setBulkPlanGenerated(false)
+    resetBulkApplyGate()
     setBulkSelectedIds((current) =>
       checked
         ? [...new Set([...current, rowId])]
@@ -175,6 +195,7 @@ export function SecretsManagementPage() {
 
   function setOperation(operation: BulkSecretCampaignOperation) {
     setBulkPlanGenerated(false)
+    resetBulkApplyGate()
     setBulkOperation(operation)
   }
 
@@ -753,7 +774,10 @@ export function SecretsManagementPage() {
                 <Button
                   type='button'
                   disabled={bulkSelectedIds.length === 0}
-                  onClick={() => setBulkPlanGenerated(true)}
+                  onClick={() => {
+                    setBulkPlanGenerated(true)
+                    resetBulkApplyGate()
+                  }}
                 >
                   Generate bulk dry-run plan
                 </Button>
@@ -892,14 +916,169 @@ export function SecretsManagementPage() {
             )}
 
             <div className='flex flex-wrap gap-2'>
-              <Button type='button' disabled>
-                Bulk apply unavailable in Stage 1
+              <Button type='button' disabled={!bulkApplyGate.canApply}>
+                Bulk apply blocked by broker campaign API
               </Button>
-              <Badge variant='secondary'>Dry-run only</Badge>
+              <Badge variant='secondary'>Dry-run plus revalidation</Badge>
               <Badge variant='outline'>No raw values</Badge>
               <Badge variant='outline'>No provider credentials</Badge>
               <Badge variant='outline'>No export</Badge>
             </div>
+
+            {bulkPlanGenerated ? (
+              <div className='grid gap-4 rounded-md border p-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]'>
+                <div className='space-y-4'>
+                  <div>
+                    <h3 className='font-medium'>
+                      Campaign confirmation and revalidation
+                    </h3>
+                    <p className='mt-1 text-muted-foreground'>
+                      Apply remains fail-closed until audit reason,
+                      confirmation, and immediate revalidation all pass. The
+                      broker campaign apply API is not connected in this UI
+                      slice.
+                    </p>
+                  </div>
+
+                  <div className='grid gap-3 md:grid-cols-2'>
+                    <div className='space-y-2'>
+                      <label
+                        htmlFor='bulk-audit-reason'
+                        className='text-sm font-medium text-muted-foreground'
+                      >
+                        Campaign audit reason
+                      </label>
+                      <Input
+                        id='bulk-audit-reason'
+                        value={bulkAuditReason}
+                        onChange={(event) => {
+                          setBulkAuditReason(event.target.value)
+                          resetBulkApplyGate()
+                        }}
+                        placeholder='Required before revalidation'
+                      />
+                    </div>
+
+                    <div className='space-y-2'>
+                      <label
+                        htmlFor='bulk-confirmation'
+                        className='text-sm font-medium text-muted-foreground'
+                      >
+                        Explicit confirmation
+                      </label>
+                      <Input
+                        id='bulk-confirmation'
+                        value={bulkConfirmation}
+                        onChange={(event) => {
+                          setBulkConfirmation(event.target.value)
+                          resetBulkApplyGate()
+                        }}
+                        placeholder={bulkApplyGate.confirmationPhrase}
+                      />
+                      <div className='text-xs text-muted-foreground'>
+                        Required phrase: {bulkApplyGate.confirmationPhrase}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className='grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]'>
+                    <div className='space-y-2'>
+                      <label
+                        htmlFor='bulk-revalidation-state'
+                        className='text-sm font-medium text-muted-foreground'
+                      >
+                        Revalidation outcome
+                      </label>
+                      <select
+                        id='bulk-revalidation-state'
+                        className='h-9 w-full rounded-md border bg-background px-3 text-sm'
+                        value={bulkRevalidationState}
+                        onChange={(event) => {
+                          setBulkRevalidationState(
+                            event.target
+                              .value as BulkSecretCampaignRevalidationState
+                          )
+                          resetBulkApplyGate()
+                        }}
+                      >
+                        {bulkSecretCampaignRevalidationStates.map((state) => (
+                          <option key={state.id} value={state.id}>
+                            {state.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className='flex items-end'>
+                      <Button
+                        type='button'
+                        variant='outline'
+                        disabled={!bulkApplyGate.auditReasonAccepted}
+                        onClick={() => setBulkRevalidated(true)}
+                      >
+                        Revalidate dry-run
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='mb-3 flex flex-wrap gap-2'>
+                    <Badge
+                      variant={
+                        bulkApplyGate.revalidationPassed
+                          ? 'default'
+                          : 'secondary'
+                      }
+                    >
+                      {bulkApplyGate.revalidationPassed
+                        ? 'Revalidated'
+                        : 'Revalidation blocked'}
+                    </Badge>
+                    <Badge variant='outline'>
+                      {bulkApplyGate.applyDisabledReason}
+                    </Badge>
+                  </div>
+
+                  <dl className='space-y-2'>
+                    <div>
+                      <dt className='text-muted-foreground'>
+                        Revalidation status
+                      </dt>
+                      <dd>{bulkApplyGate.revalidationStatus}</dd>
+                    </div>
+                    <div>
+                      <dt className='text-muted-foreground'>Apply state</dt>
+                      <dd>
+                        {bulkApplyGate.canApply
+                          ? 'campaign apply ready'
+                          : 'campaign apply disabled'}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <ul className='mt-3 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {bulkApplyGate.statusRows.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+
+                  {bulkApplyGate.blockers.length > 0 ? (
+                    <div className='mt-3 space-y-1'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Blockers
+                      </div>
+                      <div className='flex flex-wrap gap-1'>
+                        {bulkApplyGate.blockers.map((blocker) => (
+                          <Badge key={blocker} variant='outline'>
+                            {blocker}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
           </CardContent>
         </Card>
 

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import {
   buildBulkSecretCampaignPlan,
+  buildBulkSecretCampaignApplyGate,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretBulkPlanHasSecretMaterial,
@@ -145,9 +146,118 @@ describe('Secrets Broker secrets management page', () => {
       screen.getByText(/denied: policy is readonly for this ref/i)
     ).toBeVisible()
     expect(
-      screen.getByRole('button', { name: /Bulk apply unavailable in Stage 1/i })
+      screen.getByRole('button', {
+        name: /Bulk apply blocked by broker campaign API/i,
+      })
     ).toBeDisabled()
+    expect(
+      screen.getByText(/Campaign confirmation and revalidation/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/provider auth required/i)[0]).toBeVisible()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps bulk campaign apply blocked until audit reason confirmation and fresh revalidation pass', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.click(
+      screen.getByLabelText(
+        /Select ZITADEL_CLIENT_CREDENTIAL for bulk dry-run/i
+      )
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    )
+
+    expect(screen.getByText(/Revalidation blocked/i)).toBeVisible()
+    expect(screen.getByText(/audit reason missing/i)).toBeVisible()
+    expect(screen.getByText(/high-risk confirmation missing/i)).toBeVisible()
+    expect(screen.getByText(/revalidation not run/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/broker campaign API unavailable/i)[0]
+    ).toBeVisible()
+
+    await user.type(
+      screen.getByLabelText(/Campaign audit reason/i),
+      'operator requested controlled campaign rotation'
+    )
+    await user.type(
+      screen.getByLabelText(/Explicit confirmation/i),
+      'CONFIRM HIGH RISK CAMPAIGN'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+
+    expect(screen.getAllByText(/Revalidated/i)[0]).toBeVisible()
+    expect(screen.getByText(/audit reason recorded/i)).toBeVisible()
+    expect(screen.getByText(/confirmation accepted/i)).toBeVisible()
+    expect(screen.getByText(/revalidation passed/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/broker campaign API unavailable/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getByRole('button', {
+        name: /Bulk apply blocked by broker campaign API/i,
+      })
+    ).toBeDisabled()
+  })
+
+  it('shows stale plan and revalidation failure states before bulk apply', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.click(
+      screen.getByLabelText(
+        /Select ZITADEL_CLIENT_CREDENTIAL for bulk dry-run/i
+      )
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    )
+    await user.type(
+      screen.getByLabelText(/Campaign audit reason/i),
+      'operator requested controlled campaign rotation'
+    )
+    await user.type(
+      screen.getByLabelText(/Explicit confirmation/i),
+      'CONFIRM HIGH RISK CAMPAIGN'
+    )
+
+    await user.selectOptions(
+      screen.getByLabelText(/Revalidation outcome/i),
+      'stale-plan'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+    expect(screen.getAllByText(/stale plan/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/revalidation blocked/i)[0]).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Revalidation outcome/i),
+      'auth-required'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+    expect(
+      screen.getAllByText(
+        /provider auth required before revalidation can pass/i
+      )[0]
+    ).toBeVisible()
+
+    await user.selectOptions(
+      screen.getByLabelText(/Revalidation outcome/i),
+      'audit-unavailable'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+    expect(
+      screen.getAllByText(/audit unavailable; campaign apply fails closed/i)[0]
+    ).toBeVisible()
   })
 
   it('previews reveal edit reset delete and policy actions behind dry-run or confirmation gates', async () => {
@@ -319,5 +429,44 @@ describe('Secrets Broker secrets management page', () => {
     expect(bulkPlan.missingProviderCount).toBe(1)
     expect(bulkPlan.applyAvailable).toBe(false)
     expect(managedSecretBulkPlanHasSecretMaterial(bulkPlan)).toBe(false)
+
+    const blockedGate = buildBulkSecretCampaignApplyGate(
+      bulkPlan,
+      'operator requested controlled campaign rotation',
+      'CONFIRM HIGH RISK CAMPAIGN',
+      'ready',
+      true
+    )
+    expect(blockedGate.canApply).toBe(false)
+    expect(blockedGate.blockers).toContain(
+      'broker campaign apply API not connected'
+    )
+
+    const cleanPlan = buildBulkSecretCampaignPlan(
+      managedSecretRows,
+      [managedSecretRows[0].id],
+      'rotate-reset'
+    )
+    const staleGate = buildBulkSecretCampaignApplyGate(
+      cleanPlan,
+      'operator requested controlled campaign rotation',
+      'CONFIRM HIGH RISK CAMPAIGN',
+      'stale-plan',
+      true,
+      true
+    )
+    expect(staleGate.canApply).toBe(false)
+    expect(staleGate.revalidationPassed).toBe(false)
+    expect(staleGate.revalidationStatus).toMatch(/stale plan/i)
+
+    const readyGate = buildBulkSecretCampaignApplyGate(
+      cleanPlan,
+      'operator requested controlled campaign rotation',
+      'CONFIRM HIGH RISK CAMPAIGN',
+      'ready',
+      true,
+      true
+    )
+    expect(readyGate.canApply).toBe(true)
   })
 })

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -100,6 +100,30 @@ export type BulkSecretCampaignPlan = {
   applyAvailable: false
 }
 
+export type BulkSecretCampaignRevalidationState =
+  | 'ready'
+  | 'stale-plan'
+  | 'provider-changed'
+  | 'policy-changed'
+  | 'capability-changed'
+  | 'auth-required'
+  | 'denied'
+  | 'unsupported'
+  | 'audit-unavailable'
+
+export type BulkSecretCampaignApplyGate = {
+  auditReasonAccepted: boolean
+  confirmationRequired: boolean
+  confirmationPhrase: string
+  confirmationAccepted: boolean
+  revalidationPassed: boolean
+  revalidationStatus: string
+  statusRows: string[]
+  blockers: string[]
+  canApply: boolean
+  applyDisabledReason: string
+}
+
 export const managedSecretRows: ManagedSecretRow[] = [
   {
     id: 'serviceadmin-session-signing',
@@ -210,6 +234,21 @@ export const bulkSecretCampaignOperations: Array<{
   { id: 'mark-action-required', label: 'Mark action required' },
 ]
 
+export const bulkSecretCampaignRevalidationStates: Array<{
+  id: BulkSecretCampaignRevalidationState
+  label: string
+}> = [
+  { id: 'ready', label: 'Successful revalidation' },
+  { id: 'stale-plan', label: 'Stale plan' },
+  { id: 'provider-changed', label: 'Provider config changed' },
+  { id: 'policy-changed', label: 'Policy changed' },
+  { id: 'capability-changed', label: 'Capability changed' },
+  { id: 'auth-required', label: 'Provider auth required' },
+  { id: 'denied', label: 'Policy denied' },
+  { id: 'unsupported', label: 'Unsupported rows' },
+  { id: 'audit-unavailable', label: 'Audit unavailable' },
+]
+
 export const managedSecretSafeSurfaces = {
   route: '/secrets-broker/secrets',
   pageTitle: 'Service Admin - Secrets Broker Secrets',
@@ -228,6 +267,33 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:bulk-campaign-dry-run',
   ],
   persistedStorage: 'none',
+}
+
+const bulkCampaignRevalidationMessages: Record<
+  BulkSecretCampaignRevalidationState,
+  string
+> = {
+  ready:
+    'fresh dry-run revalidated against selected refs, provider config, policy, auth, capability, and audit metadata',
+  'stale-plan':
+    'stale plan: rerun dry-run because the previous campaign plan expired',
+  'provider-changed':
+    'provider config changed since dry-run; rerun before apply',
+  'policy-changed': 'policy changed since dry-run; rerun before apply',
+  'capability-changed':
+    'provider capability changed since dry-run; rerun before apply',
+  'auth-required': 'provider auth required before revalidation can pass',
+  denied: 'policy denied during revalidation; apply fails closed',
+  unsupported: 'selected rows include unsupported campaign operations',
+  'audit-unavailable': 'audit unavailable; campaign apply fails closed',
+}
+
+export function getBulkSecretCampaignConfirmationPhrase(
+  plan: BulkSecretCampaignPlan
+) {
+  return plan.highRiskCount > 0
+    ? 'CONFIRM HIGH RISK CAMPAIGN'
+    : 'CONFIRM BULK CAMPAIGN'
 }
 
 export function filterManagedSecrets(
@@ -540,6 +606,85 @@ export function buildBulkSecretCampaignPlan(
     highRiskCount: items.filter((item) => item.risk === 'high').length,
     items,
     applyAvailable: false,
+  }
+}
+
+export function buildBulkSecretCampaignApplyGate(
+  plan: BulkSecretCampaignPlan,
+  auditReason: string,
+  confirmation: string,
+  revalidationState: BulkSecretCampaignRevalidationState,
+  revalidated: boolean,
+  brokerCampaignApiAvailable = false
+): BulkSecretCampaignApplyGate {
+  const auditReasonAccepted = auditReason.trim().length >= 12
+  const confirmationPhrase = getBulkSecretCampaignConfirmationPhrase(plan)
+  const confirmationRequired = plan.highRiskCount > 0
+  const confirmationAccepted =
+    !confirmationRequired || confirmation.trim() === confirmationPhrase
+  const itemBlockers = Array.from(
+    new Set(plan.items.flatMap((item) => item.blockers))
+  )
+  const blockers: string[] = []
+
+  if (plan.selectedCount === 0) {
+    blockers.push('select at least one ref')
+  }
+  if (!auditReasonAccepted) {
+    blockers.push('audit reason must be at least 12 characters')
+  }
+  if (!confirmationAccepted) {
+    blockers.push(`type ${confirmationPhrase}`)
+  }
+  if (itemBlockers.length > 0) {
+    blockers.push(`resolve per-item blockers: ${itemBlockers.join(', ')}`)
+  }
+  if (!revalidated) {
+    blockers.push('run immediate revalidation')
+  } else if (revalidationState !== 'ready') {
+    blockers.push(bulkCampaignRevalidationMessages[revalidationState])
+  }
+  if (!brokerCampaignApiAvailable) {
+    blockers.push('broker campaign apply API not connected')
+  }
+
+  const revalidationPassed =
+    revalidated && revalidationState === 'ready' && itemBlockers.length === 0
+  const canApply =
+    blockers.length === 0 &&
+    auditReasonAccepted &&
+    confirmationAccepted &&
+    revalidationPassed &&
+    brokerCampaignApiAvailable
+
+  return {
+    auditReasonAccepted,
+    confirmationRequired,
+    confirmationPhrase,
+    confirmationAccepted,
+    revalidationPassed,
+    revalidationStatus: revalidated
+      ? bulkCampaignRevalidationMessages[revalidationState]
+      : 'not revalidated since this dry-run was generated',
+    statusRows: [
+      auditReasonAccepted ? 'audit reason recorded' : 'audit reason missing',
+      confirmationAccepted
+        ? 'confirmation accepted'
+        : 'high-risk confirmation missing',
+      revalidationPassed
+        ? 'revalidation passed'
+        : revalidated
+          ? 'revalidation blocked'
+          : 'revalidation not run',
+      brokerCampaignApiAvailable
+        ? 'broker campaign API available'
+        : 'broker campaign API unavailable',
+    ],
+    blockers,
+    canApply,
+    applyDisabledReason: canApply
+      ? 'apply ready'
+      : (blockers[0] ?? 'apply blocked'),
   }
 }
 


### PR DESCRIPTION
## Issue
Closes #171

## Summary
- Adds a bulk campaign confirmation/revalidation gate after the existing non-mutating dry-run planner.
- Models audit reason, exact high-risk confirmation, immediate revalidation outcomes, per-item blockers, stale-plan/auth/policy/capability/audit fail-closed states, and keeps apply disabled while the broker campaign API is unavailable.
- Extends focused Secrets Broker tests for confirmation, revalidation, stale-plan/auth/audit failure states, and no secret material leakage.

## Scope
- In scope: Service Admin UI gating and deterministic stub model for bulk campaign apply readiness.
- Out of scope: Real broker bulk mutation/apply API, live provider writes, raw secret reveal/export.

## Spec / contract / fixture impact
- Updated: UI fixture/model contract in `src/features/secrets-broker/secrets-management.ts` for campaign revalidation and apply gate states.
- Not required: backend/API schema docs because this is explicitly UI gating only and does not expose a production mutation contract.

## Service Lasso invariant impact
- Invariant: no raw secret values, provider credentials, tokens, raw env values, recovery material, or private keys are rendered or persisted.
- Preservation proof: focused tests assert bulk plan/gate surfaces remain free of secret material; UI continues to show refs/metadata/status only.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-management.test.tsx` — 11 tests passed; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\serviceadmin-issue-171-focused-test.log`
- PASS `npm run test` — 29 files / 167 tests passed; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\serviceadmin-issue-171-full-test.log`
- PASS `npm run lint` — 0 errors, 1 existing hook dependency warning in `secrets-management-page.tsx`; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\serviceadmin-issue-171-lint.log`
- PASS `npm run build` — Vite build passed with existing size/deprecation warnings; log: `C:\projects\service-lasso\work-agents\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\run-20260620-012611\serviceadmin-issue-171-build.log`

## Approval trail
- Required: no special human approval identified for this UI-only gating slice.
- Evidence: issue #171 explicitly says this is UI gating only and must not claim real bulk mutation.

## Cleanup
- Branch: `sl-171-bulk-confirmation-revalidation`
- Post-merge: recycle canonical Service Admin demo/runtime and run canonical verifier before issue closure.
