### PR TITLE
feat(secrets): record single-secret rotate submit result

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -14,6 +14,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import {
+  CheckCircle2,
   DatabaseZap,
   Eye,
   ListChecks,
@@ -60,6 +61,7 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionPreview,
+  buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
   bulkSecretCampaignApplyModes,
@@ -75,6 +77,7 @@ import {
   type ManagedSecretAction,
   type ManagedSecretRow,
   type ManagedSecretState,
+  type SingleSecretOperationResult,
   type StubSecretMutationState,
 } from './secrets-management'
 
@@ -111,6 +114,8 @@ export function SecretsManagementPage() {
   const [stubState, setStubState] = useState<StubSecretMutationState>('ready')
   const [auditReason, setAuditReason] = useState('')
   const [confirmed, setConfirmed] = useState(false)
+  const [singleApplyResult, setSingleApplyResult] =
+    useState<SingleSecretOperationResult | null>(null)
   const [bulkSelectedIds, setBulkSelectedIds] = useState<string[]>([
     managedSecretRows[0].id,
     managedSecretRows[1].id,
@@ -204,6 +209,7 @@ export function SecretsManagementPage() {
     (rowId: string, action: ManagedSecretAction) => {
       setSelectedRowId(rowId)
       setSelectedAction(action)
+      setSingleApplyResult(null)
     },
     []
   )
@@ -231,6 +237,13 @@ export function SecretsManagementPage() {
     setBulkApplyResult(
       buildBulkSecretCampaignApplyResult(bulkPlan, bulkApplyMode)
     )
+  }
+
+  function applySingleSecretOperation() {
+    setSingleApplyResult(
+      buildSingleSecretOperationResult(selectedRow, singleOperationPlan)
+    )
+    setStubState('success')
   }
 
   const columns = useMemo<ColumnDef<ManagedSecretRow>[]>(
@@ -1417,9 +1430,10 @@ export function SecretsManagementPage() {
                   id='stub-state'
                   className='mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm'
                   value={stubState}
-                  onChange={(event) =>
+                  onChange={(event) => {
                     setStubState(event.target.value as StubSecretMutationState)
-                  }
+                    setSingleApplyResult(null)
+                  }}
                 >
                   {stubSecretMutationStates.map((state) => (
                     <option key={state.id} value={state.id}>
@@ -1456,14 +1470,20 @@ export function SecretsManagementPage() {
                 <Input
                   id='audit-reason'
                   value={auditReason}
-                  onChange={(event) => setAuditReason(event.target.value)}
+                  onChange={(event) => {
+                    setAuditReason(event.target.value)
+                    setSingleApplyResult(null)
+                  }}
                   placeholder='Required before simulated apply; no secret values'
                 />
                 <label className='flex items-center gap-2 text-sm'>
                   <input
                     type='checkbox'
                     checked={confirmed}
-                    onChange={(event) => setConfirmed(event.target.checked)}
+                    onChange={(event) => {
+                      setConfirmed(event.target.checked)
+                      setSingleApplyResult(null)
+                    }}
                   />
                   I confirm this is a stub preview and no production mutation
                   will be performed.
@@ -1510,8 +1530,62 @@ export function SecretsManagementPage() {
               </div>
             </div>
 
+            {singleApplyResult ? (
+              <div className='rounded-lg border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <CheckCircle2 className='size-4 text-primary' />
+                  <div className='font-medium'>
+                    Single-secret operation result: {singleApplyResult.outcome}
+                  </div>
+                  <Badge variant='secondary'>Metadata only</Badge>
+                  <Badge variant='outline'>
+                    {singleApplyResult.applied ? 'Applied' : 'Not applied'}
+                  </Badge>
+                </div>
+                <div className='grid gap-3 md:grid-cols-3'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Operation ID
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.operationId}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Ref
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.ref}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Audit
+                    </div>
+                    <div className='mt-1'>{singleApplyResult.auditStatus}</div>
+                  </div>
+                </div>
+                <div className='mt-3 rounded-md border bg-muted/40 p-3'>
+                  <div>{singleApplyResult.resultStatus}</div>
+                  <div className='mt-2 text-muted-foreground'>
+                    {singleApplyResult.nextAction}
+                  </div>
+                </div>
+                <ul className='mt-3 list-disc space-y-1 ps-5 text-muted-foreground'>
+                  {singleApplyResult.safetyRows.map((row) => (
+                    <li key={row}>{row}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
             <div className='flex flex-wrap gap-2'>
-              <Button type='button' disabled={!stubMutationPreview.canApply}>
+              <Button
+                type='button'
+                disabled={!stubMutationPreview.canApply}
+                onClick={applySingleSecretOperation}
+              >
                 Simulate stub apply
               </Button>
               <Button
@@ -1521,6 +1595,7 @@ export function SecretsManagementPage() {
                   setAuditReason('')
                   setConfirmed(false)
                   setStubState('cancelled')
+                  setSingleApplyResult(null)
                 }}
               >
                 Cancel stub preview

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -6,6 +6,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
@@ -540,6 +541,21 @@ describe('Secrets Broker secrets management page', () => {
       )
     ).toBeVisible()
     expect(screen.getByText(/reset dry-run capability checked/i)).toBeVisible()
+    await user.type(
+      screen.getByLabelText(/Audit reason for stub preview/i),
+      'operator requested rotation preview'
+    )
+    await user.click(screen.getByLabelText(/I confirm this is a stub preview/i))
+    await user.click(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    )
+    expect(
+      screen.getByText(/Single-secret operation result: submitted/i)
+    ).toBeVisible()
+    expect(screen.getByText(/raw value was not revealed/i)).toBeVisible()
+    expect(
+      screen.getByText(/rotation can be requested without controlled reveal/i)
+    ).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Delete dry-run/i })[0]
@@ -680,6 +696,26 @@ describe('Secrets Broker secrets management page', () => {
     })
     expect(rotatePlan.safePayloadFields).toEqual(
       expect.arrayContaining(['ref', 'operationId', 'auditReasonMetadata'])
+    )
+    const rotateResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan
+    )
+    expect(rotateResult).toMatchObject({
+      operationId: rotatePlan.operationId,
+      ref: managedSecretRows[0].ref,
+      action: 'reset',
+      outcome: 'submitted',
+      applied: false,
+      auditStatus: 'stub audit event recorded with metadata only',
+      nextAction:
+        'monitor broker rotation outcome and dependent service restart notes',
+    })
+    expect(rotateResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'raw value was not revealed',
+        'rotation can be requested without controlled reveal',
+      ])
     )
 
     const missingDeletePlan = buildSingleSecretOperationPlan(

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -54,6 +54,18 @@ export type SingleSecretOperationPlan = {
   canSubmit: boolean
 }
 
+export type SingleSecretOperationResult = {
+  operationId: string
+  ref: string
+  action: ManagedSecretAction
+  outcome: 'submitted'
+  applied: false
+  auditStatus: string
+  resultStatus: string
+  safetyRows: string[]
+  nextAction: string
+}
+
 export type StubSecretMutationState =
   | 'ready'
   | 'denied'
@@ -1236,6 +1248,44 @@ export function buildSingleSecretOperationPlan(
       'auditReasonMetadata',
     ],
     canSubmit,
+  }
+}
+
+export function buildSingleSecretOperationResult(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretOperationResult {
+  const actionLabel =
+    plan.action === 'reset'
+      ? 'rotate/reset'
+      : plan.action === 'edit'
+        ? 'edit/update'
+        : plan.action === 'delete'
+          ? 'delete/decommission'
+          : plan.action === 'policy'
+            ? 'policy change'
+            : plan.action
+
+  return {
+    operationId: plan.operationId,
+    ref: row.ref,
+    action: plan.action,
+    outcome: 'submitted',
+    applied: false,
+    auditStatus: 'stub audit event recorded with metadata only',
+    resultStatus: `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`,
+    safetyRows: [
+      'raw value was not revealed',
+      'request body is limited to ref, operation id, action, owner, provider, policy, and audit reason metadata',
+      plan.action === 'reset'
+        ? 'rotation can be requested without controlled reveal'
+        : 'operator action used the selected dry-run gate',
+      'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
+    ],
+    nextAction:
+      plan.action === 'reset'
+        ? 'monitor broker rotation outcome and dependent service restart notes'
+        : 'monitor broker operation status and typed policy/audit result',
   }
 }
 

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -208,6 +208,37 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
+  test('submits a single-secret rotate preview without revealing the value', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker/secrets')
+    await expectNoBlankScreen(page)
+
+    await page
+      .getByRole('button', { name: /Reset\/rotate dry-run/i })
+      .first()
+      .click()
+    await expect(
+      page.getByText(/Reset\/rotate dry-run for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    await page
+      .getByLabel(/Audit reason for stub preview/i)
+      .fill('operator requested rotation preview')
+    await page.getByLabel(/I confirm this is a stub preview/i).check()
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+
+    await expect(
+      page.getByText(/Single-secret operation result: submitted/i)
+    ).toBeVisible()
+    await expect(page.getByText(/raw value was not revealed/i)).toBeVisible()
+    await expect(
+      page.getByText(/rotation can be requested without controlled reveal/i)
+    ).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+    expect(consoleErrors).toEqual([])
+  })
+
   test('covers healthy degraded offline and unconfigured broker states', async ({
     page,
   }) => {


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only single-secret operation result after the stub dry-run submit gate.
- Shows operation id, selected ref, audit status, result status, next action, and explicit safety rows.
- Covers rotate/reset submit without controlled reveal in unit and browser tests.

## Scope
- In scope: Service Admin Secrets page single-secret dry-run submit evidence for stub workflows.
- Out of scope: production Secrets Broker mutation API wiring, actual secret value mutation, bulk raw value reveal/export, and full closure of #231.

## Spec / contract / fixture impact
- Updated: local UI/model contract for the Secrets page stub operation result.
- Not required: public backend API/schema change; this remains a deterministic UI/model stub until the production mutation contract is connected.

## Nash invariant impact
- Invariant: raw secret values and provider credentials stay out of UI/routes/logs/fixtures.
- Preservation proof: result safety rows and tests assert rotation can be submitted without reveal and `DEMO_REVEAL_VALUE_42` is absent.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-management.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-rotate.log` (1 passed)
- PASS `npm run build` — `.work-agent/logs/issue-231/build.log`
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check.log`
- PASS GitHub CI `install-lint-build` — run `27876620350`
- PASS canonical preflight/post-PR health: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` status `ok`.

## Approval trail
- Required: no special approval identified for this focused UI/test PR.
- Evidence: issue #231 is open, P0, Status Ready, Agent lane Ready for Agent; no open org PRs were blocking at selection time.

## Cleanup
- Branch: `agent/issue-231-secrets-actions`
- Post-merge: recycle/pin canonical demo as required for Service Admin demo-consumed changes before claiming done.