### PR TITLE
fix(serviceadmin): improve runtime reload feedback

### DIFF
--- a/src/features/dashboard/dashboard.test.tsx
+++ b/src/features/dashboard/dashboard.test.tsx
@@ -1,0 +1,95 @@
+import { renderRoute } from '@/test/render-route'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardSummary } from '@/lib/service-lasso-dashboard/types'
+
+const hookMocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  useDashboardAction: vi.fn(),
+  useDashboardService: vi.fn(),
+  useDashboardSummary: vi.fn(),
+  useServices: vi.fn(),
+  useFavoriteFeatureState: vi.fn(),
+  useToggleFavorite: vi.fn(),
+}))
+
+vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
+  useDashboardAction: hookMocks.useDashboardAction,
+  useDashboardService: hookMocks.useDashboardService,
+  useDashboardSummary: hookMocks.useDashboardSummary,
+  useServices: hookMocks.useServices,
+  useFavoriteFeatureState: hookMocks.useFavoriteFeatureState,
+  useToggleFavorite: hookMocks.useToggleFavorite,
+}))
+
+function summary(): DashboardSummary {
+  return {
+    runtime: {
+      status: 'warning',
+      lastReloadedAt: '2026-06-20T00:00:00.000Z',
+      warningCount: 2,
+    },
+    servicesTotal: 0,
+    servicesRunning: 0,
+    servicesAvailable: 0,
+    servicesStopped: 0,
+    servicesDegraded: 0,
+    networkExposureCount: 0,
+    installedCount: 0,
+    favorites: [],
+    others: [],
+    warnings: [],
+    problemServices: [],
+  }
+}
+
+describe('Dashboard runtime health action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hookMocks.useDashboardSummary.mockReturnValue({
+      data: summary(),
+      isError: false,
+      isLoading: false,
+    })
+    hookMocks.useServices.mockReturnValue({
+      data: [],
+      isLoading: false,
+    })
+    hookMocks.useDashboardService.mockReturnValue({
+      data: null,
+      isLoading: false,
+    })
+    hookMocks.useFavoriteFeatureState.mockReturnValue({ enabled: true })
+    hookMocks.useToggleFavorite.mockReturnValue({ mutateAsync: vi.fn() })
+  })
+
+  it('runs the reload runtime action from the runtime health card', async () => {
+    hookMocks.useDashboardAction.mockReturnValue({
+      isPending: false,
+      mutate: hookMocks.mutate,
+      variables: undefined,
+    })
+
+    await renderRoute('/')
+    await userEvent.click(
+      screen.getByRole('button', { name: /Reload runtime/i })
+    )
+
+    expect(hookMocks.mutate).toHaveBeenCalledWith('reload-runtime')
+  })
+
+  it('shows a disabled progress state while runtime reload is pending', async () => {
+    hookMocks.useDashboardAction.mockReturnValue({
+      isPending: true,
+      mutate: hookMocks.mutate,
+      variables: 'reload-runtime',
+    })
+
+    await renderRoute('/')
+
+    expect(
+      screen.getByRole('button', { name: /Reloading runtime/i })
+    ).toBeDisabled()
+  })
+})

--- a/src/features/dashboard/index.tsx
+++ b/src/features/dashboard/index.tsx
@@ -293,6 +293,8 @@ export function Dashboard() {
   }
 
   const summary = summaryQuery.data
+  const isReloadingRuntime =
+    actionMutation.isPending && actionMutation.variables === 'reload-runtime'
 
   return (
     <>
@@ -331,8 +333,10 @@ export function Dashboard() {
                 disabled={actionMutation.isPending}
                 className='w-full justify-start'
               >
-                <RefreshCcw className='mr-2 h-4 w-4' />
-                Reload runtime
+                <RefreshCcw
+                  className={`mr-2 h-4 w-4 ${isReloadingRuntime ? 'animate-spin' : ''}`}
+                />
+                {isReloadingRuntime ? 'Reloading runtime...' : 'Reload runtime'}
               </Button>
             }
           />

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -104,9 +104,9 @@ function summary(services: DashboardService[]): DashboardSummary {
   }
 }
 
-function jsonResponse(body: unknown) {
+function jsonResponse(body: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status: init?.status ?? 200,
     headers: { 'Content-Type': 'application/json' },
   })
 }
