### PR TITLE
feat(secrets): expose single-secret gate evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -605,8 +605,8 @@ export function SecretsManagementPage() {
           </Card>
           <Card>
             <CardHeader className='pb-2'>
-              <CardDescription>Dry-run actions</CardDescription>
-              <CardTitle className='text-3xl'>4</CardTitle>
+              <CardDescription>Preview actions</CardDescription>
+              <CardTitle className='text-3xl'>5</CardTitle>
             </CardHeader>
           </Card>
           <Card>
@@ -1389,6 +1389,37 @@ export function SecretsManagementPage() {
                     </Badge>
                   ))}
                 </div>
+              </div>
+            </div>
+            <div className='grid gap-3 md:grid-cols-2'>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Immediate revalidation checks
+                </div>
+                <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                  {singleOperationPlan.revalidationChecks.map((check) => (
+                    <li key={check}>{check}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className='rounded-md border p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Submit blockers
+                </div>
+                {singleOperationPlan.blockers.length > 0 ? (
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleOperationPlan.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <div className='mt-2 text-muted-foreground'>
+                    No blockers after audit reason, confirmation, capability,
+                    policy, and broker-state checks pass.
+                  </div>
+                )}
               </div>
             </div>
             <div className='flex flex-wrap gap-2'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -49,6 +49,8 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Find a ref/i)).toBeVisible()
     expect(screen.getByText(/Pick row action/i)).toBeVisible()
     expect(screen.getByText(/Dry-run before apply/i)).toBeVisible()
+    expect(screen.getByText(/Preview actions/i)).toBeVisible()
+    expect(screen.getAllByText(/^5$/)[0]).toBeVisible()
     expect(screen.getByText(/Visible values/i)).toBeVisible()
     expect(screen.getByText(/Stub preview · values hidden/i)).toBeVisible()
     expect(screen.getByText(/Single-secret preview gate/i)).toBeVisible()
@@ -566,7 +568,9 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/delete preview required before apply/i)
     ).toBeVisible()
-    expect(screen.getByText(/recovery guidance/i)).toBeVisible()
+    expect(screen.getAllByText(/recovery guidance/i)[0]).toBeVisible()
+    expect(screen.getByText(/dependent service references/i)).toBeVisible()
+    expect(screen.getByText(/recoveryPlanRef/i)).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Apply policy preview/i })[0]
@@ -577,6 +581,10 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getAllByText(/policy preview required before apply/i)[0]
     ).toBeVisible()
