### PR TITLE
fix(providers): simplify Providers page to one table

### DIFF
--- a/src/features/secrets-broker/providers-management-page.tsx
+++ b/src/features/secrets-broker/providers-management-page.tsx
@@ -1,24 +1,37 @@
 import { useMemo, useState } from 'react'
 import {
-  ArrowDownUp,
-  DatabaseZap,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type SortingState,
+  flexRender,
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import {
+  Ban,
+  CirclePlus,
   KeyRound,
-  Plus,
-  Search as SearchIcon,
+  MoreHorizontal,
+  PlugZap,
+  RefreshCw,
   Settings,
   ShieldCheck,
+  Trash2,
 } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import {
   Table,
   TableBody,
@@ -28,30 +41,22 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { ConfigDrawer } from '@/components/config-drawer'
+import {
+  DataTableColumnHeader,
+  DataTablePagination,
+  DataTableToolbar,
+} from '@/components/data-table'
 import { Header } from '@/components/layout/header'
 import { Main } from '@/components/layout/main'
 import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
-import { AwsSecretsManagerProviderDetail } from './aws-secrets-manager-provider-detail'
-import { BitwardenBwsProviderDetail } from './bitwarden-bws-provider-detail'
-import { LocalBootstrapProviderDetails } from './local-bootstrap-provider-details'
-import { LocalEncryptedStoreProviderDetail } from './local-encrypted-store-detail'
-import { MountedSecretsProviderDetail } from './mounted-secrets-provider-detail'
-import { OnePasswordCliProviderDetail } from './onepassword-cli-provider-detail'
 import {
-  buildProvidersManagementSummary,
-  filterProviderManagementRows,
-  getAddableSecretsBrokerProviders,
   getConfiguredSecretsBrokerProviders,
-  secretsBrokerSourceBackends,
   type SecretsBrokerProviderLifecycle,
   type SecretsBrokerSourceBackend,
   type SecretsBrokerSourceState,
 } from './source-backends'
-import { VaultProviderDetail } from './vault-provider-detail'
-
-type ProviderOrder = 'priority' | 'name' | 'status'
 
 const stateVariant: Record<
   SecretsBrokerSourceState,
@@ -76,53 +81,243 @@ const lifecycleVariant: Record<
   ready: 'default',
 }
 
-function sortProviders(
-  providers: SecretsBrokerSourceBackend[],
-  order: ProviderOrder
-) {
-  return [...providers].sort((left, right) => {
-    if (order === 'name') return left.title.localeCompare(right.title)
-    if (order === 'status') {
-      return `${left.state}-${left.lifecycle}-${left.title}`.localeCompare(
-        `${right.state}-${right.lifecycle}-${right.title}`
-      )
-    }
-
-    return (left.priority ?? 999) - (right.priority ?? 999)
-  })
-}
-
 function providerTypeLabel(provider: SecretsBrokerSourceBackend) {
   return provider.type === 'local' ? 'local-encrypted-store' : provider.type
 }
 
-export function ProvidersManagementPage() {
-  const [query, setQuery] = useState('')
-  const [order, setOrder] = useState<ProviderOrder>('priority')
+function EnabledBadge({ enabled }: { enabled: boolean }) {
+  return enabled ? (
+    <Badge className='bg-emerald-600 hover:bg-emerald-600'>Enabled</Badge>
+  ) : (
+    <Badge variant='outline'>Disabled</Badge>
+  )
+}
 
+function ProviderActions({
+  provider,
+}: {
+  provider: SecretsBrokerSourceBackend
+}) {
+  const canEdit = provider.supportedActions.includes('edit-configuration')
+  const canTest = provider.supportedActions.includes('test-source')
+  const needsReconnect = [
+    'auth-required',
+    'locked',
+    'invalid',
+    'setup-needed',
+  ].includes(provider.lifecycle)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type='button' size='sm' variant='outline'>
+          <MoreHorizontal className='size-4' /> Actions
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end' className='w-48'>
+        <DropdownMenuItem disabled={!canEdit}>
+          <Settings className='size-4' /> View/Edit configuration
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!canTest}>
+          <ShieldCheck className='size-4' /> Test connection
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!needsReconnect}>
+          <RefreshCw className='size-4' /> Reconnect / reauth
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Ban className='size-4' /> Disable provider
+        </DropdownMenuItem>
+        <DropdownMenuItem variant='destructive'>
+          <Trash2 className='size-4' /> Remove provider
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+const columns: ColumnDef<SecretsBrokerSourceBackend>[] = [
+  {
+    id: 'provider',
+    accessorFn: (provider) =>
+      [
+        provider.title,
+        provider.type,
+        provider.provider,
+        provider.source,
+        provider.connection,
+        provider.namespaces.join(' '),
+        provider.summary,
+      ].join(' '),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Provider' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex max-w-[320px] min-w-0 flex-col'>
+        <span className='truncate font-medium' title={row.original.title}>
+          {row.original.title}
+        </span>
+        <span
+          className='truncate text-xs text-muted-foreground'
+          title={row.original.source}
+        >
+          {providerTypeLabel(row.original)} · {row.original.source}
+        </span>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    id: 'enabled',
+    accessorFn: (provider) => (provider.enabled ? 'enabled' : 'disabled'),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Enabled' />
+    ),
+    cell: ({ row }) => <EnabledBadge enabled={row.original.enabled} />,
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    id: 'status',
+    accessorFn: (provider) => provider.state,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Health' />
+    ),
+    cell: ({ row }) => (
+      <div className='flex flex-wrap gap-2'>
+        <Badge variant={stateVariant[row.original.state]}>
+          {row.original.state}
+        </Badge>
+        <Badge variant={lifecycleVariant[row.original.lifecycle]}>
+          {row.original.lifecycle}
+        </Badge>
+      </div>
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    id: 'lifecycle',
+    accessorFn: (provider) => provider.lifecycle,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Lifecycle' />
+    ),
+    cell: ({ row }) => (
+      <div className='max-w-[260px] min-w-0'>
+        <div
+          className='truncate text-sm'
+          title={
+            row.original.lifecycleDetail?.state ??
+            row.original.testResult.outcome
+          }
+        >
+          {row.original.lifecycleDetail?.state ??
+            row.original.testResult.outcome}
+        </div>
+        <div
+          className='truncate text-xs text-muted-foreground'
+          title={row.original.nextAction}
+        >
+          {row.original.nextAction}
+        </div>
+      </div>
+    ),
+    filterFn: (row, id, value) => value.includes(row.getValue(id)),
+  },
+  {
+    id: 'priority',
+    accessorFn: (provider) => provider.priority ?? 999,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Priority' />
+    ),
+    cell: ({ row }) => (
+      <div className='whitespace-nowrap'>
+        {row.original.priority ?? 'Not assigned'}
+      </div>
+    ),
+  },
+  {
+    id: 'namespaces',
+    accessorFn: (provider) =>
+      provider.namespaces.length
+        ? provider.namespaces.join(', ')
+        : 'not mapped',
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Namespaces' />
+    ),
+    cell: ({ row }) => (
+      <div
+        className='max-w-[240px] truncate text-sm'
+        title={
+          row.original.namespaces.length
+            ? row.original.namespaces.join(', ')
+            : 'not mapped'
+        }
+      >
+        {row.original.namespaces.length
+          ? row.original.namespaces.join(', ')
+          : 'not mapped'}
+      </div>
+    ),
+  },
+  {
+    id: 'lastCheckedAt',
+    accessorFn: (provider) => provider.lastCheckedAt,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title='Last checked' />
+    ),
+    cell: ({ row }) => (
+      <div
+        className='max-w-[190px] truncate whitespace-nowrap'
+        title={row.original.lastCheckedAt}
+      >
+        {row.original.lastCheckedAt}
+      </div>
+    ),
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    cell: ({ row }) => <ProviderActions provider={row.original} />,
+    enableSorting: false,
+    enableHiding: false,
+  },
+]
+
+export function ProvidersManagementPage() {
   usePageMetadata({
     title: 'Service Admin - Secrets Broker Providers',
     description:
-      'Secrets Broker provider management for configured providers, add-provider options, priority ordering, and metadata-only status.',
+      'Focused Secrets Broker provider management table for configured providers and metadata-only status.',
   })
 
-  const configuredProviders = useMemo(
+  const data = useMemo(
     () =>
-      sortProviders(
-        filterProviderManagementRows(
-          getConfiguredSecretsBrokerProviders(),
-          query
-        ),
-        order
+      getConfiguredSecretsBrokerProviders().filter(
+        (provider) => provider.enabled
       ),
-    [order, query]
+    []
   )
-  const addableProviders = useMemo(
-    () =>
-      filterProviderManagementRows(getAddableSecretsBrokerProviders(), query),
-    [query]
-  )
-  const summary = buildProvidersManagementSummary(secretsBrokerSourceBackends)
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'priority', desc: false },
+    { id: 'provider', desc: false },
+  ])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnFilters,
+    },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
 
   return (
     <>
@@ -135,271 +330,125 @@ export function ProvidersManagementPage() {
         </div>
       </Header>
 
-      <Main id='content' className='space-y-6'>
-        <div className='flex flex-wrap items-start justify-between gap-4'>
+      <Main id='content' className='flex flex-1 flex-col gap-4 sm:gap-6'>
+        <div className='flex flex-wrap items-end justify-between gap-3'>
           <div>
             <h1 className='flex items-center gap-2 text-2xl font-bold tracking-tight'>
               <KeyRound className='size-5' /> Secrets Broker providers
             </h1>
-            <p className='mt-1 text-muted-foreground'>
-              Manage configured providers, default/fallback ordering, and
-              addable provider types without rendering credential values.
+            <p className='text-muted-foreground'>
+              Enabled provider configuration, health, and row actions.
             </p>
           </div>
-          <Badge variant='secondary'>Metadata only</Badge>
+          <div className='flex flex-wrap gap-2'>
+            <Badge variant='secondary'>Metadata only</Badge>
+            <Button type='button' size='sm'>
+              <CirclePlus className='size-4' /> Add provider
+            </Button>
+          </div>
         </div>
 
-        <div className='grid gap-4 md:grid-cols-4'>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Configured providers</CardDescription>
-              <CardTitle className='text-3xl'>
-                {summary.configuredCount}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Healthy / ready</CardDescription>
-              <CardTitle className='text-3xl'>{summary.readyCount}</CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Needing action</CardDescription>
-              <CardTitle className='text-3xl'>
-                {summary.needsActionCount}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-          <Card>
-            <CardHeader className='pb-2'>
-              <CardDescription>Default / fallback</CardDescription>
-              <CardTitle className='text-xl'>
-                {summary.defaultProvider}
-              </CardTitle>
-            </CardHeader>
-          </Card>
-        </div>
+        <div className='flex flex-1 flex-col gap-4'>
+          <DataTableToolbar
+            table={table}
+            searchPlaceholder='Search providers, namespaces, source, or health...'
+            searchKey='provider'
+            filters={[
+              {
+                columnId: 'enabled',
+                title: 'Enabled',
+                options: [
+                  { label: 'Enabled', value: 'enabled' },
+                  { label: 'Disabled', value: 'disabled' },
+                ],
+              },
+              {
+                columnId: 'status',
+                title: 'Health',
+                options: [
+                  { label: 'Configured', value: 'configured' },
+                  { label: 'Reachable', value: 'reachable' },
+                  { label: 'Failing', value: 'failing' },
+                  { label: 'Untested', value: 'untested' },
+                  { label: 'Not configured', value: 'not-configured' },
+                ],
+              },
+              {
+                columnId: 'lifecycle',
+                title: 'Lifecycle',
+                options: [
+                  { label: 'Ready', value: 'ready' },
+                  { label: 'Unlocked', value: 'unlocked' },
+                  { label: 'Locked', value: 'locked' },
+                  { label: 'Auth required', value: 'auth-required' },
+                  { label: 'Invalid', value: 'invalid' },
+                  { label: 'Setup needed', value: 'setup-needed' },
+                ],
+              },
+            ]}
+          />
 
-        <Card>
-          <CardHeader>
-            <div className='flex flex-wrap items-start justify-between gap-3'>
-              <div>
-                <CardTitle className='flex items-center gap-2'>
-                  <DatabaseZap className='size-4' /> Configured provider table
-                </CardTitle>
-                <CardDescription>
-                  Only the Local encrypted store is configured by default.
-                  Additional provider types appear in Add Provider until an
-                  operator configures and tests them.
-                </CardDescription>
-              </div>
-              <div className='flex flex-wrap gap-2'>
-                <Badge variant='outline'>No raw values</Badge>
-                <Badge variant='outline'>Credentials as refs only</Badge>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className='space-y-4'>
-            <div className='grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px]'>
-              <label className='relative block'>
-                <span className='sr-only'>Search providers</span>
-                <SearchIcon className='pointer-events-none absolute top-2.5 left-3 size-4 text-muted-foreground' />
-                <Input
-                  aria-label='Search providers'
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  className='pl-9'
-                  placeholder='Search provider name, kind, namespace, status'
-                />
-              </label>
-              <label className='flex items-center gap-2'>
-                <ArrowDownUp className='size-4 text-muted-foreground' />
-                <span className='sr-only'>Provider order</span>
-                <select
-                  aria-label='Provider order'
-                  className='h-9 w-full rounded-md border bg-background px-3 text-sm'
-                  value={order}
-                  onChange={(event) =>
-                    setOrder(event.target.value as ProviderOrder)
-                  }
-                >
-                  <option value='priority'>Resolution priority</option>
-                  <option value='name'>Provider name</option>
-                  <option value='status'>Status</option>
-                </select>
-              </label>
-            </div>
-
-            <div className='overflow-x-auto rounded-md border'>
-              <Table>
+          <div className='overflow-hidden rounded-md border'>
+            <div className='overflow-x-auto'>
+              <Table className='min-w-[1180px] table-fixed'>
                 <TableHeader>
-                  <TableRow>
-                    <TableHead>Provider</TableHead>
-                    <TableHead>Configured / enabled</TableHead>
-                    <TableHead>Status / lifecycle</TableHead>
-                    <TableHead>Priority / ownership</TableHead>
-                    <TableHead>Last tested</TableHead>
-                    <TableHead>Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {configuredProviders.map((provider) => (
-                    <TableRow key={provider.id}>
-                      <TableCell className='min-w-72 align-top'>
-                        <div className='font-medium'>{provider.title}</div>
-                        <div className='text-sm text-muted-foreground'>
-                          {providerTypeLabel(provider)} · {provider.source}
-                        </div>
-                        <div className='mt-1 text-xs text-muted-foreground'>
-                          {provider.summary}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-44 align-top'>
-                        <div>
-                          {provider.configured ? 'configured' : 'addable'}
-                        </div>
-                        <div className='text-sm text-muted-foreground'>
-                          {provider.enabled ? 'enabled' : 'disabled'}
-                        </div>
-                        <Badge className='mt-2' variant='outline'>
-                          {provider.defaultRole}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className='min-w-48 align-top'>
-                        <Badge variant={stateVariant[provider.state]}>
-                          {provider.state}
-                        </Badge>
-                        <Badge
-                          className='mt-2 ml-2'
-                          variant={lifecycleVariant[provider.lifecycle]}
-                        >
-                          {provider.lifecycle}
-                        </Badge>
-                        <div className='mt-2 text-sm text-muted-foreground'>
-                          {provider.testResult.outcome}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-64 align-top'>
-                        <div>
-                          Priority {provider.priority ?? 'not assigned'}
-                        </div>
-                        <div className='mt-1 text-sm text-muted-foreground'>
-                          Namespaces:{' '}
-                          {provider.namespaces.length
-                            ? provider.namespaces.join(', ')
-                            : 'not mapped'}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-48 align-top'>
-                        <div>{provider.testResult.checkedAt}</div>
-                        <div className='text-sm text-muted-foreground'>
-                          {provider.lastCheckedAt}
-                        </div>
-                      </TableCell>
-                      <TableCell className='min-w-56 align-top'>
-                        <div className='flex flex-wrap gap-2'>
-                          <Button type='button' size='sm' variant='outline'>
-                            <Settings className='size-4' /> Configure
-                          </Button>
-                          <Button type='button' size='sm' variant='outline'>
-                            <ShieldCheck className='size-4' /> Test
-                          </Button>
-                        </div>
-                        <div className='mt-2 text-xs text-muted-foreground'>
-                          {provider.nextAction}
-                        </div>
-                      </TableCell>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id} className='group/row'>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead key={header.id} colSpan={header.colSpan}>
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                        </TableHead>
+                      ))}
                     </TableRow>
                   ))}