@@ -266,6 +266,79 @@ describe('service lasso dashboard runtime client', () => {
     )
     expect(runtimeSummary.servicesRunning).toBe(3)
     expect(runtimeSummary.problemServices).toEqual([])
+  })
+
+  it('reloads runtime through the runtime action API before refreshing dashboard status', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const warningServices = [
+      service('@traefik', 'Traefik', 'stopped'),
+      service('@serviceadmin', 'Service Admin', 'running'),
+    ]
+    const healthyServices = warningServices.map((item) => ({
+      ...item,
+      status: 'running' as const,
+      runtimeHealth: {
+        ...item.runtimeHealth,
+        state: 'running' as const,
+        health: 'healthy' as const,
+      },
+    }))
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          action: 'reload',
+          ok: true,
+          results: [],
+          skipped: [],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ summary: summary(healthyServices) })
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { runDashboardAction } = await import('./client')
+
+    const runtimeSummary = await runDashboardAction('reload-runtime')
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://runtime.test/api/runtime/actions/reload',
+      { method: 'POST' }
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://runtime.test/api/dashboard',
+      undefined
+    )
+    expect(runtimeSummary.runtime.status).toBe('healthy')
+    expect(runtimeSummary.problemServices).toEqual([])
+  })
+
+  it('surfaces runtime API error details from failed reload responses', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse(
+        {
+          detail: 'Reload blocked because @nginx has invalid health config.',
+        },
+        { status: 409 }
+      )
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { runDashboardAction } = await import('./client')
+
+    await expect(runDashboardAction('reload-runtime')).rejects.toThrow(
+      'Service Lasso runtime API returned 409: Reload blocked because @nginx has invalid health config.'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('runs stop-all and restart-all through runtime orchestration endpoints', async () => {

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -33,12 +33,52 @@ function buildApiUrl(pathname: string) {
   return `${serviceLassoApiBaseUrl}${pathname}`
 }
 
+function readApiErrorMessage(payload: unknown) {
+  if (!payload || typeof payload !== 'object') {
+    return null
+  }
+
+  for (const key of ['detail', 'message', 'title', 'error']) {
+    const value = (payload as Record<string, unknown>)[key]
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim()
+    }
+  }
+
+  return null
+}
+
+async function readResponseBody(response: Response, contentType: string) {
+  if (contentType.toLowerCase().includes('application/json')) {
+    try {
+      return await response.json()
+    } catch {
+      return null
+    }
+  }
+
+  try {
+    return await response.text()
+  } catch {
+    return null
+  }
+}
+
 async function fetchRuntimeJson<T>(pathname: string, init?: RequestInit) {
   const response = await fetch(buildApiUrl(pathname), init)
   const contentType = response.headers.get('content-type') ?? ''
 
   if (!response.ok) {
-    throw new Error(`Service Lasso runtime API returned ${response.status}.`)
+    const body = await readResponseBody(response, contentType)
+    const bodyMessage =
+      typeof body === 'string' && body.trim()
+        ? body.trim()
+        : readApiErrorMessage(body)
+    const suffix = bodyMessage ? `: ${bodyMessage}` : '.'
+
+    throw new Error(
+      `Service Lasso runtime API returned ${response.status}${suffix}`
+    )
   }
 
   if (!contentType.toLowerCase().includes('application/json')) {

--- a/src/lib/service-lasso-dashboard/hooks.test.tsx
+++ b/src/lib/service-lasso-dashboard/hooks.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDashboardAction } from './hooks'
+import type { DashboardSummary } from './types'
+
+const mocks = vi.hoisted(() => ({
+  runDashboardAction: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}))
+
+vi.mock('./client', () => ({
+  buildServiceLogUrl: vi.fn(),
+  fetchDashboardService: vi.fn(),
+  fetchDashboardSummary: vi.fn(),
+  fetchServices: vi.fn(),
+  runDashboardAction: mocks.runDashboardAction,
+}))
+
+function summary(): DashboardSummary {
+  return {
+    runtime: {
+      status: 'healthy',
+      lastReloadedAt: '2026-06-20T00:00:00.000Z',
+      warningCount: 0,
+    },
+    servicesTotal: 0,
+    servicesRunning: 0,
+    servicesAvailable: 0,
+    servicesStopped: 0,
+    servicesDegraded: 0,
+    networkExposureCount: 0,
+    installedCount: 0,
+    favorites: [],
+    others: [],
+    warnings: [],
+    problemServices: [],
+  }
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useDashboardAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a success toast after runtime reload refreshes dashboard data', async () => {
+    mocks.runDashboardAction.mockResolvedValueOnce(summary())
+
+    const { result } = renderHook(() => useDashboardAction(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync('reload-runtime')
+    })
+
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      'Runtime reloaded and health data refreshed.'
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('shows the specific runtime API error when runtime reload fails', async () => {
+    mocks.runDashboardAction.mockRejectedValueOnce(
+      new Error(
+        'Service Lasso runtime API returned 409: Reload blocked because @nginx has invalid health config.'
+      )
+    )
+
+    const { result } = renderHook(() => useDashboardAction(), { wrapper })
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync('reload-runtime')
+      ).rejects.toThrow(
+        'Reload blocked because @nginx has invalid health config.'
+      )
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Service Lasso runtime API returned 409: Reload blocked because @nginx has invalid health config.'
+    )
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import {
   buildServiceLogUrl,
   fetchDashboardService,
@@ -46,7 +47,7 @@ export function useDashboardAction() {
 
   return useMutation({
     mutationFn: (action: DashboardAction) => runDashboardAction(action),
-    onSuccess: (data) => {
+    onSuccess: (data, action) => {
       queryClient.setQueryData(dashboardQueryKey, data)
 
       const allServices = [
@@ -58,6 +59,22 @@ export function useDashboardAction() {
       for (const service of allServices) {
         queryClient.setQueryData([...dashboardQueryKey, service.id], service)
       }
+
+      if (action === 'reload-runtime') {
+        toast.success('Runtime reloaded and health data refreshed.')
+      }
+    },
+    onError: (error, action) => {
+      if (action !== 'reload-runtime') {
+        return
+      }
+
+      const message =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : 'Runtime reload failed. Check the Service Lasso runtime API logs.'
+
+      toast.error(message)
     },
   })
 }


### PR DESCRIPTION
## Issue
Closes #209

## Summary
- Parse failed runtime API responses so reload failures surface backend `detail`/`message`/`title`/`error` text instead of a generic message.
- Add reload-specific success and error toasts after the dashboard action refreshes runtime health data.
- Show a disabled `Reloading runtime...` state with a spinning reload icon while the runtime reload request is pending.

## Scope
- In scope: Dashboard runtime health reload action, runtime dashboard client error parsing, reload-action tests.
- Out of scope: Runtime backend behavior, service release/pin changes, unrelated lint warning in `src/features/secrets-broker/secrets-management-page.tsx`.

## Spec / contract / fixture impact
- Updated: No public API/schema/spec change; client now consumes existing API error fields more specifically.
- Not required because: Runtime endpoint contract already returns JSON action/error payloads; this is UI behavior and client error handling.

## Nash invariant impact
- Invariant: No secret values should be exposed in UI errors/logs.
- Preservation proof: Error extraction only uses generic API problem fields (`detail`, `message`, `title`, `error`) and tests use non-secret service health text.

## Validation
- PASS `npm run test:unit -- src/lib/service-lasso-dashboard/client.test.ts src/lib/service-lasso-dashboard/hooks.test.tsx src/features/dashboard/dashboard.test.tsx` — 3 files / 12 tests passed; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\vitest-focused.log`.
- PASS `npm run build` — production build succeeded; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\npm-build.log`.
- PASS `npm run lint` — ESLint completed with 0 errors and 1 pre-existing warning in `src/features/secrets-broker/secrets-management-page.tsx`; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\npm-lint.log`.
- PASS canonical preflight: Service Admin `http://192.168.1.53:17700/` HTTP 200 and runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\demo-health-preflight.json`.
- PASS direct runtime reload reproduction: POST `http://192.168.1.53:17883/api/runtime/actions/reload` returned HTTP 200/action `reload`/`ok: true`; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6\reproduce-runtime-reload-post.json`.

## Approval trail
- Required: yes, normal PR review/checks before merge.
- Evidence: This PR is opened from branch `fix/issue-209-reload-runtime-toast`; commit `5232bb8`.

## Cleanup
- Branch cleanup after merge: checkout `master`, fast-forward pull, delete local/remote issue branch when safe.
- Release-to-demo gate: not completed in this PR-opening run because no merge/release has occurred yet. After merge/release, the canonical demo must consume the exact released Service Admin commit/tag before #209 is claimed done.