### PR TITLE
feat(secrets): add Bitwarden BWS provider

### DIFF
--- a/src/features/secrets-broker/bitwarden-bws-provider-detail.tsx
+++ b/src/features/secrets-broker/bitwarden-bws-provider-detail.tsx
@@ -1,0 +1,254 @@
+import { KeyRound, ListChecks, ShieldCheck } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  secretsBrokerSourceBackends,
+  type SecretsBrokerSourceBackend,
+} from './source-backends'
+
+const bitwardenMappings = [
+  {
+    ref: 'secret://providers/bitwarden/default/OPENCLAW_API_KEY',
+    project: 'Service Lasso platform',
+    secretId: 'bws://project/service-lasso/openclaw-api-key',
+    selector: 'value',
+    owner: '@serviceadmin',
+    namespace: 'providers/bitwarden/default',
+  },
+  {
+    ref: 'secret://providers/bitwarden/default/RELEASE_SIGNING_KEY',
+    project: 'Service Lasso release',
+    secretId: 'bws://project/service-lasso/release-signing-key',
+    selector: 'value',
+    owner: 'release-worker',
+    namespace: 'providers/bitwarden/default',
+  },
+]
+
+const bitwardenConfigFields = [
+  ['Project id', 'service-lasso-platform'],
+  ['Source id', 'bitwarden-bws-cli'],
+  ['CLI command path', 'bws'],
+  ['Token reference', 'secret://providers/bitwarden/bws-access-token'],
+  ['Secret selector', 'value metadata only'],
+  ['Priority / fallback', 'addable until configured'],
+] as const
+
+function bitwardenProvider() {
+  return secretsBrokerSourceBackends.find(
+    (source) => source.id === 'bitwarden-bws-cli'
+  )
+}
+
+function matchesQuery(provider: SecretsBrokerSourceBackend, query: string) {
+  const normalizedQuery = query.trim().toLowerCase()
+
+  if (!normalizedQuery) return true
+
+  return [
+    provider.title,
+    provider.type,
+    provider.provider,
+    provider.source,
+    provider.state,
+    provider.lifecycle,
+    provider.summary,
+    provider.nextAction,
+    ...bitwardenConfigFields.flat(),
+    ...bitwardenMappings.flatMap((mapping) => Object.values(mapping)),
+  ]
+    .join(' ')
+    .toLowerCase()
+    .includes(normalizedQuery)
+}
+
+export function BitwardenBwsProviderDetail({ query = '' }: { query?: string }) {
+  const provider = bitwardenProvider()
+
+  if (!provider || !matchesQuery(provider, query)) return null
+
+  return (
+    <section className='space-y-4' aria-labelledby='bitwarden-bws-heading'>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <h2
+            id='bitwarden-bws-heading'
+            className='flex items-center gap-2 text-xl font-semibold'
+          >
+            <KeyRound className='size-5' /> Bitwarden / BWS CLI provider
+          </h2>
+          <p className='mt-1 text-sm text-muted-foreground'>
+            Provider-specific add/configure preview for project, source,
+            token-reference, secret mapping, selector, namespace, and fallback
+            metadata.
+          </p>
+        </div>
+        <div className='flex flex-wrap gap-2'>
+          <Badge variant='outline'>addable</Badge>
+          <Badge variant='secondary'>{provider.lifecycleDetail?.state}</Badge>
+          <Badge variant='outline'>values hidden</Badge>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className='flex flex-wrap items-start justify-between gap-3'>
+            <div>
+              <CardTitle className='flex items-center gap-2'>
+                <ListChecks className='size-4' /> Safe BWS configuration
+                metadata
+              </CardTitle>
+              <CardDescription>
+                BWS access tokens, secret values, raw CLI output, and provider
+                response bodies are never captured by this Service Admin
+                surface.
+              </CardDescription>
+            </div>
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button type='button' variant='outline'>
+                  <KeyRound className='size-4' /> Configure Bitwarden BWS
+                </Button>
+              </DialogTrigger>
+              <DialogContent className='max-h-[90vh] overflow-y-auto sm:max-w-2xl'>
+                <DialogHeader>
+                  <DialogTitle>Configure Bitwarden BWS</DialogTitle>
+                  <DialogDescription>
+                    Capture only safe metadata needed by the broker source
+                    contract. BWS authentication material remains behind a
+                    SecretRef handle.
+                  </DialogDescription>
+                </DialogHeader>
+
+                <div className='grid gap-4 md:grid-cols-2'>
+                  {bitwardenConfigFields.map(([label, value]) => (
+                    <div key={label} className='space-y-2'>
+                      <Label htmlFor={`bitwarden-${label}`}>{label}</Label>
+                      <Input id={`bitwarden-${label}`} readOnly value={value} />
+                    </div>
+                  ))}
+                </div>
+
+                <div className='rounded-md border p-3 text-sm'>
+                  <div className='font-medium'>Test action</div>
+                  <div className='mt-1 text-muted-foreground'>
+                    Metadata-only BWS project and secret-handle check; values,
+                    token material, and raw command output are scrubbed before
+                    diagnostics or audit events.
+                  </div>
+                </div>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </CardHeader>
+        <CardContent className='space-y-4'>
+          <div className='grid gap-3 text-sm md:grid-cols-3'>
+            <div>
+              <div className='text-xs text-muted-foreground'>source id</div>
+              <div className='font-medium'>{provider.sourceId}</div>
+            </div>
+            <div>
+              <div className='text-xs text-muted-foreground'>kind</div>
+              <div className='font-medium'>{provider.kind}</div>
+            </div>
+            <div>
+              <div className='text-xs text-muted-foreground'>display name</div>
+              <div className='font-medium'>{provider.title}</div>
+            </div>
+            <div>
+              <div className='text-xs text-muted-foreground'>configured</div>
+              <div className='font-medium'>{String(provider.configured)}</div>
+            </div>
+            <div>
+              <div className='text-xs text-muted-foreground'>enabled</div>
+              <div className='font-medium'>{String(provider.enabled)}</div>
+            </div>
+            <div>
+              <div className='text-xs text-muted-foreground'>next action</div>
+              <div className='font-medium'>
+                {provider.lifecycleDetail?.nextAction}
+              </div>
+            </div>
+          </div>
+
+          <div className='overflow-x-auto rounded-md border'>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ref</TableHead>
+                  <TableHead>Project / secret</TableHead>
+                  <TableHead>Selector</TableHead>
+                  <TableHead>Ownership</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bitwardenMappings.map((mapping) => (
+                  <TableRow key={mapping.ref}>
+                    <TableCell className='min-w-72 align-top'>
+                      {mapping.ref}
+                    </TableCell>
+                    <TableCell className='min-w-56 align-top'>
+                      <div>{mapping.project}</div>
+                      <div className='text-sm text-muted-foreground'>
+                        {mapping.secretId}
+                      </div>
+                    </TableCell>
+                    <TableCell className='min-w-40 align-top'>
+                      {mapping.selector}
+                    </TableCell>
+                    <TableCell className='min-w-56 align-top'>
+                      <div>{mapping.owner}</div>
+                      <div className='text-sm text-muted-foreground'>
+                        {mapping.namespace}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className='rounded-md border p-3 text-sm'>
+            <div className='flex items-center gap-2 font-medium'>
+              <ShieldCheck className='size-4' /> Diagnostics and audit
+            </div>
+            <div className='mt-2 flex flex-wrap gap-2'>
+              {provider.testResult.metadata.map((item) => (
+                <Badge key={item} variant='outline'>
+                  {item}
+                </Badge>
+              ))}
+              <Badge variant='outline'>audit metadata only</Badge>
+              <Badge variant='outline'>no raw BWS output</Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/src/features/secrets-broker/providers-management-page.tsx
+++ b/src/features/secrets-broker/providers-management-page.tsx
@@ -33,6 +33,7 @@ import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
+import { BitwardenBwsProviderDetail } from './bitwarden-bws-provider-detail'
 import { LocalBootstrapProviderDetails } from './local-bootstrap-provider-details'
 import { LocalEncryptedStoreProviderDetail } from './local-encrypted-store-detail'
 import { OnePasswordCliProviderDetail } from './onepassword-cli-provider-detail'
@@ -327,6 +328,8 @@ export function ProvidersManagementPage() {
         <LocalBootstrapProviderDetails query={query} />
 
         <OnePasswordCliProviderDetail query={query} />
+
+        <BitwardenBwsProviderDetail query={query} />
 
         <Card>
           <CardHeader>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -526,7 +526,7 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getByText(/OpenClaw \/ API key/i)).toBeVisible()
     expect(screen.getByText(/Release \/ signing key/i)).toBeVisible()
     expect(screen.getAllByText(/^sign-in required$/i)[0]).toBeVisible()
-    expect(screen.getByText(/audit metadata only/i)).toBeVisible()
+    expect(screen.getAllByText(/audit metadata only/i)[0]).toBeVisible()
     expect(screen.getByText(/no raw CLI output/i)).toBeVisible()
 
     const onePasswordProvider = secretsBrokerSourceBackends.find(
@@ -565,6 +565,80 @@ describe('Secrets Broker setup wizard', () => {
     expect(screen.getByText(/Metadata-only CLI status check/i)).toBeVisible()
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
+    assertNoSecretMaterial(collectBrowserLeakSurfaces())
+  })
+
+  it('renders Bitwarden BWS provider configuration metadata safely', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/sources')
+
+    expect(
+      screen.getAllByText(/Bitwarden \/ BWS CLI provider/i)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Safe BWS configuration metadata/i)).toBeVisible()
+    expect(screen.getAllByText(/auth_required/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/add_bws_project_mappings_and_token_ref/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /project, source, token-reference, secret mapping, selector/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /secret:\/\/providers\/bitwarden\/default\/OPENCLAW_API_KEY/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/bws:\/\/project\/service-lasso\/openclaw-api-key/i)
+    ).toBeVisible()
+    expect(screen.getByText(/BWS token reference required/i)).toBeVisible()
+    expect(screen.getAllByText(/audit metadata only/i)[0]).toBeVisible()
+    expect(screen.getByText(/no raw BWS output/i)).toBeVisible()
+
+    const bitwardenProvider = secretsBrokerSourceBackends.find(
+      (source) => source.id === 'bitwarden-bws-cli'
+    )
+    expect(bitwardenProvider).toMatchObject({
+      configured: false,
+      enabled: false,
+      defaultRole: 'addable',
+      lifecycle: 'setup-needed',
+      brokerState: 'auth_required',
+      kind: 'bitwarden-bws',
+    })
+    expect(bitwardenProvider?.supportedActions).toEqual(
+      expect.arrayContaining([
+        'test-source',
+        'view-diagnostics',
+        'edit-configuration',
+        'view-examples',
+      ])
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: /Configure Bitwarden BWS/i })
+    )
+    expect(
+      screen.getByRole('dialog', { name: /Configure Bitwarden BWS/i })
+    ).toBeVisible()
+    expect(screen.getByLabelText(/Project id/i)).toHaveValue(
+      'service-lasso-platform'
+    )
+    expect(screen.getByLabelText(/Source id/i)).toHaveValue('bitwarden-bws-cli')
+    expect(screen.getByLabelText(/CLI command path/i)).toHaveValue('bws')
+    expect(screen.getByLabelText(/Token reference/i)).toHaveValue(
+      'secret://providers/bitwarden/bws-access-token'
+    )
+    expect(screen.getByLabelText(/Secret selector/i)).toHaveValue(
+      'value metadata only'
+    )
+    expect(screen.getByText(/Metadata-only BWS project/i)).toBeVisible()
+
+    expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
+    expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
+    expect(screen.queryByText(/SERVICE_LASSO_FAKE_SECRET_SENTINEL/i)).toBeNull()
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 

--- a/src/features/secrets-broker/source-backends.ts
+++ b/src/features/secrets-broker/source-backends.ts
@@ -480,6 +480,24 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     type: 'bitwarden-bws-cli',
     provider: 'bitwarden',
     source: 'addable:bitwarden-bws',
+    sourceId: 'bitwarden-bws-cli',
+    kind: 'bitwarden-bws',
+    brokerState: 'auth_required',
+    critical: false,
+    capabilities: [
+      'read',
+      'project mapping',
+      'secret selector',
+      'metadata test',
+      'auth state',
+      'audit',
+    ],
+    lifecycleDetail: {
+      state: 'auth_required',
+      outcome: 'not_configured',
+      nextAction: 'add_bws_project_mappings_and_token_ref',
+      retryable: true,
+    },
     connection: 'Add provider to configure BWS project mappings',
     configured: false,
     enabled: false,
@@ -493,20 +511,41 @@ export const secretsBrokerSourceBackends: SecretsBrokerSourceBackend[] = [
     mode: 'external cli metadata probe',
     lastCheckedAt: 'never',
     summary:
-      'Optional external BWS source placeholder for future Service Lasso refs.',
-    warnings: [],
+      'Bitwarden Secrets Manager source for managed refs with project, secret, selector, and token-handle metadata only.',
+    warnings: [
+      {
+        code: 'auth_required',
+        title: 'BWS token reference required',
+        severity: 'warning',
+        description:
+          'BWS access tokens must be supplied through a broker-managed SecretRef handle, not Service Admin input.',
+      },
+    ],
     testResult: {
       outcome: 'not-run',
       checkedAt: 'never',
-      metadata: ['not configured', 'no values requested'],
+      metadata: [
+        'auth required',
+        'project mapping pending',
+        'values not requested',
+      ],
     },
-    exampleRefs: ['bws://service-lasso/project/openclaw-api-key'],
+    exampleRefs: [
+      'secret://providers/bitwarden/default/OPENCLAW_API_KEY',
+      'bws://project/service-lasso/openclaw-api-key',
+    ],
     exampleConfig: [
-      'project=service-lasso',
-      'auth=operator-required',
+      'projectId=service-lasso-platform',
+      'tokenRef=secret://providers/bitwarden/bws-access-token',
+      'selector=value',
       'value=hidden',
     ],
-    supportedActions: ['edit-configuration', 'view-examples'],
+    supportedActions: [
+      'test-source',
+      'view-diagnostics',
+      'edit-configuration',
+      'view-examples',
+    ],
   },
   {
     id: 'mounted-secrets',


### PR DESCRIPTION
## Issue
Closes #189

## Summary
- Adds a Bitwarden / BWS CLI provider detail/configuration surface to Secrets Broker provider management.
- Expands the Bitwarden source backend fixture from a placeholder into metadata-only project/source/token-ref/secret-selector coverage.
- Adds regression coverage for not-configured/addable state, the configuration dialog, supported actions, safe mappings, and browser leak surfaces.

## Scope
- In scope: Service Admin provider management UI fixture/detail surface and tests.
- Out of scope: real BWS CLI execution, token collection, backend provider persistence, or secret-value reads.

## Spec / contract / fixture impact
- Updated: `source-backends.ts` fixture contract for `bitwarden-bws-cli` metadata.
- Not required: no runtime API/schema behavior changed; this is a Service Admin UI/provider-template slice.

## Nash invariant impact
- Invariant: Service Admin must not render raw secret values, provider credentials, tokens, private keys, raw CLI output, or response bodies.
- Preservation proof: new Bitwarden UI uses SecretRef/token-handle metadata only and tests assert browser leak surfaces are clean.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/vitest-secrets-broker-setup.log`, 37 passed.
- PASS `npx prettier --check src/features/secrets-broker/bitwarden-bws-provider-detail.tsx src/features/secrets-broker/providers-management-page.tsx src/features/secrets-broker/source-backends.ts src/features/secrets-broker/secrets-broker-setup.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/prettier-check.log`.
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/npm-build.log`.
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/npm-lint.log`; existing warning remains in `src/features/secrets-broker/secrets-management-page.tsx:391`, outside this change.

## Demo gate
- Required after merge/release because this changes the deployed Service Admin artifact. This PR has not been merged or released yet, so canonical demo is expected to still run the previous Service Admin artifact until the release/pin step.

## Approval trail
- Required: repo rules/CI status.
- Evidence: pending GitHub PR checks after push.

## Cleanup
- Branch: `serviceadmin-189-bitwarden-bws-provider`.
- Post-merge: release/pin/recycle canonical demo and verify Service Admin `http://192.168.1.53:17700/` plus runtime `http://192.168.1.53:17883/api/health`.