### PR TITLE
feat(secrets): add single-secret operation plan contract

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   type ColumnDef,
   type ColumnFiltersState,
@@ -60,6 +60,7 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionPreview,
+  buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
   bulkSecretCampaignApplyModes,
   bulkSecretCampaignOperations,
@@ -165,6 +166,13 @@ export function SecretsManagementPage() {
     auditReason,
     confirmed
   )
+  const singleOperationPlan = buildSingleSecretOperationPlan(
+    selectedRow,
+    selectedAction,
+    auditReason,
+    confirmed,
+    stubState
+  )
   const bulkPlan = useMemo(
     () =>
       buildBulkSecretCampaignPlan(
@@ -183,29 +191,35 @@ export function SecretsManagementPage() {
     bulkPlan.applyAvailable
   )
 
-  function resetBulkApplyGate() {
+  const resetBulkApplyGate = useCallback(() => {
     setBulkRevalidated(false)
     setBulkApplyResult(null)
-  }
+  }, [])
 
   function resetBulkApplyResult() {
     setBulkApplyResult(null)
   }
 
-  function chooseAction(rowId: string, action: ManagedSecretAction) {
-    setSelectedRowId(rowId)
-    setSelectedAction(action)
-  }
+  const chooseAction = useCallback(
+    (rowId: string, action: ManagedSecretAction) => {
+      setSelectedRowId(rowId)
+      setSelectedAction(action)
+    },
+    []
+  )
 
-  function toggleBulkSelection(rowId: string, checked: boolean) {
-    setBulkPlanGenerated(false)
-    resetBulkApplyGate()
-    setBulkSelectedIds((current) =>
-      checked
-        ? [...new Set([...current, rowId])]
-        : current.filter((id) => id !== rowId)
-    )
-  }
+  const toggleBulkSelection = useCallback(
+    (rowId: string, checked: boolean) => {
+      setBulkPlanGenerated(false)
+      resetBulkApplyGate()
+      setBulkSelectedIds((current) =>
+        checked
+          ? [...new Set([...current, rowId])]
+          : current.filter((id) => id !== rowId)
+      )
+    },
+    [resetBulkApplyGate]
+  )
 
   function setOperation(operation: BulkSecretCampaignOperation) {
     setBulkPlanGenerated(false)
@@ -388,7 +402,7 @@ export function SecretsManagementPage() {
         enableSorting: false,
       },
     ],
-    [bulkSelectedIds]
+    [bulkSelectedIds, chooseAction, toggleBulkSelection]
   )
 
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -1321,6 +1335,48 @@ export function SecretsManagementPage() {
                 Next step
               </div>
               <div>{actionPreview.nextStep}</div>
+            </div>
+            <div className='grid gap-3 rounded-md border p-3 md:grid-cols-3'>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Broker operation contract
+                </div>
+                <div className='mt-1 font-medium break-all'>
+                  {singleOperationPlan.operationId}
+                </div>
+                <div className='mt-1 text-muted-foreground'>
+                  {singleOperationPlan.endpoint}
+                </div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Dry-run and policy
+                </div>
+                <div className='mt-1'>{singleOperationPlan.dryRunStatus}</div>
+                <div className='mt-1 text-muted-foreground'>
+                  {singleOperationPlan.policyDecision}
+                </div>
+              </div>
+              <div>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Submit gate
+                </div>
+                <Badge
+                  className='mt-1'
+                  variant={
+                    singleOperationPlan.canSubmit ? 'default' : 'secondary'
+                  }
+                >
+                  {singleOperationPlan.applyGate}
+                </Badge>
+                <div className='mt-2 flex flex-wrap gap-1'>
+                  {singleOperationPlan.safePayloadFields.map((field) => (
+                    <Badge key={field} variant='outline'>
+                      {field}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
             </div>
             <div className='flex flex-wrap gap-2'>
               <Button type='button' disabled>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -6,6 +6,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretBulkApplyResultHasSecretMaterial,
@@ -58,6 +59,11 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Reset\/rotate dry-run/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Delete dry-run/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Apply policy preview/i)[0]).toBeVisible()
+    expect(screen.getByText(/Broker operation contract/i)).toBeVisible()
+    expect(screen.getByText(/single-metadata/i)).toBeVisible()
+    expect(
+      screen.getByText(/GET \/v1\/management\/secrets\/\{ref\}\/metadata/i)
+    ).toBeVisible()
     expect(screen.getAllByText(/Raw values hidden/i)[0]).toBeVisible()
     expect(screen.getByText(/No bulk mutation/i)).toBeVisible()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
@@ -515,7 +521,9 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/Edit\/update dry-run for SESSION_SIGNING_KEY/i)
     ).toBeVisible()
-    expect(screen.getByText(/dry-run required before apply/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/dry-run required before apply/i)[0]
+    ).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Reset\/rotate dry-run/i })[0]
@@ -526,6 +534,12 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/rotation preview required before apply/i)
     ).toBeVisible()
