### PR TITLE
feat(serviceadmin): add full config JSON modal to service details

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -14,6 +14,7 @@ import {
   ArrowRight,
   Copy,
   ExternalLink,
+  FileJson,
   HeartPulse,
   Link2,
   Network,
@@ -60,6 +61,16 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -79,6 +90,46 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+
+const REDACTED_CONFIG_VALUE = '[redacted by Service Admin]'
+const SENSITIVE_CONFIG_KEY_PATTERN =
+  /(?:password|passphrase|token|api[_-]?key|secret|private[_-]?key|credential|cookie)/i
+
+function redactSensitiveConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveConfigValue(item))
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value
+  }
+
+  const record = value as Record<string, unknown>
+
+  if (typeof record.key === 'string' && record.secret === true) {
+    return {
+      ...record,
+      value: REDACTED_CONFIG_VALUE,
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entryValue]) => {
+      if (
+        SENSITIVE_CONFIG_KEY_PATTERN.test(key) &&
+        typeof entryValue === 'string'
+      ) {
+        return [key, REDACTED_CONFIG_VALUE]
+      }
+
+      return [key, redactSensitiveConfigValue(entryValue)]
+    })
+  )
+}
+
+function buildServiceConfigJson(service: DashboardService) {
+  return JSON.stringify(redactSensitiveConfigValue(service), null, 2)
+}
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
   if (status === 'running') {
@@ -644,6 +695,42 @@ function MetadataRow({ label, value }: { label: string; value?: string }) {
   )
 }
 
+function FullConfigJsonDialog({ service }: { service: DashboardService }) {
+  const configJson = useMemo(() => buildServiceConfigJson(service), [service])
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type='button' variant='outline' size='sm'>
+          <FileJson className='mr-2 size-4' />
+          View full config JSON
+        </Button>
+      </DialogTrigger>
+      <DialogContent className='max-h-[88vh] gap-5 sm:max-w-4xl'>
+        <DialogHeader className='pr-8'>
+          <DialogTitle>Full config JSON</DialogTitle>
+          <DialogDescription>
+            {service.name} runtime service record with sensitive values masked.
+          </DialogDescription>
+        </DialogHeader>
+        <pre
+          data-testid='service-detail-full-config-json'
+          className='max-h-[60vh] overflow-auto rounded-md border bg-muted/35 p-4 font-mono text-xs leading-relaxed break-words whitespace-pre-wrap text-foreground'
+        >
+          {configJson}
+        </pre>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type='button' variant='outline'>
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 function EnvironmentTable({
   serviceId,
   variables,
@@ -995,6 +1082,7 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                         Runtime
                       </Link>
                     </Button>
+                    <FullConfigJsonDialog service={service} />
                   </div>
                 </div>
 

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -50,6 +50,47 @@ describe('service detail quick actions', () => {
     ).toBeNull()
     expect(screen.getByText('Diagnostics + recent logs')).toBeVisible()
   })
+
+  it('opens a full config JSON modal with secret values redacted', async () => {
+    const user = userEvent.setup()
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /view full config json/i })
+    )
+
+    const dialog = screen.getByRole('dialog', { name: /full config json/i })
+    const configJson = within(dialog).getByTestId(
+      'service-detail-full-config-json'
+    )
+
+    expect(configJson).toHaveTextContent('"id": "@serviceadmin"')
+    expect(configJson).toHaveTextContent('"favorite": true')
+    expect(configJson).toHaveTextContent('"templateValue"')
+    expect(configJson).toHaveTextContent('SESSION_SECRET')
+    expect(configJson).toHaveTextContent('[redacted by Service Admin]')
+    expect(configJson).not.toHaveTextContent(
+      'secret://@serviceadmin/SESSION_SECRET'
+    )
+    expect(configJson).not.toHaveTextContent(
+      'secret://openclaw/anthropic/api_key'
+    )
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('dialog', { name: /full config json/i })
+      ).toBeNull()
+    })
+  })
 })
 
 describe('service detail endpoints table', () => {


### PR DESCRIPTION
## Issue
Closes #203

## Summary
- Added a service detail action to open the full runtime service record as formatted JSON.
- Masks secret-backed environment variable values and sensitive keyed string values before rendering the JSON.
- Added focused component coverage for opening the modal, rendering representative fields, redaction, and Escape dismissal.

## Scope
- In scope: service details page full-config JSON modal, redaction helper, focused tests.
- Out of scope: changing the runtime API contract or adding a separate service.json fetch endpoint.

## Spec / contract / fixture impact
- Not required because this uses the existing `DashboardService` detail response from `/api/dashboard/services/:serviceId` and does not change API/schema behavior.
- Field audit: directly surfaced detail tabs already show service id/name/role/status/health, metadata paths/build/runtime, endpoints, dependencies/dependents, environment variable key/value/scope/source, logs, and actions. Fields that were not all directly visible as one complete document include `favorite`, `links`, `metadata.imageUrl` when present, and `environmentVariables[].templateValue`; these are now inspectable in the JSON modal from the existing runtime service record.

## Nash invariant impact
- Invariant: Service Admin must not expose raw secret values through config inspection surfaces.
- Preservation proof: secret-marked environment variable `value` fields and sensitive keyed string fields are replaced with `[redacted by Service Admin]`; tests assert known stub secret refs do not render in the modal.

## Validation
- PASS `npm run format:check` — `.work-agent/logs/issue-203-serviceadmin-format-check.log`
- PASS `npm run test -- src/features/service-detail/service-detail.test.tsx` — `.work-agent/logs/issue-203-service-detail-vitest.log`
- PASS `npm run build` — `.work-agent/logs/issue-203-serviceadmin-build.log`
- PASS `npm run lint` with one pre-existing warning in `src/features/secrets-broker/secrets-management-page.tsx:371` — `.work-agent/logs/issue-203-serviceadmin-lint.log`
- PASS `npx playwright test tests/ui/service-admin.spec.ts` — `.work-agent/logs/issue-203-serviceadmin-playwright.log`
- Initial CI failure on PR #221 was formatting-only and is captured at `.work-agent/logs/issue-203-ci-failure.log`; commit `27bcdbc` fixes it and re-runs local format check successfully.
- Preflight canonical demo before edits: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no explicit approval requested by issue trail.
- Evidence: issue was Project #1 Status Ready / Agent lane Ready for Agent at selection time.

## Cleanup
- Branch: `issue-203-full-config-json-modal`
- Commit: `27bcdbc`
- Post-merge: recycle/deploy canonical demo if merged, then verify Service Admin and runtime health before closing.
