### PR TITLE
fix(serviceadmin): show feedback after start services action

### DIFF
--- a/src/features/dashboard/dashboard.test.tsx
+++ b/src/features/dashboard/dashboard.test.tsx
@@ -79,6 +79,21 @@ describe('Dashboard runtime health action', () => {
     expect(hookMocks.mutate).toHaveBeenCalledWith('reload-runtime')
   })
 
+  it('runs the start services action from the services card', async () => {
+    hookMocks.useDashboardAction.mockReturnValue({
+      isPending: false,
+      mutate: hookMocks.mutate,
+      variables: undefined,
+    })
+
+    await renderRoute('/')
+    await userEvent.click(
+      screen.getByRole('button', { name: /Start services/i })
+    )
+
+    expect(hookMocks.mutate).toHaveBeenCalledWith('start-services')
+  })
+
   it('shows a disabled progress state while runtime reload is pending', async () => {
     hookMocks.useDashboardAction.mockReturnValue({
       isPending: true,
@@ -90,6 +105,20 @@ describe('Dashboard runtime health action', () => {
 
     expect(
       screen.getByRole('button', { name: /Reloading runtime/i })
+    ).toBeDisabled()
+  })
+
+  it('shows a disabled progress state while services are starting', async () => {
+    hookMocks.useDashboardAction.mockReturnValue({
+      isPending: true,
+      mutate: hookMocks.mutate,
+      variables: 'start-services',
+    })
+
+    await renderRoute('/')
+
+    expect(
+      screen.getByRole('button', { name: /Starting services/i })
     ).toBeDisabled()
   })
 })

--- a/src/features/dashboard/index.tsx
+++ b/src/features/dashboard/index.tsx
@@ -295,6 +295,8 @@ export function Dashboard() {
   const summary = summaryQuery.data
   const isReloadingRuntime =
     actionMutation.isPending && actionMutation.variables === 'reload-runtime'
+  const isStartingServices =
+    actionMutation.isPending && actionMutation.variables === 'start-services'
 
   return (
     <>
@@ -353,7 +355,7 @@ export function Dashboard() {
                 className='w-full justify-start'
               >
                 <Play className='mr-2 h-4 w-4' />
-                Start services
+                {isStartingServices ? 'Starting services...' : 'Start services'}
               </Button>
             }
           />

--- a/src/lib/service-lasso-dashboard/hooks.test.tsx
+++ b/src/lib/service-lasso-dashboard/hooks.test.tsx
@@ -101,4 +101,40 @@ describe('useDashboardAction', () => {
     )
     expect(mocks.toastSuccess).not.toHaveBeenCalled()
   })
+
+  it('shows a success toast after start services refreshes dashboard data', async () => {
+    mocks.runDashboardAction.mockResolvedValueOnce(summary())
+
+    const { result } = renderHook(() => useDashboardAction(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync('start-services')
+    })
+
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      'Start services request accepted. Services status refreshed.'
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('shows the specific runtime API error when start services fails', async () => {
+    mocks.runDashboardAction.mockRejectedValueOnce(
+      new Error(
+        'Service Lasso runtime API returned 503: startAll failed because @postgres did not reach healthy state.'
+      )
+    )
+
+    const { result } = renderHook(() => useDashboardAction(), { wrapper })
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync('start-services')
+      ).rejects.toThrow('@postgres did not reach healthy state')
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Service Lasso runtime API returned 503: startAll failed because @postgres did not reach healthy state.'
+    )
+    expect(mocks.toastSuccess).not.toHaveBeenCalled()
+  })
 })

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -63,16 +63,27 @@ export function useDashboardAction() {
       if (action === 'reload-runtime') {
         toast.success('Runtime reloaded and health data refreshed.')
       }
+
+      if (action === 'start-services') {
+        toast.success(
+          'Start services request accepted. Services status refreshed.'
+        )
+      }
     },
     onError: (error, action) => {
-      if (action !== 'reload-runtime') {
+      if (action !== 'reload-runtime' && action !== 'start-services') {
         return
       }
+
+      const fallback =
+        action === 'reload-runtime'
+          ? 'Runtime reload failed. Check the Service Lasso runtime API logs.'
+          : 'Start services failed. Check the Service Lasso runtime API logs.'
 
       const message =
         error instanceof Error && error.message.trim()
           ? error.message
-          : 'Runtime reload failed. Check the Service Lasso runtime API logs.'
+          : fallback
 
       toast.error(message)
     },


### PR DESCRIPTION
## Issue
Closes #210

## Summary
- Add a visible pending label for the dashboard Services card `Start services` action.
- Show success and actionable error toasts for `start-services` through the shared dashboard action hook.
- Cover the start action, pending state, success toast, and failure toast with focused tests.

## Scope
- In scope: dashboard Services card feedback and shared dashboard action feedback for `start-services`.
- Out of scope: changing runtime orchestration endpoints, service lifecycle semantics, or unrelated Services page actions.

## Spec / contract / fixture impact
- Not required because this changes existing UI feedback for an existing runtime action and does not alter public API/schema/manifest behavior.

## Nash invariant impact
- Invariant: no service lifecycle action should appear silent after operator activation.
- Preservation proof: existing `runDashboardAction('start-services')` API call remains unchanged; the mutation still refreshes cached dashboard/services data, with new user-visible feedback only.

## Validation
- PASS `npx vitest run src/lib/service-lasso-dashboard/hooks.test.tsx src/features/dashboard/dashboard.test.tsx` — 2 files / 8 tests passed; log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-032515\issue-210-focused-vitest.log`
- PASS `npm run lint` — 0 errors, 1 pre-existing warning in `src/features/secrets-broker/secrets-management-page.tsx`; log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-032515\issue-210-lint.log`
- PASS `npm run build` — production build completed; log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-032515\issue-210-build.log`
- PASS `npm run test:unit` — 31 files / 177 tests passed; log: `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-032515\issue-210-full-vitest.log`

## Demo / release gate
- Canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200 with `status: ok`.
- Current live Service Admin installed artifact before merge/release: `2026.6.19-f2b616e` from `service-lasso/lasso-serviceadmin`.
- This PR has not been merged or released yet, so the mandatory release-to-demo pin gate is not complete in this PR state.

## Approval trail
- Required: yes, until repository rules/checks allow merge.
- Evidence: PR checks and mergeability to be inspected after opening.

## Cleanup
- Branch: `issue-210-start-services-feedback`
- Commit: `5af7eb2`
- Post-merge: release Service Admin, update core demo pin if required, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, then close #210 only after expected and live Service Admin release/commit match.