### PR TITLE
feat(serviceadmin): improve service details endpoint table actions

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -141,6 +141,73 @@ function CopyValueButton({
   )
 }
 
+function canOpenEndpointUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function EndpointRowActions({ endpoint }: { endpoint: ServiceEndpoint }) {
+  const canOpen = canOpenEndpointUrl(endpoint.url)
+
+  return (
+    <div className='flex items-center gap-1'>
+      <Button
+        asChild={canOpen}
+        type='button'
+        size='icon'
+        variant='outline'
+        className='size-8 shrink-0'
+        title={
+          canOpen
+            ? `Open ${endpoint.label} endpoint`
+            : `Endpoint URL unavailable for ${endpoint.label}`
+        }
+        disabled={!canOpen}
+      >
+        {canOpen ? (
+          <a href={endpoint.url} target='_blank' rel='noreferrer'>
+            <ExternalLink className='size-3.5' />
+            <span className='sr-only'>Open {endpoint.label} endpoint</span>
+          </a>
+        ) : (
+          <>
+            <ExternalLink className='size-3.5' />
+            <span className='sr-only'>
+              Endpoint URL unavailable for {endpoint.label}
+            </span>
+          </>
+        )}
+      </Button>
+      <CopyValueButton
+        value={endpoint.url}
+        label={`Copy ${endpoint.label} URL`}
+      />
+      <Button
+        asChild
+        type='button'
+        size='icon'
+        variant='outline'
+        className='size-8 shrink-0'
+        title={`Open ${endpoint.label} in route inventory`}
+      >
+        <Link
+          to='/service-routes'
+          search={{ route: endpoint.url, page: 1, pageSize: 10 }}
+        >
+          <Network className='size-3.5' />
+          <span className='sr-only'>
+            Open {endpoint.label} in route inventory
+          </span>
+        </Link>
+      </Button>
+    </div>
+  )
+}
+
 function EndpointsTable({ endpoints }: { endpoints: ServiceEndpoint[] }) {
   return (
     <div className='overflow-x-auto rounded-md border'>
@@ -153,7 +220,7 @@ function EndpointsTable({ endpoints }: { endpoints: ServiceEndpoint[] }) {
             <TableHead>Port</TableHead>
             <TableHead>Exposure</TableHead>
             <TableHead>URL</TableHead>
-            <TableHead>Action</TableHead>
+            <TableHead>Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -165,16 +232,11 @@ function EndpointsTable({ endpoints }: { endpoints: ServiceEndpoint[] }) {
                 <TableCell>{endpoint.bind}</TableCell>
                 <TableCell>{endpoint.port}</TableCell>
                 <TableCell>{endpoint.exposure}</TableCell>
-                <TableCell className='max-w-[280px] text-sm break-all text-muted-foreground'>
-                  {endpoint.url}
+                <TableCell className='max-w-[360px] min-w-[220px] font-mono text-xs break-all text-muted-foreground'>
+                  {endpoint.url || 'No URL recorded'}
                 </TableCell>
                 <TableCell>
-                  <Button asChild size='sm' variant='outline'>
-                    <a href={endpoint.url} target='_blank' rel='noreferrer'>
-                      Open
-                      <ExternalLink className='ml-2 size-3.5' />
-                    </a>
-                  </Button>
+                  <EndpointRowActions endpoint={endpoint} />
                 </TableCell>
               </TableRow>
             ))

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -1,7 +1,7 @@
 import { renderRoute } from '@/test/render-route'
 import { screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 describe('service detail quick actions', () => {
   it('keeps jump actions in the header and removes duplicate log-panel actions', async () => {
@@ -49,5 +49,52 @@ describe('service detail quick actions', () => {
       screen.queryByRole('link', { name: /open runtime view/i })
     ).toBeNull()
     expect(screen.getByText('Diagnostics + recent logs')).toBeVisible()
+  })
+})
+
+describe('service detail endpoints table', () => {
+  it('renders actual endpoint URLs with open, copy, and route inventory actions', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /endpoints/i }))
+
+    const localUrlCell = screen.getByText('http://localhost:17700')
+    const localEndpointRow = localUrlCell.closest('tr')
+    expect(localEndpointRow).not.toBeNull()
+    const row = within(localEndpointRow as HTMLTableRowElement)
+
+    expect(row.getByText('Local UI')).toBeVisible()
+    expect(row.getByText('HTTP')).toBeVisible()
+    expect(row.getByText('0.0.0.0')).toBeVisible()
+    expect(row.getByText('17700')).toBeVisible()
+    expect(row.getByText('local')).toBeVisible()
+    expect(localUrlCell).toBeVisible()
+
+    expect(
+      row.getByRole('link', { name: 'Open Local UI endpoint' })
+    ).toHaveAttribute('href', 'http://localhost:17700')
+
+    await user.click(row.getByRole('button', { name: 'Copy Local UI URL' }))
+    expect(writeText).toHaveBeenCalledWith('http://localhost:17700')
+
+    expect(
+      row.getByRole('link', { name: 'Open Local UI in route inventory' })
+    ).toHaveAttribute(
+      'href',
+      expect.stringContaining('route=http%3A%2F%2Flocalhost%3A17700')
+    )
   })
 })


### PR DESCRIPTION
## Issue
Closes #208

## Summary
- Updated the Service Details Endpoints table so the `URL` column displays the actual endpoint URL as the primary value.
- Replaced the single text `Open` action with compact row actions for opening the endpoint, copying the URL, and opening the route inventory filtered to that endpoint URL.
- Handles missing or non-browser-openable endpoint URLs by disabling the open action instead of rendering a broken link.

## Scope
- In scope: Service Details Endpoints table rendering/actions and focused component route coverage.
- Out of scope: backend endpoint contract changes, route inventory data model changes, and unrelated Network table behavior.

## Spec / contract / fixture impact
- Not required because this is a UI behavior change over existing `ServiceEndpoint.url` data.

## Nash invariant impact
- Invariant: Service Admin remains optional and uses existing Service Lasso dashboard data contracts.
- Preservation proof: no service manifest, runtime API, secrets, or deployment contract changes.

## Validation
- PASS `npx vitest run src/features/service-detail/service-detail.test.tsx --pool=threads --maxWorkers=1 --reporter=dot` — 2 tests passed; logged at `.work-agent/logs/issue-208/service-detail-test.log`.
- PASS `npx prettier --check src/features/service-detail/index.tsx src/features/service-detail/service-detail.test.tsx` — all matched files use Prettier style.
- PASS `git diff --check` — no whitespace errors.
- PASS `npm run build` — exit 0; Vite emitted only existing/deferred chunk-size/deprecation warnings.
- PASS `npm run lint` — exit 0; one pre-existing warning remains in `src/features/secrets-broker/secrets-management-page.tsx:371` outside this issue.

## Approval trail
- Required: no explicit human review requirement found before PR creation.
- Evidence: branch is a focused issue branch from clean/current `master`.

## Cleanup
- Branch cleanup after merge: delete `issue-208-endpoint-table-actions` and return local repo to clean/current `master`.
- Demo gate: Service Admin is demo-consumed; after merge/release, canonical demo must consume the exact release/commit and verify LAN Service Admin/runtime before closure.