### PR TITLE
feat(variables): show template value column

### DIFF
--- a/src/features/variables/index.tsx
+++ b/src/features/variables/index.tsx
@@ -51,6 +51,7 @@ type VariableRow = {
   id: string
   key: string
   value: string
+  templateValue: string | null
   scope: 'global' | 'service'
   secret: 'secret' | 'plain'
   source: string
@@ -88,7 +89,7 @@ const columns: ColumnDef<VariableRow>[] = [
     id: 'value',
     accessorFn: (row) => row.value,
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Value' />
+      <DataTableColumnHeader column={column} title='Resolved value' />
     ),
     cell: ({ row }) => (
       <div className='flex min-w-0 items-center gap-2'>
@@ -112,6 +113,32 @@ const columns: ColumnDef<VariableRow>[] = [
         </Button>
       </div>
     ),
+  },
+  {
+    id: 'templateValue',
+    accessorFn: (row) => row.templateValue ?? '',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Template value' />
+    ),
+    cell: ({ row }) => {
+      const displayValue =
+        row.original.secret === 'secret'
+          ? '••••••••'
+          : (row.original.templateValue ?? 'Not recorded')
+
+      return (
+        <span
+          className='block max-w-[320px] truncate text-sm text-muted-foreground'
+          title={
+            row.original.secret === 'secret'
+              ? undefined
+              : (row.original.templateValue ?? 'Not recorded')
+          }
+        >
+          {displayValue}
+        </span>
+      )
+    },
   },
   {
     id: 'scope',
@@ -236,6 +263,7 @@ export function Variables({ service, search, navigate }: VariablesProps) {
         const id = [
           variable.key,
           variable.value,
+          variable.templateValue ?? '',
           variable.scope,
           variable.secret ? 'secret' : 'plain',
           variable.source ?? 'Not recorded',
@@ -256,12 +284,16 @@ export function Variables({ service, search, navigate }: VariablesProps) {
         }
 
         const safeValue = variable.secret ? '' : variable.value
+        const safeTemplateValue = variable.secret
+          ? ''
+          : (variable.templateValue ?? '')
         const serviceRef = { id: service.id, name: service.name }
 
         map.set(id, {
           id,
           key: variable.key,
           value: variable.value,
+          templateValue: variable.templateValue ?? null,
           scope: variable.scope,
           secret: variable.secret ? 'secret' : 'plain',
           source: variable.source ?? 'Not recorded',
@@ -269,6 +301,7 @@ export function Variables({ service, search, navigate }: VariablesProps) {
           searchText: [
             variable.key,
             safeValue,
+            safeTemplateValue,
             variable.scope,
             variable.secret ? 'secret' : 'plain',
             variable.source ?? 'Not recorded',

--- a/src/features/variables/variables.test.tsx
+++ b/src/features/variables/variables.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
           {
             key: 'SERVICE_LASSO_API_BASE_URL',
             value: 'http://127.0.0.1:17883',
+            templateValue: '${runtime.API_BASE_URL}',
             scope: 'service',
             secret: false,
             source: '@serviceadmin/service.json',
@@ -20,6 +21,7 @@ vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
           {
             key: 'SERVICE_LASSO_SESSION_SECRET',
             value: 'super-secret-session-value',
+            templateValue: '${serviceadmin.SESSION_SECRET}',
             scope: 'service',
             secret: true,
             source: '@serviceadmin/service.json',
@@ -33,6 +35,7 @@ vi.mock('@/lib/service-lasso-dashboard/hooks', () => ({
           {
             key: 'WORKER_QUEUE_URL',
             value: 'https://queue.internal/jobs',
+            templateValue: undefined,
             scope: 'global',
             secret: false,
             source: 'workspace/env',
@@ -57,7 +60,12 @@ describe('variables page', () => {
     expect(screen.queryByText('Environment variables')).not.toBeInTheDocument()
     expect(screen.queryByText(/variable rows shown/i)).not.toBeInTheDocument()
     expect(screen.getByRole('columnheader', { name: /key/i })).toBeVisible()
-    expect(screen.getByRole('columnheader', { name: /value/i })).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /resolved value/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /template value/i })
+    ).toBeVisible()
     expect(screen.getByRole('columnheader', { name: /source/i })).toBeVisible()
     expect(screen.getAllByRole('button', { name: /^Scope/i })[0]).toBeVisible()
     expect(screen.getAllByRole('button', { name: /^Source/i })[0]).toBeVisible()
@@ -66,9 +74,13 @@ describe('variables page', () => {
     ).toBeVisible()
     expect(screen.getByText('SERVICE_LASSO_API_BASE_URL')).toBeVisible()
     expect(screen.getByText('http://127.0.0.1:17883')).toBeVisible()
-    expect(screen.getByText('••••••••')).toBeVisible()
+    expect(screen.getByText('${runtime.API_BASE_URL}')).toBeVisible()
+    expect(screen.getAllByText('••••••••')).toHaveLength(2)
     expect(
       screen.queryByText('super-secret-session-value')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('${serviceadmin.SESSION_SECRET}')
     ).not.toBeInTheDocument()
 
     const scrollRegion = screen.getByTestId('variables-table-scroll-region')
@@ -101,8 +113,39 @@ describe('variables page', () => {
       expect(router.state.location.search).toMatchObject({ q: 'worker' })
     })
     expect(screen.getByText('WORKER_QUEUE_URL')).toBeVisible()
+    expect(screen.getByText('Not recorded')).toBeVisible()
     expect(
       screen.queryByText('SERVICE_LASSO_API_BASE_URL')
+    ).not.toBeInTheDocument()
+  })
+
+  it('can search by the source template value without indexing secret templates', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/variables')
+
+    await user.type(
+      screen.getByPlaceholderText(/Search variable keys/i),
+      'runtime.API_BASE_URL'
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('SERVICE_LASSO_API_BASE_URL')).toBeVisible()
+    })
+    expect(screen.queryByText('WORKER_QUEUE_URL')).not.toBeInTheDocument()
+
+    await user.clear(screen.getByPlaceholderText(/Search variable keys/i))
+    await user.type(
+      screen.getByPlaceholderText(/Search variable keys/i),
+      'serviceadmin.SESSION_SECRET'
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No variables match the current filters.')
+      ).toBeVisible()
+    })
+    expect(
+      screen.queryByText('${serviceadmin.SESSION_SECRET}')
     ).not.toBeInTheDocument()
   })
 })

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -269,6 +269,7 @@ const defaultServices: DashboardService[] = [
       {
         key: 'VITE_SERVICE_LASSO_API_BASE_URL',
         value: 'http://127.0.0.1:3001',
+        templateValue: '${SERVICE_LASSO_RUNTIME_URL}',
         scope: 'service',
         source: '.env.local',
       },
@@ -281,6 +282,7 @@ const defaultServices: DashboardService[] = [
       {
         key: 'SESSION_SECRET',
         value: 'secret://@serviceadmin/SESSION_SECRET',
+        templateValue: '${@serviceadmin.SESSION_SECRET}',
         scope: 'service',
         secret: true,
         source: '@secretsbroker/local/default',

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -27,6 +27,7 @@ export type ServiceEndpoint = {
 export type ServiceEnvironmentVariable = {
   key: string
   value: string
+  templateValue?: string
   scope: 'global' | 'service'
   secret?: boolean
   source?: string

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -200,6 +200,11 @@ test('runtime, network, installed, and variables tables render', async ({
   await expect(page.getByRole('heading', { name: 'Variables' })).toBeVisible()
   await expect(page.getByText('Environment variables')).toHaveCount(0)
   await expect(page.getByRole('columnheader', { name: /key/i })).toBeVisible()
-  await expect(page.getByRole('columnheader', { name: /value/i })).toBeVisible()
+  await expect(
+    page.getByRole('columnheader', { name: /resolved value/i })
+  ).toBeVisible()
+  await expect(
+    page.getByRole('columnheader', { name: /template value/i })
+  ).toBeVisible()
   await expect(page.getByText('SERVICE_LASSO_ROOT').first()).toBeVisible()
 })


### PR DESCRIPTION
## Issue
Closes #202

## Summary
- Adds a distinct `Template value` column next to the resolved value in the Variables table.
- Extends the Service Admin variable row type with optional `templateValue` support and updates stub data so template/resolved values can differ.
- Keeps secret rows masked in both resolved and template columns and excludes secret template text from table search.
- Updates the affected Playwright table smoke test to assert `Resolved value` and `Template value` separately.

## Scope
- In scope: Service Admin Variables table display, filtering/search data, focused UI tests, stub/type support, affected browser smoke test.
- Out of scope: Core runtime population of `templateValue` for live `/api/dashboard/services` payloads.

## Spec / contract / fixture impact
- Updated: Service Admin local dashboard type `ServiceEnvironmentVariable.templateValue?: string` and stub fixtures.
- Runtime contract note: live canonical core currently does not emit `templateValue`; rows without it render `Not recorded`. The UI is compatible with the field when core provides it.

## Nash invariant impact
- Invariant: secret-sensitive environment material must not be rendered through variables views.
- Preservation proof: focused tests assert secret resolved value and secret template value are not rendered, and secret template text is not indexed by search.

## Validation
- PASS `npx vitest run src/features/variables/variables.test.tsx --reporter verbose` — `.work-agent/logs/issue-202/variables-test-4.log` (3 tests passed).
- PASS `npx playwright test tests/ui/service-admin.spec.ts -g "runtime, network, installed, and variables tables render"` — `.work-agent/logs/issue-202/playwright-variables-column.log`.
- PASS `npm run build` — `.work-agent/logs/issue-202/build.log`.
- PASS `npm run lint` — `.work-agent/logs/issue-202/lint-2.log`; one existing warning in `src/features/secrets-broker/secrets-management-page.tsx`, unrelated to this PR.
- PASS `npm run format:check` — `.work-agent/logs/issue-202/format-check-2.log`.
- PASS canonical preflight before work and post-PR: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` status `ok`.

## Demo / release gate
- Not merged or released in this PR yet, so no demo-consumed release pin has changed.
- After merge/release, canonical Service Admin must consume commit/release `8c4fdf8` or its release artifact and the demo must be recycled/verified before issue closure.

## Approval trail
- Required: yes, normal PR review/checks before merge.
- Evidence: branch `issue-202-template-variable-column`, commit `8c4fdf8`.

## Cleanup
- Branch can be deleted after merge and canonical demo verification.
