### PR TITLE
fix(secretsbroker): simplify Overview dashboard

### DIFF
--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -102,7 +102,7 @@ export const sidebarData: SidebarData = {
       title: 'Secrets Broker',
       items: [
         {
-          title: 'Overview / Setup',
+          title: 'Overview',
           url: '/secrets-broker',
           icon: ShieldCheck,
         },

--- a/src/features/secrets-broker/connection-detail.tsx
+++ b/src/features/secrets-broker/connection-detail.tsx
@@ -145,7 +145,7 @@ function ConnectionDetailMissing({ connectionId }: { connectionId: string }) {
           </CardHeader>
           <CardContent>
             <Button asChild variant='secondary'>
-              <Link to='/secrets-broker'>Back to Secrets Broker setup</Link>
+              <Link to='/secrets-broker'>Back to Secrets Broker overview</Link>
             </Button>
           </CardContent>
         </Card>

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -157,9 +157,10 @@ const secretsBrokerSectionMetadata: Record<
   { title: string; heading: string; description: string }
 > = {
   overview: {
-    title: 'Service Admin - Secrets Broker Setup',
-    heading: 'Secrets Broker setup',
-    description: 'Configure sources, policies, and recovery safely.',
+    title: 'Service Admin - Secrets Broker Overview',
+    heading: 'Overview',
+    description:
+      'Monitor Secrets Broker health, sources, policy, audit, and operator action state.',
   },
   'operational-controls': {
     title: 'Service Admin - Secrets Broker Operational Controls',
@@ -399,25 +400,6 @@ const brokerOverviewScenarios: SecretsBrokerOverviewScenario[] = [
       'Add a local encrypted store or connect an external source to activate @secretsbroker.',
   },
 ]
-
-const statusCopy: Record<WizardSource['status'], string> = {
-  ready: 'Ready',
-  locked: 'Locked',
-  'auth-required': 'Auth required',
-  degraded: 'Degraded',
-  'policy-denied': 'Policy denied',
-}
-
-const statusVariant: Record<
-  WizardSource['status'],
-  'default' | 'secondary' | 'destructive' | 'outline'
-> = {
-  ready: 'default',
-  locked: 'secondary',
-  'auth-required': 'secondary',
-  degraded: 'outline',
-  'policy-denied': 'destructive',
-}
 
 const brokerOverviewStateCopy: Record<SecretsBrokerOverviewState, string> = {
   healthy: 'Healthy',
@@ -865,55 +847,6 @@ function BackupKeyManagementPanel() {
         </div>
       </CardContent>
     </Card>
-  )
-}
-
-function SourceIcon({ source }: { source: WizardSource }) {
-  if (source.id === 'local-vault') return <LockKeyhole className='size-4' />
-  if (source.id === 'file-source') return <FileKey2 className='size-4' />
-  if (source.id === 'exec-adapter') return <TerminalSquare className='size-4' />
-  if (source.id === 'generated-writeback') {
-    return <ClipboardCheck className='size-4' />
-  }
-  return <KeyRound className='size-4' />
-}
-
-function SourceCard({
-  source,
-  selected,
-  onSelect,
-}: {
-  source: WizardSource
-  selected: boolean
-  onSelect: () => void
-}) {
-  return (
-    <button
-      type='button'
-      onClick={onSelect}
-      className={`rounded-lg border p-4 text-left transition hover:border-primary ${
-        selected ? 'border-primary bg-muted/60' : 'bg-card'
-      }`}
-    >
-      <div className='mb-3 flex items-start justify-between gap-3'>
-        <div className='flex items-center gap-2 font-medium'>
-          <SourceIcon source={source} />
-          {source.title}
-        </div>
-        <Badge variant={statusVariant[source.status]}>
-          {statusCopy[source.status]}
-        </Badge>
-      </div>
-      <p className='text-sm text-muted-foreground'>{source.summary}</p>
-    </button>
-  )
-}
-
-function SafeExample({ value }: { value: string }) {
-  return (
-    <div className='rounded-md border bg-muted/40 p-3 font-mono text-sm break-all'>
-      {value}
-    </div>
   )
 }
 
@@ -2058,7 +1991,6 @@ export function SecretsBrokerSetupWizard({
     description: pageMetadata.description,
   })
 
-  const [selectedId, setSelectedId] = useState(wizardSources[0].id)
   const [auditTypeFilter, setAuditTypeFilter] = useState<
     SecretsBrokerAuditEventType | 'all'
   >('all')
@@ -2096,12 +2028,6 @@ export function SecretsBrokerSetupWizard({
     brokerOverviewScenarios.find(
       (scenario) => scenario.id === overviewScenarioId
     ) ?? brokerOverviewScenarios[0]
-  const selectedSource = useMemo(
-    () =>
-      wizardSources.find((source) => source.id === selectedId) ??
-      wizardSources[0],
-    [selectedId]
-  )
   const readyCount = wizardSources.filter(
     (source) => source.status === 'ready'
   ).length
@@ -3486,135 +3412,6 @@ export function SecretsBrokerSetupWizard({
               </div>
             </CardContent>
           </Card>
-        ) : null}
-
-        {focusSection === 'overview' ? (
-          <>
-            <div className='grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,0.9fr)]'>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Source setup paths</CardTitle>
-                  <CardDescription>
-                    Pick a source type to preview the safe setup contract and
-                    current stubbed state.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className='grid gap-3'>
-                  {wizardSources.map((source) => (
-                    <SourceCard
-                      key={source.id}
-                      source={source}
-                      selected={source.id === selectedSource.id}
-                      onSelect={() => setSelectedId(source.id)}
-                    />
-                  ))}
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <div className='flex items-start justify-between gap-3'>
-                    <div>
-                      <CardTitle className='flex items-center gap-2'>
-                        <SourceIcon source={selectedSource} />
-                        {selectedSource.title}
-                      </CardTitle>
-                      <CardDescription>{selectedSource.kind}</CardDescription>
-                    </div>
-                    <Badge variant={statusVariant[selectedSource.status]}>
-                      {statusCopy[selectedSource.status]}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className='space-y-5'>
-                  <section className='space-y-2'>
-                    <h3 className='font-medium'>Safe example</h3>
-                    <SafeExample value={selectedSource.safeExample} />
-                    <p className='text-sm text-muted-foreground'>
-                      Examples intentionally use SecretRef-style identifiers and
-                      hidden generated values only.
-                    </p>
-                  </section>
-
-                  <section className='space-y-2'>
-                    <h3 className='font-medium'>Affected refs and services</h3>
-                    <div className='flex flex-wrap gap-2'>
-                      {selectedSource.affected.map((item) => (
-                        <Badge key={item} variant='outline'>
-                          {item}
-                        </Badge>
-                      ))}
-                    </div>
-                  </section>
-
-                  {selectedSource.warning ? (
-                    <div className='flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100'>
-                      <AlertTriangle className='mt-0.5 size-4 shrink-0' />
-                      <span>{selectedSource.warning}</span>
-                    </div>
-                  ) : null}
-
-                  <section className='space-y-2'>
-                    <h3 className='font-medium'>Next safe action</h3>
-                    <p className='text-sm text-muted-foreground'>
-                      {selectedSource.nextAction}
-                    </p>
-                  </section>
-
-                  <div className='rounded-lg border p-3 text-sm'>
-                    <div className='mb-2 flex items-center gap-2 font-medium'>
-                      <ShieldCheck className='size-4' /> Security gates
-                    </div>
-                    <ul className='list-disc space-y-1 pl-5 text-muted-foreground'>
-                      <li>
-                        Require preview before destructive or broad changes.
-                      </li>
-                      <li>
-                        Require explicit confirmation and an audit reason before
-                        save/write.
-                      </li>
-                      <li>
-                        Show policy decisions and audit links without values.
-                      </li>
-                    </ul>
-                  </div>
-
-                  <div className='flex flex-wrap gap-2'>
-                    <Button type='button'>Test selected source</Button>
-                    <Button type='button' variant='outline'>
-                      Cancel setup
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className='flex items-center gap-2'>
-                  <CheckCircle2 className='size-4' /> Covered setup states
-                </CardTitle>
-                <CardDescription>
-                  This first slice makes the states visible before wiring live
-                  Secrets Broker APIs.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className='grid gap-3 text-sm md:grid-cols-2 lg:grid-cols-3'>
-                <div>
-                  Blank install: choose local/file/exec/external source.
-                </div>
-                <div>Existing vault on new machine: import or re-wrap.</div>
-                <div>External auth required: show affected refs first.</div>
-                <div>
-                  Service dependency blocked: explain source/policy reason.
-                </div>
-                <div>OpenClaw exec adapter: namespace and last check only.</div>
-                <div>
-                  Generated secret write-back: policy and audit, value hidden.
-                </div>
-              </CardContent>
-            </Card>
-          </>
         ) : null}
       </Main>
     </>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -4,7 +4,7 @@ import {
   collectBrowserLeakSurfaces,
   serviceLassoSecretLeakSentinels,
 } from '@/test/secret-leak-harness'
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
@@ -111,19 +111,17 @@ const topologyTestServices = [
   },
 ] as DashboardService[]
 
-describe('Secrets Broker setup wizard', () => {
-  it('shows the safe setup contract without plaintext values', async () => {
+describe('Secrets Broker overview dashboard', () => {
+  it('shows the operator overview without setup-wall or plaintext values', async () => {
     await renderRoute('/secrets-broker')
 
     expect(
-      await screen.findByRole('heading', { name: /Secrets Broker setup/i })
+      await screen.findByRole('heading', { name: /^Overview$/i })
     ).toBeVisible()
     expect(screen.getAllByText(/Values hidden/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Local encrypted vault/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/OpenClaw exec adapter/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
-    expect(screen.getByText(/SecretRef:/i)).toBeVisible()
-    expect(screen.getAllByText(/value hidden/i)[0]).toBeVisible()
+    expect(screen.getByText(/Broker API is reachable/i)).toBeVisible()
+    expect(screen.getByText(/Ready providers/i)).toBeVisible()
+    expect(screen.getByText(/Needs operator action/i)).toBeVisible()
     expect(
       screen.getByRole('link', { name: /View audit\/events/i })
     ).toHaveAttribute('href', '/secrets-broker/audit-events')
@@ -133,6 +131,8 @@ describe('Secrets Broker setup wizard', () => {
     expect(
       screen.queryByRole('heading', { name: /Secret Sources \/ Backends/i })
     ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Source setup paths/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cancel setup/i)).not.toBeInTheDocument()
     expect(
       screen.queryByRole('heading', {
         name: /Privileged single-secret reveal/i,
@@ -274,41 +274,33 @@ describe('Secrets Broker setup wizard', () => {
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   }, 30000)
 
-  it('covers locked, auth-required, degraded, policy-denied, cancel, and ready states', async () => {
-    const user = userEvent.setup()
+  it('keeps overview action-oriented and provider setup detail on the providers page', async () => {
     await renderRoute('/secrets-broker')
 
-    expect(screen.getAllByText(/Locked/i)[0]).toBeVisible()
-    expect(screen.getByText(/import portable master key/i)).toBeVisible()
-
-    await user.click(screen.getByRole('button', { name: /File source/i }))
-    expect(screen.getAllByText(/Degraded/i)[0]).toBeVisible()
-    expect(screen.getByText(/Risky broad paths are rejected/i)).toBeVisible()
-
-    await user.click(
-      screen.getByRole('button', { name: /OpenClaw exec adapter/i })
-    )
-    expect(screen.getAllByText(/Policy denied/i)[0]).toBeVisible()
-    expect(screen.getByText(/namespace allowlist/i)).toBeVisible()
-
-    await user.click(
-      screen.getByRole('button', { name: /External source auth/i })
-    )
-    expect(screen.getAllByText(/Auth required/i)[0]).toBeVisible()
+    expect(screen.getByRole('heading', { name: /^Overview$/i })).toBeVisible()
+    expect(screen.getByText(/Reconnect required/i)).toBeVisible()
+    expect(screen.getByText(/Recent denied requests/i)).toBeVisible()
     expect(
-      screen.getAllByText(/Authenticate the external source/i)[0]
-    ).toBeVisible()
-    expect(screen.getByText(/payments-api:STRIPE_KEY/i)).toBeVisible()
+      screen.queryByText(/Affected refs and services/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cancel setup/i)).not.toBeInTheDocument()
 
-    await user.click(
-      screen.getByRole('button', { name: /Generated secret write-back/i })
-    )
-    expect(screen.getAllByText(/Generated secret write-back/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Ready/i)[0]).toBeVisible()
+    await renderRoute('/secrets-broker/sources')
+
     expect(
-      screen.getByText(/Confirm operation, policy decision, and audit reason/i)
+      screen.getByRole('heading', { name: /Secrets Broker providers/i })
     ).toBeVisible()
-    expect(screen.getByRole('button', { name: /Cancel setup/i })).toBeVisible()
+    expect(screen.getByText(/Credentials as refs only/i)).toBeVisible()
+    expect(screen.getAllByText(/Local encrypted store/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/setup_needed/i)[0]).toBeVisible()
+    expect(screen.getByText(/Authentication required/i)).toBeVisible()
+    expect(
+      screen.getByText(/HashiCorp Vault \/ OpenBao provider/i)
+    ).toBeVisible()
+    expect(screen.getByText(/tokens hidden/i)).toBeVisible()
+    expect(
+      screen.queryByText(/correct-horse-battery-staple/i)
+    ).not.toBeInTheDocument()
   }, 30000)
 
   it('keeps single-secret reveal safe surfaces free of raw material', () => {
@@ -1449,27 +1441,18 @@ describe('Secrets Broker setup wizard', () => {
     ).toBe(true)
   })
 
-  it('shows affected refs before unlock or auth prompts', async () => {
-    const user = userEvent.setup()
-    await renderRoute('/secrets-broker')
+  it('shows provider refs and warnings on the dedicated providers page', async () => {
+    await renderRoute('/secrets-broker/sources')
 
-    const affectedSection = screen.getByText(
-      /Affected refs and services/i
-    ).parentElement
-    expect(affectedSection).toBeTruthy()
     expect(
-      within(affectedSection!).getByText(/echo-service:DB_PASSWORD/i)
+      screen.getByText(/secret:\/\/providers\/vault\/payments\/STRIPE_KEY/i)
     ).toBeVisible()
-
-    await user.click(
-      screen.getByRole('button', { name: /External source auth/i })
-    )
-    const updatedSection = screen.getByText(
-      /Affected refs and services/i
-    ).parentElement
-    expect(updatedSection).toBeTruthy()
     expect(
-      within(updatedSection!).getByText(/backup-worker:AWS_SECRET_ACCESS_KEY/i)
+      screen.getByText(/secret:\/\/providers\/aws\/default\/backup-worker/i)
     ).toBeVisible()
+    expect(screen.getByText(/Sealed, locked, auth_required/i)).toBeVisible()
+    expect(
+      screen.queryByText(/fixture-provider-credential-value/i)
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/features/secrets-broker/single-secret-reveal.ts
+++ b/src/features/secrets-broker/single-secret-reveal.ts
@@ -153,7 +153,7 @@ export const singleSecretRevealScenarios: SingleSecretRevealScenario[] = [
 
 export const singleSecretRevealSafeSurfaces = {
   route: '/secrets-broker/single-reveal',
-  pageTitle: 'Secrets Broker setup',
+  pageTitle: 'Secrets Broker overview',
   breadcrumb: 'Secrets Broker / privileged single-secret reveal',
   diagnostics:
     'reveal_status=redacted; selected_ref=metadata_only; raw_value=hidden',

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -60,8 +60,8 @@ const appScreens: ScreenCase[] = [
   },
   {
     path: '/secrets-broker',
-    heading: /^Secrets Broker setup$/i,
-    title: 'Service Admin - Secrets Broker Setup',
+    heading: /^Overview$/i,
+    title: 'Service Admin - Secrets Broker Overview',
   },
   {
     path: '/secrets-broker/sources',

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -69,12 +69,12 @@ test.describe('Secrets Broker browser coverage', () => {
     page,
   }) => {
     await page.goto('/')
-    await page.getByRole('link', { name: 'Overview / Setup' }).click()
+    await page.getByRole('link', { name: 'Overview' }).click()
 
     await expect(page).toHaveURL(/\/secrets-broker$/)
     await expectNoBlankScreen(page)
     await expect(
-      page.getByRole('heading', { name: /Secrets Broker setup/i })
+      page.getByRole('heading', { name: /^Overview$/i })
     ).toBeVisible()
     await expect(page.getByText(/@secretsbroker overview/i)).toBeVisible()
     await expect(
@@ -98,7 +98,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await page.goto('/')
 
     const navLinks = [
-      ['Overview / Setup', /\/secrets-broker$/],
+      ['Overview', /\/secrets-broker$/],
       ['Secrets', /\/secrets-broker\/secrets$/],
       ['Operational Controls', /\/secrets-broker\/operational-controls$/],
       ['Providers', /\/secrets-broker\/sources$/],


### PR DESCRIPTION
## Issue
Closes #230

## Summary
- Rename the Secrets Broker sidebar entry and `/secrets-broker` page from setup wording to `Overview`.
- Keep the first viewport as the compact operator dashboard and remove the embedded setup/source picker from the overview route.
- Move tests toward the split model: Overview stays action/status oriented; provider/source setup details live on `Secrets Broker > Providers`.

## Scope
- In scope: visible nav/page metadata, overview route rendering, stale setup wording regression tests, focused browser coverage.
- Out of scope: changing backend contracts, mutation/reveal behavior, bulk secrets workflows, or provider configuration semantics.

## Spec / contract / fixture impact
- Not required because this is a Service Admin UI presentation/navigation cleanup and does not change API contracts or data schemas.

## Nash invariant impact
- Invariant: no raw secrets, credentials, provider tokens, private keys, recovery material, or raw env values are rendered/logged.
- Preservation proof: updated tests continue to assert no known secret material appears on the overview/providers surfaces.

## Validation
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-232514\serviceadmin-build-2.log`
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx src/test/app-screens.test.tsx` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-232514\serviceadmin-vitest-focused-final.log`
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts -g "loads the broker entry route|dedicated Secrets Broker navigation"` — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-232514\serviceadmin-playwright-secrets-overview.log`
- PASS `npm run lint` with one existing warning in `src/features/secrets-broker/secrets-management-page.tsx` unrelated to this change — `C:\projects\service-lasso\.work-agent\logs\cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260620-232514\serviceadmin-lint.log`

## Approval trail
- Required: no explicit human approval identified for this UI cleanup PR before review.
- Evidence: issue is Project #1 Ready / Agent lane Ready for Agent; start comment posted on #230.

## Cleanup
- Branch: `agent/issue-230-secrets-overview-dashboard`
- Commit: `094d780`
- Post-merge: recycle/pin canonical demo for Service Admin and verify LAN endpoints/UI before issue closure.