### PR TITLE
feat(secrets): enable policy and migration bulk campaigns

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -11,7 +11,7 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - Links to provider metadata, ref usage, and audit views where applicable.
 - Shows unavailable privileged operations as explanatory text, not controls.
 - The Secrets Broker Secrets page also exposes a bulk campaign workflow. Operators can select multiple metadata rows, choose a campaign operation, and generate safe per-ref/aggregate capability, policy, risk, audit, operation ID, idempotency, and blocker metadata.
-- Supported rotate/reset and update/edit campaigns can apply only after audit reason, explicit confirmation, and immediate revalidation. Apply results show campaign ID, operation ID, plan token, per-item operation IDs, idempotency keys, typed outcomes, audit status, retry/recovery guidance, and skipped/denied/unsupported/auth-required rows without raw values.
+- Supported rotate/reset, update/edit, policy apply/change, and provider migration/remap campaigns can apply only after audit reason, explicit confirmation, and immediate revalidation. Apply results show campaign ID, operation ID, plan token, per-item operation IDs, idempotency keys, typed outcomes, audit status, retry/recovery guidance, and skipped/denied/unsupported/auth-required rows without raw values.
 
 ## Not implemented in this slice
 
@@ -36,7 +36,7 @@ Any future raw reveal or mutation workflow must be separate from this inventory 
 - no-logging/no-export boundaries for revealed values
 - tests proving values do not leak into ordinary UI, logs, diagnostics, support bundles, or table fixtures
 
