### PR TITLE
feat(secrets): add single-secret operation history

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -61,6 +61,7 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionPreview,
+  buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -77,6 +78,7 @@ import {
   type ManagedSecretAction,
   type ManagedSecretRow,
   type ManagedSecretState,
+  type SingleSecretOperationHistoryEntry,
   type SingleSecretOperationResult,
   type StubSecretMutationState,
 } from './secrets-management'
@@ -116,6 +118,9 @@ export function SecretsManagementPage() {
   const [confirmed, setConfirmed] = useState(false)
   const [singleApplyResult, setSingleApplyResult] =
     useState<SingleSecretOperationResult | null>(null)
+  const [singleOperationHistory, setSingleOperationHistory] = useState<
+    SingleSecretOperationHistoryEntry[]
+  >([])
   const [bulkSelectedIds, setBulkSelectedIds] = useState<string[]>([
     managedSecretRows[0].id,
     managedSecretRows[1].id,
@@ -240,9 +245,19 @@ export function SecretsManagementPage() {
   }
 
   function applySingleSecretOperation() {
-    setSingleApplyResult(
-      buildSingleSecretOperationResult(selectedRow, singleOperationPlan)
+    const result = buildSingleSecretOperationResult(
+      selectedRow,
+      singleOperationPlan
     )
+    setSingleApplyResult(result)
+    setSingleOperationHistory((current) => [
+      buildSingleSecretOperationHistoryEntry(
+        selectedRow,
+        singleOperationPlan,
+        current.length + 1
+      ),
+      ...current,
+    ])
     setStubState('success')
   }
 
@@ -1610,6 +1625,71 @@ export function SecretsManagementPage() {
                 </ul>
               </div>
             ) : null}
+
+            <div className='rounded-lg border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <ListChecks className='size-4 text-primary' />
+                <div className='font-medium'>
+                  Single-secret operation history
+                </div>
+                <Badge variant='secondary'>Metadata only</Badge>
+                <Badge variant='outline'>
+                  {singleOperationHistory.length} submitted
+                </Badge>
+              </div>
+              {singleOperationHistory.length > 0 ? (
+                <div className='overflow-x-auto rounded-md border'>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Ref</TableHead>
+                        <TableHead>Action / status</TableHead>
+                        <TableHead>Audit event</TableHead>
+                        <TableHead>Next action</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {singleOperationHistory.map((entry) => (
+                        <TableRow key={entry.auditEventId}>
+                          <TableCell className='min-w-72 align-top'>
+                            <div className='font-medium'>{entry.rowName}</div>
+                            <div className='text-sm break-all text-muted-foreground'>
+                              {entry.ref}
+                            </div>
+                            <div className='mt-2 text-xs text-muted-foreground'>
+                              {entry.provider}
+                            </div>
+                          </TableCell>
+                          <TableCell className='min-w-44 align-top'>
+                            <Badge variant='outline'>{entry.action}</Badge>
+                            <div className='mt-2'>{entry.statusBadge}</div>
+                            <div className='text-xs text-muted-foreground'>
+                              {entry.submittedAt}
+                            </div>
+                          </TableCell>
+                          <TableCell className='min-w-72 align-top'>
+                            <div className='break-all'>
+                              {entry.auditEventId}
+                            </div>
+                            <div className='mt-2 text-xs break-all text-muted-foreground'>
+                              {entry.policy}
+                            </div>
+                          </TableCell>
+                          <TableCell className='min-w-64 align-top'>
+                            {entry.nextAction}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ) : (
+                <div className='rounded-md border bg-muted/40 p-3 text-muted-foreground'>
+                  No submitted stub operations yet. History will list refs,
+                  operation ids, audit event ids, and next actions only.
+                </div>
+              )}
+            </div>
 
             <div className='flex flex-wrap gap-2'>
               <Button

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -6,6 +6,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -14,6 +15,7 @@ import {
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
+  managedSecretSingleHistoryHasSecretMaterial,
   managedSecretsHaveSecretMaterial,
   valueSearchManagedSecrets,
 } from './secrets-management'
@@ -55,6 +57,8 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Stub preview · values hidden/i)).toBeVisible()
     expect(screen.getByText(/Single-secret preview gate/i)).toBeVisible()
     expect(screen.getAllByText(/Stub API · preview only/i)[0]).toBeVisible()
+    expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
+    expect(screen.getByText(/0 submitted/i)).toBeVisible()
     expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
     expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
     expect(screen.getAllByText(/Controlled reveal/i)[0]).toBeVisible()
@@ -554,6 +558,10 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/Single-secret operation result: submitted/i)
     ).toBeVisible()
+    expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
+    expect(screen.getByText(/1 submitted/i)).toBeVisible()
+    expect(screen.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
+    expect(screen.getByText(/submitted to stub broker/i)).toBeVisible()
     expect(screen.getByText(/raw value was not revealed/i)).toBeVisible()
     expect(
       screen.getByText(/rotation can be requested without controlled reveal/i)
@@ -724,6 +732,22 @@ describe('Secrets Broker secrets management page', () => {
         'raw value was not revealed',
         'rotation can be requested without controlled reveal',
       ])
+    )
+    const historyEntry = buildSingleSecretOperationHistoryEntry(
+      managedSecretRows[0],
+      rotatePlan,
+      1
+    )
+    expect(historyEntry).toMatchObject({
+      operationId: rotatePlan.operationId,
+      rowName: 'SESSION_SIGNING_KEY',
+      provider: 'local encrypted store',
+      auditEventId: 'audit-reset-serviceadmin-session-signing-1',
+      statusBadge: 'submitted to stub broker',
+      submittedAt: 'stub-sequence-1',
+    })
+    expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(
+      false
     )
 
     const missingDeletePlan = buildSingleSecretOperationPlan(

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -67,6 +67,15 @@ export type SingleSecretOperationResult = {
   nextAction: string
 }
 
+export type SingleSecretOperationHistoryEntry = SingleSecretOperationResult & {
+  rowName: string
+  provider: string
+  policy: string
+  auditEventId: string
+  statusBadge: string
+  submittedAt: string
+}
+
 export type StubSecretMutationState =
   | 'ready'
   | 'denied'
@@ -357,6 +366,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:action-preview',
     'secrets-management:stub-mutation-preview',
     'secrets-management:stub-mutation-apply-status',
+    'secrets-management:single-secret-operation-history',
     'secrets-management:stub-delete-preview',
     'secrets-management:bulk-campaign-dry-run',
     'secrets-management:bulk-campaign-apply',
@@ -1345,6 +1355,25 @@ export function buildSingleSecretOperationResult(
   }
 }
 
+export function buildSingleSecretOperationHistoryEntry(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  sequence: number
+): SingleSecretOperationHistoryEntry {
+  const result = buildSingleSecretOperationResult(row, plan)
+  const safeSequence = Math.max(1, sequence)
+
+  return {
+    ...result,
+    rowName: row.name,
+    provider: row.provider,
+    policy: row.policy,
+    auditEventId: `audit-${safeOperationSlug(plan.action, row)}-${safeSequence}`,
+    statusBadge: 'submitted to stub broker',
+    submittedAt: `stub-sequence-${safeSequence}`,
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -1366,4 +1395,10 @@ export function managedSecretBulkApplyResultHasSecretMaterial(
   result: BulkSecretCampaignApplyResult
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(result))
+}
+
+export function managedSecretSingleHistoryHasSecretMaterial(
+  entries: SingleSecretOperationHistoryEntry[]
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(entries))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -201,6 +201,10 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/targetPolicyRef/i)).toBeVisible()
 
     await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
+    await expect(
+      page.getByText(/Single-secret operation history/i)
+    ).toBeVisible()
+    await expect(page.getByText(/0 submitted/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Simulate stub apply/i })
@@ -247,6 +251,9 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/Single-secret operation result: submitted/i)
     ).toBeVisible()