+    expect(
+      screen.getByText(/target policy assignment diff checked/i)
+    ).toBeVisible()
+    expect(screen.getByText(/targetPolicyRef/i)).toBeVisible()
     expect(
       screen.getByRole('button', {
         name: /Apply disabled until dry-run preview is accepted/i,
@@ -728,6 +736,39 @@ describe('Secrets Broker secrets management page', () => {
     expect(missingDeletePlan.canSubmit).toBe(false)
     expect(missingDeletePlan.blockers).toContain('ref unavailable')
     expect(missingDeletePlan.blockers).toContain('delete dry-run unsupported')
+    expect(missingDeletePlan.safePayloadFields).toEqual(
+      expect.arrayContaining(['recoveryPlanRef', 'dependentServiceRefs'])
+    )
+    expect(missingDeletePlan.revalidationChecks).toEqual(
+      expect.arrayContaining([
+        'dependent service references and recovery guidance checked',
+      ])
+    )
+
+    const singlePolicyPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[0],
+      'policy',
+      'operator requested policy assignment preview',
+      true,
+      'ready'
+    )
+    expect(singlePolicyPlan.safePayloadFields).toEqual(
+      expect.arrayContaining(['targetPolicyRef', 'policyDiffMetadata'])
+    )
+    expect(singlePolicyPlan.revalidationChecks).toEqual(
+      expect.arrayContaining([
+        'target policy assignment diff checked as metadata only',
+      ])
+    )
+    const policyResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      singlePolicyPlan
+    )
+    expect(policyResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'policy change carries target policy metadata only',
+      ])
+    )
 
     const bulkPlan = buildBulkSecretCampaignPlan(
       managedSecretRows,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -51,6 +51,7 @@ export type SingleSecretOperationPlan = {
   applyGate: string
   blockers: string[]
   safePayloadFields: string[]
+  revalidationChecks: string[]
   canSubmit: boolean
 }
 
@@ -1167,6 +1168,61 @@ function safeOperationSlug(action: ManagedSecretAction, row: ManagedSecretRow) {
     .replace(/^-+|-+$/g, '')
 }
 
+function safePayloadFieldsForSingleSecretAction(action: ManagedSecretAction) {
+  const baseFields = [
+    'ref',
+    'operationId',
+    'action',
+    'owningService',
+    'provider',
+    'policy',
+    'auditReasonMetadata',
+  ]
+
+  switch (action) {
+    case 'reveal':
+      return [...baseFields, 'revealChallengeId']
+    case 'edit':
+      return [...baseFields, 'metadataDiff']
+    case 'reset':
+      return [...baseFields, 'rotationReason']
+    case 'delete':
+      return [...baseFields, 'recoveryPlanRef', 'dependentServiceRefs']
+    case 'policy':
+      return [...baseFields, 'targetPolicyRef', 'policyDiffMetadata']
+    case 'metadata':
+    default:
+      return ['ref', 'operationId', 'action', 'owningService', 'provider']
+  }
+}
+
+function revalidationChecksForSingleSecretAction(
+  action: ManagedSecretAction,
+  requirement: string
+) {
+  if (action === 'metadata') {
+    return ['metadata view does not revalidate a mutation']
+  }
+
+  const checks = [
+    `${requirement} broker capability rechecked immediately before submit`,
+    'policy decision rechecked immediately before submit',
+    'audit writer availability required before submit',
+  ]
+
+  if (action === 'delete') {
+    checks.push('dependent service references and recovery guidance checked')
+  }
+  if (action === 'policy') {
+    checks.push('target policy assignment diff checked as metadata only')
+  }
+  if (action === 'reset') {
+    checks.push('rotation can submit without controlled reveal')
+  }
+
+  return checks
+}
+
 export function buildSingleSecretOperationPlan(
   row: ManagedSecretRow,
   action: ManagedSecretAction,
@@ -1238,15 +1294,11 @@ export function buildSingleSecretOperationPlan(
         ? 'metadata view only'
         : (blockers[0] ?? 'operation blocked'),
     blockers,
-    safePayloadFields: [
-      'ref',
-      'operationId',
-      'action',
-      'owningService',
-      'provider',
-      'policy',
-      'auditReasonMetadata',
-    ],
+    safePayloadFields: safePayloadFieldsForSingleSecretAction(action),
+    revalidationChecks: revalidationChecksForSingleSecretAction(
+      action,
+      requirement
+    ),
     canSubmit,
   }
 }
@@ -1279,7 +1331,11 @@ export function buildSingleSecretOperationResult(
       'request body is limited to ref, operation id, action, owner, provider, policy, and audit reason metadata',
       plan.action === 'reset'
         ? 'rotation can be requested without controlled reveal'
-        : 'operator action used the selected dry-run gate',
+        : plan.action === 'delete'
+          ? 'delete/decommission remains broker-owned and recovery-guided; current value was not read'
+          : plan.action === 'policy'
+            ? 'policy change carries target policy metadata only'
+            : 'operator action used the selected dry-run gate',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction:

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -139,6 +139,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Find a ref/i)).toBeVisible()
     await expect(page.getByText(/Pick row action/i)).toBeVisible()
     await expect(page.getByText(/Dry-run before apply/i)).toBeVisible()
+    await expect(page.getByText(/Preview actions/i)).toBeVisible()
     await expect(page.getByText(/Stub preview · values hidden/i)).toBeVisible()
     await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
     await expect(page.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
@@ -186,6 +187,18 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/delete preview required before apply/i)
     ).toBeVisible()
+    await expect(
+      page.getByText(/dependent service references and recovery guidance/i)
+    ).toBeVisible()
+    await expect(page.getByText(/recoveryPlanRef/i)).toBeVisible()
+    await page
+      .getByRole('button', { name: /Apply policy preview/i })
+      .first()
+      .click()
+    await expect(
+      page.getByText(/target policy assignment diff checked/i)
+    ).toBeVisible()
+    await expect(page.getByText(/targetPolicyRef/i)).toBeVisible()
 
     await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds explicit single-secret dry-run gate evidence for action-specific safe payload fields.
- Shows immediate revalidation checks and submit blockers on the Secrets page.
- Covers delete recovery references and policy target metadata without exposing raw values.

## Scope
- In scope: Service Admin Secrets Broker > Secrets single-secret preview/gate model, UI, and tests.
- Out of scope: production broker mutation API wiring, full #231 completion, release/demo pin/recycle after merge.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin UI/model fixture for single-secret dry-run gate evidence.
- Not required because: no external API/schema contract changed; backend endpoints remain represented as stub/dry-run operation metadata.

## Nash invariant impact
- Invariant: Service Admin must not render, route, log, export, store, or diagnose raw secret values/provider credentials.
- Preservation proof: action-specific payload fields are metadata handles only (`recoveryPlanRef`, `dependentServiceRefs`, `targetPolicyRef`, `policyDiffMetadata`); tests assert forbidden material is absent.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-management-single-gate.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table"` — `.work-agent/logs/issue-231/playwright-secrets-single-gate.log` (1 passed)
- PASS `npm run build` — `.work-agent/logs/issue-231/build-single-secret-gate.log`
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-single-gate.log`
- PASS canonical demo preflight after push: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` status `ok`.

## Approval trail
- Required: no special approval rule found for this focused UI/test advancement.
- Evidence: PR is intentionally `Refs #231`, not closing the broader issue.

## Cleanup
- Branch: `agent/issue-231-single-secret-gate`
- Post-merge plan: release lasso-serviceadmin, update the core `@serviceadmin` demo pin, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, then clean local/remote branches when safe.