-Bulk policy and provider migration apply operations remain separate future slices. They must reuse the same dry-run, audit reason, explicit confirmation, fresh revalidation, operation ID/idempotency, partial-outcome, and redaction boundaries before they can apply.
+Bulk policy and provider migration apply operations reuse the same dry-run, audit reason, explicit confirmation, fresh revalidation, operation ID/idempotency, partial-outcome, and redaction boundaries. Their preview/apply rows stay metadata-only and fail closed on unsupported capability, missing provider configuration, auth-required, policy-denied, stale-plan, and recovery-unavailable states.
 
 ## Secret-safety boundary
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -761,7 +761,8 @@ export function SecretsManagementPage() {
             </CardTitle>
             <CardDescription>
               Selected refs become a broker campaign plan, then supported
-              rotate/reset/update campaigns can apply through operation IDs.
+              rotate/reset/update, policy, and provider migration campaigns can
+              apply through operation IDs.
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4 text-sm'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -264,6 +264,123 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
+  it('applies a bulk policy campaign through the same confirmation and revalidation gate', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.selectOptions(screen.getByLabelText(/Campaign operation/i), [
+      'apply-policy',
+    ])
+    await user.click(
+      screen.getByLabelText(
+        /Select ZITADEL_CLIENT_CREDENTIAL for bulk dry-run/i
+      )
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    )
+
+    expect(
+      screen.getByText(/supported: policy dry-run and apply available/i)
+    ).toBeVisible()
+    expect(screen.getByText(/bulk-campaign-apply/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/broker campaign API available/i)[0]
+    ).toBeVisible()
+
+    await user.type(
+      screen.getByLabelText(/Campaign audit reason/i),
+      'operator requested least privilege policy campaign'
+    )
+    await user.type(
+      screen.getByLabelText(/Explicit confirmation/i),
+      'CONFIRM HIGH RISK CAMPAIGN'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Apply bulk campaign/i })
+    )
+
+    expect(screen.getByText(/Campaign apply result: applied/i)).toBeVisible()
+    expect(screen.getAllByText(/campaign-apply-policy/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(
+        /reapply the previous policy through a fresh audited campaign/i
+      )
+    ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('plans and applies provider migration campaigns with typed partial outcomes', async () => {
+    const user = userEvent.setup()
+    await renderRoute('/secrets-broker/secrets')
+
+    await user.selectOptions(screen.getByLabelText(/Campaign operation/i), [
+      'migrate-provider',
+    ])
+    await user.click(
+      screen.getByLabelText(/Select NODE_REGISTRY_AUTH for bulk dry-run/i)
+    )
+    await user.click(
+      screen.getByLabelText(/Select PAYMENTS_SIGNING_REF for bulk dry-run/i)
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Generate bulk dry-run plan/i })
+    )
+
+    expect(
+      screen.getByText(/provider migration\/remap dry-run and apply available/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /auth required: source provider challenge before migration apply/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/unsupported: file sources migrate outside broker/i)
+    ).toBeVisible()
+    expect(screen.getByText('missing provider/source')).toBeVisible()
+    expect(
+      screen.getAllByText(/broker campaign API available/i)[0]
+    ).toBeVisible()
+
+    await user.type(
+      screen.getByLabelText(/Campaign audit reason/i),
+      'operator requested provider migration campaign'
+    )
+    await user.type(
+      screen.getByLabelText(/Explicit confirmation/i),
+      'CONFIRM HIGH RISK CAMPAIGN'
+    )
+    await user.selectOptions(
+      screen.getByLabelText(/Apply result mode/i),
+      'partial-failure'
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Revalidate dry-run/i })
+    )
+    await user.click(
+      screen.getByRole('button', { name: /Apply bulk campaign/i })
+    )
+
+    expect(
+      screen.getByText(/Campaign apply result: partial_failure/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/Applied 1/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Unsupported 1/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Auth 1/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Denied 1/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/campaign-migrate-provider/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(
+        /use source provider as rollback target where supported/i
+      )
+    ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
   it('covers retryable non-retryable and stale apply result states', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')
@@ -600,6 +717,47 @@ describe('Secrets Broker secrets management page', () => {
     expect(applyResult.authRequiredCount).toBe(1)
     expect(applyResult.skippedCount).toBe(0)
     expect(managedSecretBulkApplyResultHasSecretMaterial(applyResult)).toBe(
+      false
+    )
+
+    const policyPlan = buildBulkSecretCampaignPlan(
+      managedSecretRows,
+      managedSecretRows.map((row) => row.id),
+      'apply-policy'
+    )
+    expect(policyPlan.applyAvailable).toBe(true)
+    expect(policyPlan.applicableCount).toBe(1)
+    expect(policyPlan.unsupportedCount).toBe(2)
+    expect(policyPlan.deniedCount).toBe(1)
+    expect(policyPlan.planToken).toMatch(/apply_policy/)
+    expect(policyPlan.items[0].targetPolicy).toMatch(/bulk-campaign-apply/)
+    expect(managedSecretBulkPlanHasSecretMaterial(policyPlan)).toBe(false)
+
+    const migrationPlan = buildBulkSecretCampaignPlan(
+      managedSecretRows,
+      managedSecretRows.map((row) => row.id),
+      'migrate-provider'
+    )
+    expect(migrationPlan.applyAvailable).toBe(true)
+    expect(migrationPlan.applicableCount).toBe(1)
+    expect(migrationPlan.unsupportedCount).toBe(1)
+    expect(migrationPlan.authRequiredCount).toBe(1)
+    expect(migrationPlan.missingProviderCount).toBe(1)
+    expect(migrationPlan.deniedCount).toBe(1)
+    expect(migrationPlan.items[0].targetProvider).toBe('vault-prod')
+    expect(migrationPlan.items[1].targetProvider).toBe('local-default')
+    expect(managedSecretBulkPlanHasSecretMaterial(migrationPlan)).toBe(false)
+
+    const migrationResult = buildBulkSecretCampaignApplyResult(
+      migrationPlan,
+      'partial-failure'
+    )
+    expect(migrationResult.outcome).toBe('partial_failure')
+    expect(migrationResult.appliedCount).toBe(1)
+    expect(migrationResult.unsupportedCount).toBe(1)
+    expect(migrationResult.authRequiredCount).toBe(1)
+    expect(migrationResult.deniedCount).toBe(1)
+    expect(managedSecretBulkApplyResultHasSecretMaterial(migrationResult)).toBe(
       false
     )
   })

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -285,7 +285,7 @@ export const bulkSecretCampaignOperations: Array<{
 }> = [
   { id: 'rotate-reset', label: 'Rotate/reset selected refs' },
   { id: 'update-edit', label: 'Update/edit selected refs' },
-  { id: 'apply-policy', label: 'Apply policy preview' },
+  { id: 'apply-policy', label: 'Apply/change policy' },
   { id: 'migrate-provider', label: 'Migrate/remap provider' },
   { id: 'mark-action-required', label: 'Mark action required' },
 ]
@@ -395,7 +395,30 @@ function buildIdempotencyKey(
 }
 
 function bulkCampaignOperationCanApply(operation: BulkSecretCampaignOperation) {
-  return operation === 'rotate-reset' || operation === 'update-edit'
+  return (
+    operation === 'rotate-reset' ||
+    operation === 'update-edit' ||
+    operation === 'apply-policy' ||
+    operation === 'migrate-provider'
+  )
+}
+
+function bulkCampaignOperationIsHighRisk(
+  operation: BulkSecretCampaignOperation
+) {
+  return operation !== 'mark-action-required'
+}
+
+function bulkPolicyTargetForRow(row: ManagedSecretRow) {
+  return row.owningService === 'payments-api'
+    ? 'policy/openclaw/service-lasso/payments-campaign-review'
+    : 'policy/openclaw/service-lasso/bulk-campaign-apply'
+}
+
+function bulkMigrationTargetForRow(row: ManagedSecretRow) {
+  if (row.source === 'local-default') return 'vault-prod'
+  if (row.provider === 'provider connection') return 'local-default'
+  return 'vault-prod'
 }
 
 export function filterManagedSecrets(
@@ -612,18 +635,40 @@ export function buildBulkSecretCampaignPlan(
     let policyResult = 'allow preview'
     let risk: BulkSecretCampaignItem['risk'] = 'medium'
     let expectedAction = 'Generate campaign dry-run metadata; do not apply.'
+    let recovery = 'retry with the same idempotency key or restore from backup'
+    let targetProvider = row.source
+    let targetPolicy = row.policy
 
     if (operation === 'mark-action-required') {
       risk = 'low'
       expectedAction = 'Mark ref for follow-up only; no provider mutation.'
+      recovery = 'clear the action marker after provider/operator follow-up'
     }
 
-    if (
-      operation === 'rotate-reset' ||
-      operation === 'update-edit' ||
-      operation === 'migrate-provider'
-    ) {
+    if (bulkCampaignOperationIsHighRisk(operation)) {
       risk = 'high'
+    }
+
+    if (operation === 'apply-policy') {
+      targetPolicy = bulkPolicyTargetForRow(row)
+      capabilityResult = 'supported: policy dry-run and apply available'
+      policyResult = 'allow: target policy can be applied after revalidation'
+      expectedAction =
+        'Apply the target policy through broker policy-change operation ID.'
+      recovery =
+        'reapply the previous policy through a fresh audited campaign if rollback is required'
+    }
+
+    if (operation === 'migrate-provider') {
+      targetProvider = bulkMigrationTargetForRow(row)
+      capabilityResult =
+        'supported: provider migration/remap dry-run and apply available'
+      policyResult =
+        'allow: source and target provider namespaces are policy approved'
+      expectedAction =
+        'Move or remap the ref through broker migration operation ID.'
+      recovery =
+        'retry by operation ID; use source provider as rollback target where supported'
     }
 
     if (row.policy.includes('readonly')) {
@@ -650,12 +695,27 @@ export function buildBulkSecretCampaignPlan(
       blockers.push('unsupported capability')
       expectedAction = 'Skip this ref or choose a reset/policy preview.'
     } else if (
+      operation === 'apply-policy' &&
+      !row.backendCapability.includes('policy preview')
+    ) {
+      capabilityResult = 'unsupported: policy apply capability unavailable'
+      blockers.push('unsupported capability')
+      expectedAction = 'Skip this ref until policy apply is broker-supported.'
+    } else if (
       operation === 'migrate-provider' &&
       row.provider === 'file source'
     ) {
       capabilityResult = 'unsupported: file sources migrate outside broker'
       blockers.push('unsupported capability')
       expectedAction = 'Document external provider action only.'
+    } else if (
+      operation === 'migrate-provider' &&
+      row.safeTags.includes('provider')
+    ) {
+      capabilityResult =
+        'auth required: source provider challenge before migration apply'
+      blockers.push('provider auth required')
+      expectedAction = 'Reconnect provider auth, then create a fresh plan.'
     } else if (
       operation === 'rotate-reset' &&
       row.safeTags.includes('provider')
@@ -671,14 +731,8 @@ export function buildBulkSecretCampaignPlan(
       name: row.name,
       owningService: row.owningService,
       sourceProvider: `${row.provider} / ${row.source}`,
-      targetProvider:
-        operation === 'migrate-provider'
-          ? '@secretsbroker/local/default'
-          : row.source,
-      targetPolicy:
-        operation === 'apply-policy'
-          ? 'policy/openclaw/service-lasso/bulk-campaign-preview'
-          : row.policy,
+      targetProvider,
+      targetPolicy,
       capabilityResult,
       policyResult,
       risk,
@@ -693,7 +747,7 @@ export function buildBulkSecretCampaignPlan(
       retrySafe: blockers.length === 0,
       recovery:
         blockers.length === 0
-          ? 'retry with the same idempotency key or restore from backup'
+          ? recovery
           : 'fix blocker, create a fresh plan, then retry',
     }
   })


### PR DESCRIPTION
## Issue
Closes #173

## Summary
- Enable `apply-policy` and `migrate-provider` as broker-backed bulk campaign apply families.
- Add metadata-only target policy/provider planning, high-risk confirmation, provider auth/config/capability blockers, retry/recovery guidance, and typed partial outcomes for policy and migration campaigns.
- Update secret inventory docs to reflect the delivered policy/migration campaign boundary.

## Scope
- In scope: Service Admin Secrets Broker bulk campaign planner/apply UI model, page copy, focused tests, and documentation.
- Out of scope: raw value reveal/export, provider credential entry, backend enforcement changes, and campaign history browsing.

## Spec / contract / fixture impact
- Updated: `docs/secret-inventory.md` to state policy apply/change and provider migration/remap reuse the existing dry-run, audit, confirmation, revalidation, operation ID/idempotency, typed outcome, and redaction boundaries.
- Backend contract change not required because this consumes the already delivered metadata-only bulk campaign API from `lasso-secretsbroker#97`.

## Nash invariant impact
- Invariant: raw secrets and provider credentials must not render, route, log, export, screenshot, or persist from this surface.
- Preservation proof: implementation only adds safe policy/provider IDs, campaign IDs, operation IDs, idempotency keys, typed blockers/outcomes, audit status, and recovery text. Focused tests assert plans/results contain no secret material and UI flows do not render `DEMO_REVEAL_VALUE_42`.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-management.test.tsx` — 15 tests passed; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\serviceadmin-secrets-management-vitest-after-format.log`
- PASS `npx prettier --check src/features/secrets-broker/secrets-management.ts src/features/secrets-broker/secrets-management-page.tsx src/features/secrets-broker/secrets-management.test.tsx docs/secret-inventory.md` — log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\serviceadmin-prettier-check-after-format.log`
- PASS `npm run lint` — no errors; one existing React hook dependency warning in `secrets-management-page.tsx`; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\serviceadmin-lint.log`
- PASS `npm run build` — Vite completed with existing warnings about deprecated `esbuild` option and large chunks; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\serviceadmin-build.log`
- PASS canonical preflight before selection: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`; log `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620T1719\canonical-health-preflight.json`

## Approval trail
- Required: no explicit human approval requirement found before opening this PR.
- Evidence: Project #1 selected this issue from `Status: Ready` / `Agent lane: Ready for Agent`; start note is on issue #173.

## Cleanup
- Branch: `sl-173-policy-migration-campaigns`
- Commit: `3b66609`
- Release-to-demo gate: pending. This changes demo-consumed Service Admin code; after merge/release, core must pin the new `@serviceadmin` release, canonical demo must recycle on port `17883`, and `npm run demo:verify-canonical` plus LAN checks must pass before final done.