+    await expect(page.getByText(/1 submitted/i)).toBeVisible()
+    await expect(page.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
+    await expect(page.getByText(/submitted to stub broker/i)).toBeVisible()
     await expect(page.getByText(/raw value was not revealed/i)).toBeVisible()
     await expect(
       page.getByText(/rotation can be requested without controlled reveal/i)


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a deterministic metadata-only history model for submitted single-secret stub operations.
- Show a Secrets page operation history table with ref, provider, action/status, audit event id, policy, and next action after simulated single-secret submissions.
- Cover the history helper and UI with unit and browser assertions, including no-secret-material checks.

## Scope
- In scope: Service Admin Secrets Broker > Secrets single-secret operation feedback for the current stub preview/apply workflow.
- Out of scope: production Secrets Broker mutation API wiring, raw reveal, plaintext editing, export/copy, and full #231 closure.

## Spec / contract / fixture impact
- Updated: deterministic UI fixture/model only in `src/features/secrets-broker/secrets-management.ts`.
- Not required because no public backend API, route, schema, release manifest, or lifecycle contract changed.

## Nash invariant impact
- Invariant: raw values, provider credentials, tokens, cookies, private keys, recovery material, and raw env values must not render or persist.
- Preservation proof: history entries contain refs, provider, policy, operation/audit IDs, status, and next action only; tests assert no forbidden secret material and no `DEMO_REVEAL_VALUE_42` render.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-operation-history.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-operation-history.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-operation-history.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-operation-history.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-operation-history.log`
- PASS preflight canonical demo health before work: Service Admin HTTP 200; runtime `/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: not known for this focused UI/test advancement; awaiting repository checks/review.
- Evidence: PR opened from `agent/issue-231-operation-history`.

## Cleanup
- Branch will be deleted after merge.
- Release-to-demo gate applies after merge/release because Service Admin is demo-consumed; this PR does not claim #231 complete until release, core pin, canonical recycle, and `npm run demo:verify-canonical` complete.