+    expect(
+      screen.getByText(
+        /POST \/v1\/management\/secrets\/\{ref\}\/rotate:dry-run/i
+      )
+    ).toBeVisible()
+    expect(screen.getByText(/reset dry-run capability checked/i)).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Delete dry-run/i })[0]
@@ -650,6 +664,35 @@ describe('Secrets Broker secrets management page', () => {
         true
       ).canApply
     ).toBe(false)
+
+    const rotatePlan = buildSingleSecretOperationPlan(
+      managedSecretRows[0],
+      'reset',
+      'operator requested rotation preview',
+      true,
+      'ready'
+    )
+    expect(rotatePlan).toMatchObject({
+      endpoint: 'POST /v1/management/secrets/{ref}/rotate:dry-run',
+      capabilityDecision: 'supported: reset dry-run',
+      applyGate: 'operation submit ready after dry-run revalidation',
+      canSubmit: true,
+    })
+    expect(rotatePlan.safePayloadFields).toEqual(
+      expect.arrayContaining(['ref', 'operationId', 'auditReasonMetadata'])
+    )
+
+    const missingDeletePlan = buildSingleSecretOperationPlan(
+      managedSecretRows[3],
+      'delete',
+      'operator requested delete preview',
+      true,
+      'ready'
+    )
+    expect(missingDeletePlan.canSubmit).toBe(false)
+    expect(missingDeletePlan.blockers).toContain('ref unavailable')
+    expect(missingDeletePlan.blockers).toContain('delete dry-run unsupported')
+
     const bulkPlan = buildBulkSecretCampaignPlan(
       managedSecretRows,
       managedSecretRows.map((row) => row.id),

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -40,6 +40,20 @@ export type ManagedSecretActionPreview = {
   requiresConfirmation: boolean
 }
 
+export type SingleSecretOperationPlan = {
+  action: ManagedSecretAction
+  operationId: string
+  endpoint: string
+  dryRunStatus: string
+  capabilityDecision: string
+  policyDecision: string
+  auditRequirement: string
+  applyGate: string
+  blockers: string[]
+  safePayloadFields: string[]
+  canSubmit: boolean
+}
+
 export type StubSecretMutationState =
   | 'ready'
   | 'denied'
@@ -1095,6 +1109,133 @@ export function buildManagedSecretActionPreview(
           'Choose a controlled row action when an operator task is needed.',
         requiresConfirmation: false,
       }
+  }
+}
+
+function capabilityRequirementForAction(action: ManagedSecretAction) {
+  switch (action) {
+    case 'edit':
+      return 'edit dry-run'
+    case 'reset':
+      return 'reset dry-run'
+    case 'delete':
+      return 'delete dry-run'
+    case 'policy':
+      return 'policy preview'
+    case 'reveal':
+      return 'reveal'
+    case 'metadata':
+    default:
+      return 'metadata'
+  }
+}
+
+function endpointForSingleSecretAction(action: ManagedSecretAction) {
+  switch (action) {
+    case 'reveal':
+      return 'POST /v1/management/secrets/{ref}/reveal:preview'
+    case 'edit':
+      return 'POST /v1/management/secrets/{ref}/update:dry-run'
+    case 'reset':
+      return 'POST /v1/management/secrets/{ref}/rotate:dry-run'
+    case 'delete':
+      return 'POST /v1/management/secrets/{ref}/delete:dry-run'
+    case 'policy':
+      return 'POST /v1/management/secrets/{ref}/policy:preview'
+    case 'metadata':
+    default:
+      return 'GET /v1/management/secrets/{ref}/metadata'
+  }
+}
+
+function safeOperationSlug(action: ManagedSecretAction, row: ManagedSecretRow) {
+  return `${action}-${row.id}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function buildSingleSecretOperationPlan(
+  row: ManagedSecretRow,
+  action: ManagedSecretAction,
+  auditReason: string,
+  confirmed: boolean,
+  state: StubSecretMutationState
+): SingleSecretOperationPlan {
+  const requirement = capabilityRequirementForAction(action)
+  const blockers: string[] = []
+  const hasAuditReason = auditReason.trim().length >= 8
+  const metadataOnly = action === 'metadata'
+  const capabilitySupported =
+    metadataOnly || row.backendCapability.includes(requirement)
+
+  if (!metadataOnly && row.state === 'missing') {
+    blockers.push('ref unavailable')
+  }
+  if (!capabilitySupported) {
+    blockers.push(`${requirement} unsupported`)
+  }
+  if (!metadataOnly && !hasAuditReason) {
+    blockers.push('audit reason required')
+  }
+  if (!metadataOnly && !confirmed) {
+    blockers.push('explicit confirmation required')
+  }
+  if (state === 'denied') {
+    blockers.push('policy denied')
+  }
+  if (state === 'auth-required') {
+    blockers.push('operator auth required')
+  }
+  if (state === 'unavailable') {
+    blockers.push('broker unavailable')
+  }
+  if (state === 'cancelled') {
+    blockers.push('operator cancelled')
+  }
+  if (state === 'failure') {
+    blockers.push('previous apply failed')
+  }
+
+  const canSubmit = !metadataOnly && blockers.length === 0 && state === 'ready'
+
+  return {
+    action,
+    operationId: `single-${safeOperationSlug(action, row)}-2026-06-20-a`,
+    endpoint: endpointForSingleSecretAction(action),
+    dryRunStatus: metadataOnly
+      ? 'metadata read only; no mutation dry-run needed'
+      : capabilitySupported
+        ? `${requirement} capability checked; preview required before submit`
+        : `${requirement} capability unavailable; fail closed`,
+    capabilityDecision: capabilitySupported
+      ? `supported: ${requirement}`
+      : `unsupported: ${requirement}`,
+    policyDecision:
+      row.policy.includes('readonly') && action !== 'metadata'
+        ? 'review required: readonly policy blocks mutation unless broker policy changes'
+        : 'allow preview: final allow/deny belongs to Secrets Broker',
+    auditRequirement: hasAuditReason
+      ? 'audit reason captured as metadata only'
+      : metadataOnly
+        ? 'audit reason not required for metadata view'
+        : 'audit reason required before submit',
+    applyGate: canSubmit
+      ? 'operation submit ready after dry-run revalidation'
+      : metadataOnly
+        ? 'metadata view only'
+        : (blockers[0] ?? 'operation blocked'),
+    blockers,
+    safePayloadFields: [
+      'ref',
+      'operationId',
+      'action',
+      'owningService',
+      'provider',
+      'policy',
+      'auditReasonMetadata',
+    ],
+    canSubmit,
   }
 }
 


### PR DESCRIPTION
## Issue
Progresses #231

## Summary
- Added a typed single-secret operation plan contract for metadata/reveal/edit/rotate/delete/policy row actions.
- Renders the selected operation endpoint, deterministic operation id, dry-run/policy status, submit gate, and metadata-only payload fields on the Secrets page.
- Covers rotate-without-reveal readiness, missing/delete blockers, and safe payload fields in existing Secrets tests.

## Scope
- In scope: Service Admin Secrets Broker > Secrets per-row operation contract/status UI.
- Out of scope: production Secrets Broker mutation API wiring, actual secret value reads/writes, issue closure, release/pin/demo deployment.

## Spec / contract / fixture impact
- Updated: UI-local typed operation plan model in `src/features/secrets-broker/secrets-management.ts`.
- Not required because: no public backend API/schema/release contract changes are made in this PR.

## Nash invariant impact
- Invariant: no raw secret values, credentials, tokens, private keys, or raw env values are rendered or persisted by the Secrets UI.
- Preservation proof: new operation plan exposes only ref, operation id, action, owner/provider/policy metadata, and audit reason metadata field names.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-secrets-management-test-4.log`
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "Secrets sub-page"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-playwright-secrets-2.log`
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-format-check-4.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-lint-4.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-build-2.log`

## Approval trail
- Required: no special approval identified for this focused UI-contract slice.
- Evidence: PR remains open for normal review/checks.

## Demo / release gate
- This PR changes `lasso-serviceadmin`, a demo-consumed service. The mandatory release-to-demo gate is not completed in this PR because it is not merged/released yet.
- Required after merge/release: publish/consume the exact Service Admin release or commit in `service-lasso/service-lasso`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and record expected vs live Service Admin tag/commit.

## Cleanup
- Branch: `issue-231-secrets-actions`
- Local cleanup deferred until PR merge/closure.
