### PR TITLE
feat: move service detail jump actions to header

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -16,9 +16,12 @@ import {
   ExternalLink,
   HeartPulse,
   Link2,
+  Network,
   PackageCheck,
   Save,
   ScanSearch,
+  ScrollText,
+  Split,
   Undo2,
   Wrench,
 } from 'lucide-react'
@@ -896,14 +899,39 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       </p>
                     </div>
                   </div>
-                  <div className='flex flex-wrap gap-2'>
+                  <div
+                    className='flex flex-wrap justify-start gap-2 sm:justify-end'
+                    data-testid='service-detail-quick-actions'
+                  >
+                    <Button variant='outline' size='sm' asChild>
+                      <Link to='/logs' search={{ service: service.id }}>
+                        <ScrollText className='mr-2 size-4' />
+                        Logs
+                      </Link>
+                    </Button>
+                    <Button variant='outline' size='sm' asChild>
+                      <Link to='/dependencies' search={{ service: service.id }}>
+                        <Split className='mr-2 size-4' />
+                        Dependencies
+                      </Link>
+                    </Button>
                     <Button variant='outline' size='sm' asChild>
                       <Link to='/variables' search={{ service: service.id }}>
+                        <ArrowRight className='mr-2 size-4' />
                         Variables
                       </Link>
                     </Button>
                     <Button variant='outline' size='sm' asChild>
-                      <Link to='/network'>Network</Link>
+                      <Link to='/network'>
+                        <Network className='mr-2 size-4' />
+                        Network
+                      </Link>
+                    </Button>
+                    <Button variant='outline' size='sm' asChild>
+                      <Link to='/runtime' search={{ service: service.id }}>
+                        <HeartPulse className='mr-2 size-4' />
+                        Runtime
+                      </Link>
                     </Button>
                   </div>
                 </div>
@@ -1139,8 +1167,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                       <CardHeader>
                         <CardTitle>Diagnostics + recent logs</CardTitle>
                         <CardDescription>
-                          Recent activity preview plus the next operator jump
-                          points.
+                          Recent activity preview for this service.
                         </CardDescription>
                       </CardHeader>
                       <CardContent className='space-y-4'>
@@ -1149,32 +1176,6 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                           value={service.metadata.logPath}
                         />
                         <ServiceLogViewer entries={service.recentLogs} />
-                        <div className='grid gap-2 sm:grid-cols-2 lg:grid-cols-4'>
-                          <Button variant='outline' asChild>
-                            <Link to='/logs' search={{ service: service.id }}>
-                              Open live logs
-                            </Link>
-                          </Button>
-                          <Button variant='outline' asChild>
-                            <Link
-                              to='/dependencies'
-                              search={{ service: service.id }}
-                            >
-                              Open dependencies
-                            </Link>
-                          </Button>
-                          <Button variant='outline' asChild>
-                            <Link to='/network'>Open network view</Link>
-                          </Button>
-                          <Button variant='outline' asChild>
-                            <Link
-                              to='/runtime'
-                              search={{ service: service.id }}
-                            >
-                              Open runtime view
-                            </Link>
-                          </Button>
-                        </div>
                       </CardContent>
                     </Card>
                   </TabsContent>

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -1,0 +1,53 @@
+import { renderRoute } from '@/test/render-route'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+describe('service detail quick actions', () => {
+  it('keeps jump actions in the header and removes duplicate log-panel actions', async () => {
+    const user = userEvent.setup()
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    const quickActions = within(
+      screen.getByTestId('service-detail-quick-actions')
+    )
+
+    expect(quickActions.getByRole('link', { name: /logs/i })).toHaveAttribute(
+      'href',
+      '/logs?service=%40serviceadmin'
+    )
+    expect(
+      quickActions.getByRole('link', { name: /dependencies/i })
+    ).toHaveAttribute('href', '/dependencies?service=%40serviceadmin')
+    expect(
+      quickActions.getByRole('link', { name: /variables/i })
+    ).toHaveAttribute('href', '/variables?service=%40serviceadmin')
+    expect(
+      quickActions.getByRole('link', { name: /network/i })
+    ).toHaveAttribute('href', '/network')
+    expect(
+      quickActions.getByRole('link', { name: /runtime/i })
+    ).toHaveAttribute('href', '/runtime?service=%40serviceadmin')
+
+    await user.click(screen.getByRole('tab', { name: /logs/i }))
+
+    expect(screen.queryByRole('link', { name: /open live logs/i })).toBeNull()
+    expect(
+      screen.queryByRole('link', { name: /open dependencies/i })
+    ).toBeNull()
+    expect(
+      screen.queryByRole('link', { name: /open network view/i })
+    ).toBeNull()
+    expect(
+      screen.queryByRole('link', { name: /open runtime view/i })
+    ).toBeNull()
+    expect(screen.getByText('Diagnostics + recent logs')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Issue
Closes #206

## Summary
- Moves `Logs`, `Dependencies`, and `Runtime` into the service detail header quick-action row beside `Variables` and `Network`.
- Removes the duplicate lower jump-action button row from the Logs tab while keeping the diagnostics/recent log preview intact.
- Adds focused route-render coverage for the header links and removed lower actions.

## Scope
- In scope: Service detail quick-action placement and focused UI regression coverage.
- Out of scope: Changing destination routes, tab counts, route data contracts, runtime APIs, service manifests, or release pins.

## Spec / contract / fixture impact
- Updated: no public API/schema/manifest contract changes.
- Not required because: this is a Service Admin UI layout/navigation adjustment using existing routes.

## Nash invariant impact
- Invariant: no secret values or runtime credentials are exposed by this navigation change.
- Preservation proof: change only moves links and removes duplicate buttons; no data-fetching or render paths for secret values were added.

## Validation
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-format-check-rerun.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-npm-lint-rerun.log` (existing warning remains in `src/features/secrets-broker/secrets-management-page.tsx:371`)
- PASS `npm run test:unit -- src/features/service-detail/service-detail.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-focused-test-rerun.log`
- PASS `npm run test:unit` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-npm-test-unit.log` (32 files / 178 tests)
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-npm-build.log`
- PASS `npx playwright test tests/ui/service-admin.spec.ts` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-playwright-service-admin.log` (4 tests)
- PASS `powershell -File scripts/package.ps1` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-206-package-win32.log`

## Demo / release gate
- Preflight canonical demo health passed before work: Service Admin `http://192.168.1.53:17700/` HTTP 200 and runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.
- This PR has not been merged or released, so the mandatory release-to-demo pin/install gate is not complete yet.
- Current live canonical `@serviceadmin` manifest still points at release tag `2026.6.19-e3a7578`; expected PR commit is `beab328`. Those do not match until this PR is merged, released, core pin is updated if required, and the canonical demo is recycled/verified.

## Approval trail
- Required: yes, before merge/release/demo pin.
- Evidence: PR is open for review and validation.

## Cleanup
- Branch: `issue-206-service-detail-actions`
- Post-merge: release/pin/recycle canonical demo before closing issue as done.