-                  {configuredProviders.length === 0 ? (
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.length ? (
+                    table.getRowModel().rows.map((row) => (
+                      <TableRow key={row.id} className='group/row'>
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id} className='min-w-0'>
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))
+                  ) : (
                     <TableRow>
-                      <TableCell colSpan={6} className='h-24 text-center'>
-                        No configured providers match the current filters.
+                      <TableCell
+                        colSpan={columns.length}
+                        className='h-28 text-center'
+                      >
+                        <div className='mx-auto flex max-w-md flex-col items-center gap-2'>
+                          <PlugZap className='size-5 text-muted-foreground' />
+                          <div className='font-medium'>
+                            No enabled providers match the current filters.
+                          </div>
+                          <div className='text-sm text-muted-foreground'>
+                            Add a provider or clear filters to review enabled
+                            provider state.
+                          </div>
+                          <Button type='button' size='sm'>
+                            <CirclePlus className='size-4' /> Add provider
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
-                  ) : null}
+                  )}
                 </TableBody>
               </Table>
             </div>
-          </CardContent>
-        </Card>
-
-        <LocalEncryptedStoreProviderDetail />
-
-        <LocalBootstrapProviderDetails query={query} />
-
-        <VaultProviderDetail query={query} />
-
-        <AwsSecretsManagerProviderDetail query={query} />
-
-        <OnePasswordCliProviderDetail query={query} />
-
-        <BitwardenBwsProviderDetail query={query} />
-
-        <MountedSecretsProviderDetail query={query} />
-
-        <Card>
-          <CardHeader>
-            <div className='flex flex-wrap items-start justify-between gap-3'>
-              <div>
-                <CardTitle className='flex items-center gap-2'>
-                  <Plus className='size-4' /> Add Provider
-                </CardTitle>
-                <CardDescription>
-                  Supported provider types stay unconfigured until an operator
-                  adds provider-specific metadata, mappings, priority, and a
-                  safe test result.
-                </CardDescription>
-              </div>
-              <Badge variant='outline'>{summary.addableCount} available</Badge>
-            </div>
-          </CardHeader>
-          <CardContent className='space-y-4'>
-            <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-3'>
-              {addableProviders.map((provider) => (
-                <div
-                  key={provider.id}
-                  className='rounded-md border p-4 text-sm'
-                >
-                  <div className='flex flex-wrap items-start justify-between gap-2'>
-                    <div>
-                      <div className='font-medium'>{provider.title}</div>
-                      <div className='text-xs text-muted-foreground'>
-                        {providerTypeLabel(provider)}
-                      </div>
-                    </div>
-                    <Badge variant='outline'>addable</Badge>
-                  </div>
-                  <p className='mt-3 text-muted-foreground'>
-                    {provider.summary}
-                  </p>
-                  {provider.warnings.length ? (
-                    <div className='mt-3 flex flex-wrap gap-1'>
-                      {provider.warnings.map((warning) => (
-                        <Badge key={warning.code} variant='secondary'>
-                          {warning.title}
-                        </Badge>
-                      ))}
-                    </div>
-                  ) : null}
-                  <div className='mt-3 rounded-md bg-muted/40 p-3'>
-                    {provider.nextAction}
-                  </div>
-                  <Button type='button' className='mt-3' variant='outline'>
-                    <Plus className='size-4' /> Add {provider.title}
-                  </Button>
-                </div>
-              ))}
-            </div>
-            {addableProviders.length === 0 ? (
-              <div className='rounded-md border border-dashed p-6 text-sm text-muted-foreground'>
-                No addable provider options match the current filters.
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
+          </div>
+          <DataTablePagination table={table} className='mt-auto' />
+        </div>
       </Main>
     </>
   )

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -231,14 +231,17 @@ describe('Secrets Broker overview dashboard', () => {
     expect(
       screen.getByRole('heading', { name: /Secrets Broker providers/i })
     ).toBeVisible()
-    expect(screen.getByText(/Credentials as refs only/i)).toBeVisible()
-    expect(screen.getAllByText(/Local encrypted store/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/setup_needed/i)[0]).toBeVisible()
-    expect(screen.getByText(/Authentication required/i)).toBeVisible()
     expect(
-      screen.getByText(/HashiCorp Vault \/ OpenBao provider/i)
+      screen.getByRole('button', { name: /^Add provider$/i })
     ).toBeVisible()
-    expect(screen.getByText(/tokens hidden/i)).toBeVisible()
+    expect(screen.getByPlaceholderText(/Search providers/i)).toBeVisible()
+    expect(screen.getAllByText(/Local encrypted store/i)[0]).toBeVisible()
+    expect(
+      screen.queryByText(/HashiCorp Vault \/ OpenBao provider/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Authentication required/i)
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText(/correct-horse-battery-staple/i)
     ).not.toBeInTheDocument()
@@ -351,7 +354,7 @@ describe('Secrets Broker overview dashboard', () => {
     })
   })
 
-  it('renders Providers management with local default and addable provider options', async () => {
+  it('renders Providers management as one enabled-provider table', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/sources')
 
@@ -359,111 +362,74 @@ describe('Secrets Broker overview dashboard', () => {
       screen.getByRole('heading', { name: /Secrets Broker providers/i })
     ).toBeVisible()
     expect(screen.getAllByText(/Metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/Configured provider table/i)).toBeVisible()
-    expect(screen.getByText(/^Add Provider$/i)).toBeVisible()
+    expect(
+      screen.getByRole('button', { name: /^Add provider$/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('columnheader', { name: /Provider/i })
+    ).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /Enabled/i })).toBeVisible()
+    expect(screen.getByRole('columnheader', { name: /Health/i })).toBeVisible()
     expect(screen.getAllByText(/Local encrypted store/i)[0]).toBeVisible()
     expect(screen.getAllByText(/local-encrypted-store/i)[0]).toBeVisible()
-    expect(screen.getByText(/Priority 0/i)).toBeVisible()
-    expect(screen.getByText(/^default$/i)).toBeVisible()
-    expect(screen.getByRole('button', { name: /^Configure$/i })).toBeVisible()
-    expect(screen.getByRole('button', { name: /^Test$/i })).toBeVisible()
-    expect(screen.getAllByText(/setup_needed/i)[0]).toBeVisible()
+    expect(screen.getByText(/^0$/i)).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /^Actions$/i }))
+    expect(
+      screen.getByRole('menuitem', { name: /View\/Edit configuration/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('menuitem', { name: /Test connection/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('menuitem', { name: /Reconnect \/ reauth/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('menuitem', { name: /Disable provider/i })
+    ).toBeVisible()
+    expect(
+      screen.getByRole('menuitem', { name: /Remove provider/i })
+    ).toBeVisible()
+    await user.keyboard('{Escape}')
     expect(screen.getAllByText(/reconnect_required/i)[0]).toBeVisible()
     expect(screen.getAllByText(/locked/i)[0]).toBeVisible()
     expect(screen.getAllByText(/unlock_or_unseal_source/i)[0]).toBeVisible()
-    expect(screen.getByText(/default fallback provider/i)).toBeVisible()
-    expect(screen.getByText(/Local bootstrap providers/i)).toBeVisible()
-    expect(screen.getAllByText(/Read-only by default/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Environment provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/File provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Exec provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/configured_metadata/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/policy_denied/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/not_configured/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/read-only bootstrap source/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/path policy denied/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/command not executed/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/metadata event only/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/HashiCorp Vault CLI/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/AWS Secrets Manager CLI/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/1Password CLI/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Bitwarden \/ BWS CLI/i)[0]).toBeVisible()
     expect(
-      screen.getAllByText(/Docker\/Kubernetes mounted secrets/i)[0]
-    ).toBeVisible()
-    expect(screen.getAllByText(/Broad env allowlist/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Insecure path override/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Untrusted command path/i)[0]).toBeVisible()
+      screen.queryByText(/Local bootstrap providers/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Environment provider/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/HashiCorp Vault CLI/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Broad env allowlist/i)).not.toBeInTheDocument()
     expect(
-      screen.getAllByText(/Missing timeout\/output limits/i)[0]
-    ).toBeVisible()
-    expect(
-      screen.getAllByRole('button', { name: /Add Environment provider/i })[0]
-    ).toBeVisible()
+      screen.queryByText(/Insecure path override/i)
+    ).not.toBeInTheDocument()
 
-    await user.type(screen.getByLabelText(/Search providers/i), 'aws')
-    expect(screen.getByText(/No configured providers match/i)).toBeVisible()
-    expect(screen.getAllByText(/AWS Secrets Manager CLI/i)[0]).toBeVisible()
+    await user.type(screen.getByPlaceholderText(/Search providers/i), 'aws')
+    expect(screen.getByText(/No enabled providers match/i)).toBeVisible()
+    expect(
+      screen.queryByText(/AWS Secrets Manager CLI/i)
+    ).not.toBeInTheDocument()
     expect(screen.queryByText(/Environment provider/i)).not.toBeInTheDocument()
   })
 
-  it('renders Env File Exec provider details with safe state coverage', async () => {
+  it('keeps addable provider details off the focused providers page', async () => {
     await renderRoute('/secrets-broker/sources')
 
-    expect(screen.getByText(/Local bootstrap providers/i)).toBeVisible()
-    expect(screen.getAllByText(/Environment provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/File provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/Exec provider/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/^reachable$/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/^failing$/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/^untested$/i)[0]).toBeVisible()
+    expect(screen.queryByText(/Local bootstrap providers/i)).toBeNull()
+    expect(screen.queryByText(/Environment provider/i)).toBeNull()
+    expect(screen.queryByText(/File provider/i)).toBeNull()
+    expect(screen.queryByText(/Exec provider/i)).toBeNull()
+    expect(screen.queryByText(/narrow_allowlist_before_production/i)).toBeNull()
+    expect(screen.queryByText(/fix_path_scope_and_symlink_policy/i)).toBeNull()
     expect(
-      screen.getAllByText(/narrow_allowlist_before_production/i)[0]
-    ).toBeVisible()
-    expect(
-      screen.getAllByText(/fix_path_scope_and_symlink_policy/i)[0]
-    ).toBeVisible()
-    expect(
-      screen.getAllByText(
-        /configure_trusted_command_timeout_and_output_limits/i
-      )[0]
-    ).toBeVisible()
-    expect(
-      screen.getByText(/Matches explicit env ref mappings only/i)
-    ).toBeVisible()
-    expect(screen.getByText(/Blocks unsafe paths/i)).toBeVisible()
-    expect(screen.getByText(/Runs only explicitly allowlisted/i)).toBeVisible()
+      screen.queryByText(/configure_trusted_command_timeout_and_output_limits/i)
+    ).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 
-  it('renders Vault OpenBao provider configuration metadata safely', async () => {
-    const user = userEvent.setup()
+  it('keeps Vault OpenBao addable metadata safe but off the table page', async () => {
     await renderRoute('/secrets-broker/sources')
-
-    expect(
-      screen.getAllByText(/HashiCorp Vault \/ OpenBao provider/i)[0]
-    ).toBeVisible()
-    expect(
-      screen.getByText(/Vault\/OpenBao configuration metadata/i)
-    ).toBeVisible()
-    expect(screen.getAllByText(/auth_required/i)[0]).toBeVisible()
-    expect(
-      screen.getByText(/configure_vault_address_mount_auth_ref_and_policy/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(/address, mount, token-env handle, auth identity ref/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(/secret:\/\/providers\/vault\/payments\/STRIPE_KEY/i)
-    ).toBeVisible()
-    expect(screen.getAllByText(/kv\/service-lasso/i)[0]).toBeVisible()
-    expect(screen.getByText(/payments\/api/i)).toBeVisible()
-    expect(screen.getAllByText(/stripe_key/i)[0]).toBeVisible()
-    expect(screen.getByText(/Sealed, locked, auth_required/i)).toBeVisible()
-    expect(screen.getAllByText(/policy metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/no raw Vault\/OpenBao output/i)).toBeVisible()
 
     const vaultProvider = secretsBrokerSourceBackends.find(
       (source) => source.id === 'vault-cli'
@@ -485,26 +451,12 @@ describe('Secrets Broker overview dashboard', () => {
       ])
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /Configure Vault\/OpenBao/i })
-    )
     expect(
-      screen.getByRole('dialog', { name: /Configure Vault\/OpenBao/i })
-    ).toBeVisible()
-    expect(screen.getByLabelText(/Address/i)).toHaveValue(
-      'https://vault.service-lasso.local'
-    )
-    expect(screen.getByLabelText(/^Mount$/i)).toHaveValue('kv/service-lasso')
-    expect(screen.getByLabelText(/Auth identity reference/i)).toHaveValue(
-      'secret://providers/vault/operator-session'
-    )
-    expect(screen.getByLabelText(/Token env handle/i)).toHaveValue(
-      'VAULT_TOKEN via broker-managed env ref'
-    )
-    expect(screen.getByLabelText(/Namespace/i)).toHaveValue('providers/vault/*')
+      screen.queryByText(/HashiCorp Vault \/ OpenBao provider/i)
+    ).toBeNull()
     expect(
-      screen.getByText(/Metadata-only Vault\/OpenBao status check/i)
-    ).toBeVisible()
+      screen.queryByText(/secret:\/\/providers\/vault\/payments\/STRIPE_KEY/i)
+    ).toBeNull()
 
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
@@ -512,32 +464,8 @@ describe('Secrets Broker overview dashboard', () => {
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 
-  it('renders AWS Secrets Manager provider configuration metadata safely', async () => {
-    const user = userEvent.setup()
+  it('keeps AWS Secrets Manager addable metadata safe but off the table page', async () => {
     await renderRoute('/secrets-broker/sources')
-
-    expect(
-      screen.getAllByText(/AWS Secrets Manager CLI provider/i)[0]
-    ).toBeVisible()
-    expect(screen.getByText(/AWS configuration metadata/i)).toBeVisible()
-    expect(screen.getAllByText(/auth_required/i)[0]).toBeVisible()
-    expect(
-      screen.getByText(/configure_region_profile_token_env/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(
-        /region, account\/profile, token-env handle, endpoint override/i
-      )
-    ).toBeVisible()
-    expect(
-      screen.getByText(/secret:\/\/providers\/aws\/default\/backup-worker/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(/\/service-lasso\/payments\/signing/i)
-    ).toBeVisible()
-    expect(screen.getByText(/AWS auth reference required/i)).toBeVisible()
-    expect(screen.getAllByText(/IAM metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/no raw AWS output/i)).toBeVisible()
 
     const awsProvider = secretsBrokerSourceBackends.find(
       (source) => source.id === 'aws-secrets-manager-cli'
@@ -559,32 +487,10 @@ describe('Secrets Broker overview dashboard', () => {
       ])
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /Configure AWS Secrets Manager/i })
-    )
+    expect(screen.queryByText(/AWS Secrets Manager CLI provider/i)).toBeNull()
     expect(
-      screen.getByRole('dialog', { name: /Configure AWS Secrets Manager/i })
-    ).toBeVisible()
-    expect(screen.getByLabelText(/^Region$/i)).toHaveValue('ap-southeast-2')
-    expect(screen.getByLabelText(/Account \/ profile/i)).toHaveValue(
-      'service-lasso-ops profile metadata'
-    )
-    expect(screen.getByLabelText(/Token env handle/i)).toHaveValue(
-      'AWS_SESSION_TOKEN presence check only'
-    )
-    expect(screen.getByLabelText(/Endpoint override/i)).toHaveValue(
-      'http://127.0.0.1:4566 for tests'
-    )
-    expect(screen.getByLabelText(/Secret id mapping/i)).toHaveValue(
-      '/service-lasso/{service}/{ref}'
-    )
-    expect(screen.getByLabelText(/Path \/ field mapping/i)).toHaveValue(
-      'JSON field selector metadata only'
-    )
-    expect(screen.getByLabelText(/Namespace ownership/i)).toHaveValue(
-      'providers/aws/*'
-    )
-    expect(screen.getByText(/Metadata-only AWS CLI probe/i)).toBeVisible()
+      screen.queryByText(/secret:\/\/providers\/aws\/default\/backup-worker/i)
+    ).toBeNull()
 
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
@@ -593,29 +499,8 @@ describe('Secrets Broker overview dashboard', () => {
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 
-  it('renders 1Password CLI provider configuration metadata safely', async () => {
-    const user = userEvent.setup()
+  it('keeps 1Password CLI addable metadata safe but off the table page', async () => {
     await renderRoute('/secrets-broker/sources')
-
-    expect(screen.getByText(/1Password CLI provider/i)).toBeVisible()
-    expect(screen.getByText(/Safe configuration metadata/i)).toBeVisible()
-    expect(screen.getAllByText(/auth_required/i)[0]).toBeVisible()
-    expect(screen.getByText(/sign_in_and_map_item_fields/i)).toBeVisible()
-    expect(
-      screen.getByText(
-        /vault, account, item, field, command-path, auth, namespace/i
-      )
-    ).toBeVisible()
-    expect(
-      screen.getByText(
-        /secret:\/\/providers\/onepassword\/default\/OPENCLAW_API_KEY/i
-      )
-    ).toBeVisible()
-    expect(screen.getByText(/OpenClaw \/ API key/i)).toBeVisible()
-    expect(screen.getByText(/Release \/ signing key/i)).toBeVisible()
-    expect(screen.getAllByText(/^sign-in required$/i)[0]).toBeVisible()
-    expect(screen.getAllByText(/audit metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/no raw CLI output/i)).toBeVisible()
 
     const onePasswordProvider = secretsBrokerSourceBackends.find(
       (source) => source.id === 'onepassword-cli'
@@ -631,59 +516,19 @@ describe('Secrets Broker overview dashboard', () => {
       'edit-configuration'
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /Configure 1Password CLI/i })
-    )
+    expect(screen.queryByText(/1Password CLI provider/i)).toBeNull()
     expect(
-      screen.getByRole('dialog', { name: /Configure 1Password CLI/i })
-    ).toBeVisible()
-    expect(screen.getByLabelText(/Account context/i)).toHaveValue(
-      'service-lasso.1password.com'
-    )
-    expect(screen.getByLabelText(/CLI command path/i)).toHaveValue('op')
-    expect(screen.getByLabelText(/Trusted command dirs/i)).toHaveValue(
-      'C:/Program Files/1Password CLI'
-    )
-    expect(screen.getByLabelText(/Auth state/i)).toHaveValue(
-      'operator sign-in required'
-    )
-    expect(screen.getByLabelText(/Credential handle/i)).toHaveValue(
-      'secret://providers/onepassword/cli-session'
-    )
-    expect(screen.getByText(/Metadata-only CLI status check/i)).toBeVisible()
+      screen.queryByText(
+        /secret:\/\/providers\/onepassword\/default\/OPENCLAW_API_KEY/i
+      )
+    ).toBeNull()
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 
-  it('renders Bitwarden BWS provider configuration metadata safely', async () => {
-    const user = userEvent.setup()
+  it('keeps Bitwarden BWS addable metadata safe but off the table page', async () => {
     await renderRoute('/secrets-broker/sources')
-
-    expect(
-      screen.getAllByText(/Bitwarden \/ BWS CLI provider/i)[0]
-    ).toBeVisible()
-    expect(screen.getByText(/Safe BWS configuration metadata/i)).toBeVisible()
-    expect(screen.getAllByText(/auth_required/i)[0]).toBeVisible()
-    expect(
-      screen.getByText(/add_bws_project_mappings_and_token_ref/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(
-        /project, source, token-reference, secret mapping, selector/i
-      )
-    ).toBeVisible()
-    expect(
-      screen.getByText(
-        /secret:\/\/providers\/bitwarden\/default\/OPENCLAW_API_KEY/i
-      )
-    ).toBeVisible()
-    expect(
-      screen.getByText(/bws:\/\/project\/service-lasso\/openclaw-api-key/i)
-    ).toBeVisible()
-    expect(screen.getByText(/BWS token reference required/i)).toBeVisible()
-    expect(screen.getAllByText(/audit metadata only/i)[0]).toBeVisible()
-    expect(screen.getByText(/no raw BWS output/i)).toBeVisible()
 
     const bitwardenProvider = secretsBrokerSourceBackends.find(
       (source) => source.id === 'bitwarden-bws-cli'
@@ -705,24 +550,12 @@ describe('Secrets Broker overview dashboard', () => {
       ])
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /Configure Bitwarden BWS/i })
-    )
+    expect(screen.queryByText(/Bitwarden \/ BWS CLI provider/i)).toBeNull()
     expect(
-      screen.getByRole('dialog', { name: /Configure Bitwarden BWS/i })
-    ).toBeVisible()
-    expect(screen.getByLabelText(/Project id/i)).toHaveValue(
-      'service-lasso-platform'
-    )
-    expect(screen.getByLabelText(/Source id/i)).toHaveValue('bitwarden-bws-cli')
-    expect(screen.getByLabelText(/CLI command path/i)).toHaveValue('bws')
-    expect(screen.getByLabelText(/Token reference/i)).toHaveValue(
-      'secret://providers/bitwarden/bws-access-token'
-    )
-    expect(screen.getByLabelText(/Secret selector/i)).toHaveValue(
-      'value metadata only'
-    )
-    expect(screen.getByText(/Metadata-only BWS project/i)).toBeVisible()
+      screen.queryByText(
+        /secret:\/\/providers\/bitwarden\/default\/OPENCLAW_API_KEY/i
+      )
+    ).toBeNull()
 
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
@@ -730,32 +563,8 @@ describe('Secrets Broker overview dashboard', () => {
     assertNoSecretMaterial(collectBrowserLeakSurfaces())
   })
 
-  it('renders mounted secrets provider configuration metadata safely', async () => {
-    const user = userEvent.setup()
+  it('keeps mounted secrets addable metadata safe but off the table page', async () => {
     await renderRoute('/secrets-broker/sources')
-
-    expect(
-      screen.getAllByText(/Docker\/Kubernetes mounted secrets/i)[0]
-    ).toBeVisible()
-    expect(
-      screen.getByText(/Mounted file configuration metadata/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(
-        /mount root, allowed paths, symlink policy, file mappings/i
-      )
-    ).toBeVisible()
-    expect(
-      screen.getByText(/configure_mount_root_allowed_paths/i)
-    ).toBeVisible()
-    expect(
-      screen.getByText(/mounted:\/\/run-secrets\/postgres-password/i)
-    ).toBeVisible()
-    expect(screen.getByText('/run/secrets/postgres-password')).toBeVisible()
-    expect(screen.getByText(/services\/@serviceadmin\/runtime/i)).toBeVisible()
-    expect(screen.getAllByText(/symlink check passed/i)[0]).toBeVisible()
-    expect(screen.getByText(/path metadata only/i)).toBeVisible()
-    expect(screen.getByText(/no file contents/i)).toBeVisible()
 
     const mountedProvider = secretsBrokerSourceBackends.find(
       (source) => source.id === 'mounted-secrets'
@@ -777,19 +586,10 @@ describe('Secrets Broker overview dashboard', () => {
       ])
     )
 
-    await user.click(
-      screen.getByRole('button', { name: /Configure mounted secrets/i })
-    )
+    expect(screen.queryByText(/Docker\/Kubernetes mounted secrets/i)).toBeNull()
     expect(
-      screen.getByRole('dialog', { name: /Configure mounted secrets/i })
-    ).toBeVisible()
-    expect(screen.getByLabelText(/Root path/i)).toHaveValue('/run/secrets')
-    expect(screen.getByLabelText(/Allowed paths/i)).toHaveValue(
-      '/run/secrets/postgres-password, /run/secrets/serviceadmin-session'
-    )
-    expect(screen.getByLabelText(/Follow symlinks/i)).toHaveValue('false')
-    expect(screen.getByLabelText(/Max bytes per file/i)).toHaveValue('4096')
-    expect(screen.getByText(/Metadata-only path existence/i)).toBeVisible()
+      screen.queryByText(/mounted:\/\/run-secrets\/postgres-password/i)
+    ).toBeNull()
 
     expect(screen.queryByText(/fixture-provider-credential-value/i)).toBeNull()
     expect(screen.queryByText(/correct-horse-battery-staple/i)).toBeNull()
@@ -847,8 +647,9 @@ describe('Secrets Broker overview dashboard', () => {
     })
 
     expect(
-      screen.getByRole('button', { name: /Add AWS Secrets Manager CLI/i })
+      screen.getByRole('button', { name: /^Add provider$/i })
     ).toBeVisible()
+    expect(screen.queryByText(/AWS Secrets Manager CLI/i)).toBeNull()
   })
 
   it('keeps source backend fixtures free of secret values', () => {
@@ -1362,16 +1163,18 @@ describe('Secrets Broker overview dashboard', () => {
     ).toBe(true)
   })
 
-  it('shows provider refs and warnings on the dedicated providers page', async () => {
+  it('keeps provider refs and warning detail off the focused providers table', async () => {
     await renderRoute('/secrets-broker/sources')
 
     expect(
-      screen.getByText(/secret:\/\/providers\/vault\/payments\/STRIPE_KEY/i)
-    ).toBeVisible()
+      screen.queryByText(/secret:\/\/providers\/vault\/payments\/STRIPE_KEY/i)
+    ).not.toBeInTheDocument()
     expect(
-      screen.getByText(/secret:\/\/providers\/aws\/default\/backup-worker/i)
-    ).toBeVisible()
-    expect(screen.getByText(/Sealed, locked, auth_required/i)).toBeVisible()
+      screen.queryByText(/secret:\/\/providers\/aws\/default\/backup-worker/i)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Sealed, locked, auth_required/i)
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText(/fixture-provider-credential-value/i)
     ).not.toBeInTheDocument()


### PR DESCRIPTION
## Issue
Closes #238

## Summary
- Replaces the cluttered Secrets Broker Providers page with one focused enabled-provider table.
- Moves provider row workflows behind a compact Actions menu so the table stays scannable.
- Removes addable-provider/detail sections from the page and updates tests to prevent those filler sections from returning.

## Scope
- In scope: `/secrets-broker/sources` Providers page layout, table controls, row actions, and route tests.
- Out of scope: wiring Add provider or row actions to live backend mutations; existing controls remain UI-level affordances pending backend workflow integration.

## Spec / contract / fixture impact
- Updated: UI tests for the Providers page table-only contract.
- Not required: no backend API/schema/manifest change.

## Nash invariant impact
- Invariant: provider credentials and secret values must not render on provider management surfaces.
- Preservation proof: route tests assert removed provider refs/details are not rendered; existing source fixture leak test remains green.

## Validation
- PASS `npm run test -- src/features/secrets-broker/secrets-broker-setup.test.tsx` — `.work-agent/logs/issue-238/vitest-secrets-broker-setup.log`, 40 passed.
- PASS `npm run lint` — `.work-agent/logs/issue-238/npm-lint.log`.
- PASS `npm run build` — `.work-agent/logs/issue-238/npm-build.log`.
- PASS Playwright screenshot smoke against local preview `http://127.0.0.1:17701/secrets-broker/sources` — `.work-agent/logs/issue-238/playwright-screenshot.log`, screenshot `.work-agent/logs/issue-238/providers-page-desktop.png`.
- PASS canonical pre/post health: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` returned `status: ok`.

## Demo / release gate
- PR is not merged/released in this run, so the mandatory release-to-demo pin gate is not applicable yet.
- If this PR is merged/released, the canonical demo must consume the resulting Service Admin release/commit and be recycled/verified before the issue is closed.

## Approval trail
- Required: yes, normal PR review/merge checks before demo release.
- Evidence: this PR and issue comment trail.

## Cleanup
- Branch: `issue-238-simplify-providers` pushed.
- Local preview process stopped after screenshot smoke.
