### PR TITLE
feat(secrets): show action readiness by row

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -61,6 +61,7 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionPreview,
+  buildManagedSecretActionReadiness,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
@@ -105,6 +106,17 @@ const providerOptions = Array.from(
 )
   .sort()
   .map((provider) => ({ label: provider, value: provider }))
+
+const actionButtonLabels: Record<
+  Exclude<ManagedSecretAction, 'metadata'>,
+  string
+> = {
+  reveal: 'Controlled reveal',
+  edit: 'Edit/update dry-run',
+  reset: 'Reset/rotate dry-run',
+  delete: 'Delete dry-run',
+  policy: 'Apply policy preview',
+}
 
 export function SecretsManagementPage() {
   const stubModeEnabled = isServiceAdminStubModeEnabled()
@@ -167,6 +179,10 @@ export function SecretsManagementPage() {
     selectedRow,
     selectedAction
   )
+  const selectedActionReadiness = buildManagedSecretActionReadiness(selectedRow)
+  const selectedActionReadinessDetail =
+    selectedActionReadiness.find((item) => item.action === selectedAction) ??
+    null
   const stubMutationPreview = buildStubSecretMutationPreview(
     selectedRow,
     selectedAction === 'metadata' || selectedAction === 'policy'
@@ -375,58 +391,50 @@ export function SecretsManagementPage() {
       {
         id: 'actions',
         header: 'Actions',
-        cell: ({ row }) => (
-          <div className='flex min-w-72 flex-wrap gap-2 align-top'>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'metadata')}
-            >
-              View metadata
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'reveal')}
-            >
-              Controlled reveal
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'edit')}
-            >
-              Edit/update dry-run
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'reset')}
-            >
-              Reset/rotate dry-run
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'delete')}
-            >
-              Delete dry-run
-            </Button>
-            <Button
-              type='button'
-              size='sm'
-              variant='outline'
-              onClick={() => chooseAction(row.original.id, 'policy')}
-            >
-              Apply policy preview
-            </Button>
-          </div>
-        ),
+        cell: ({ row }) => {
+          const readiness = buildManagedSecretActionReadiness(row.original)
+          const readyCount = readiness.filter((item) => item.canPreview).length
+
+          return (
+            <div className='min-w-80 space-y-3 align-top'>
+              <div className='text-xs text-muted-foreground'>
+                Readiness: {readyCount} ready / {readiness.length - readyCount}{' '}
+                blocked
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                <Button
+                  type='button'
+                  size='sm'
+                  variant='outline'
+                  onClick={() => chooseAction(row.original.id, 'metadata')}
+                >
+                  View metadata
+                </Button>
+                {readiness.map((item) => (
+                  <Button
+                    key={item.action}
+                    type='button'
+                    size='sm'
+                    variant={item.canPreview ? 'outline' : 'secondary'}
+                    onClick={() => chooseAction(row.original.id, item.action)}
+                  >
+                    {actionButtonLabels[item.action]}
+                  </Button>
+                ))}
+              </div>
+              <div className='flex flex-wrap gap-1'>
+                {readiness.map((item) => (
+                  <Badge
+                    key={`${item.action}-${item.status}`}
+                    variant={item.canPreview ? 'outline' : 'secondary'}
+                  >
+                    {item.label}: {item.badge}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )
+        },
         enableSorting: false,
       },
     ],
@@ -1364,6 +1372,56 @@ export function SecretsManagementPage() {
               </div>
               <div>{actionPreview.nextStep}</div>
             </div>
+            {selectedActionReadinessDetail ? (
+              <div className='grid gap-3 rounded-md border p-3 md:grid-cols-3'>
+                <div>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Selected action readiness
+                  </div>
+                  <Badge
+                    className='mt-1'
+                    variant={
+                      selectedActionReadinessDetail.canPreview
+                        ? 'default'
+                        : 'secondary'
+                    }
+                  >
+                    {selectedActionReadinessDetail.badge}
+                  </Badge>
+                  <div className='mt-2 text-muted-foreground'>
+                    {selectedActionReadinessDetail.nextStep}
+                  </div>
+                </div>
+                <div>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Readiness blockers
+                  </div>
+                  {selectedActionReadinessDetail.blockers.length > 0 ? (
+                    <div className='mt-2 flex flex-wrap gap-1'>
+                      {selectedActionReadinessDetail.blockers.map((blocker) => (
+                        <Badge key={blocker} variant='outline'>
+                          {blocker}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className='mt-2 text-muted-foreground'>
+                      No row-level blockers before the dry-run gate.
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Safe readiness checks
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {selectedActionReadinessDetail.safeChecks.map((check) => (
+                      <li key={check}>{check}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ) : null}
             <div className='grid gap-3 rounded-md border p-3 md:grid-cols-3'>
               <div>
                 <div className='text-xs font-medium text-muted-foreground uppercase'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -6,6 +6,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildManagedSecretActionReadiness,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
@@ -13,6 +14,7 @@ import {
   filterManagedSecrets,
   managedSecretBulkApplyResultHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
+  managedSecretActionReadinessHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -59,6 +61,11 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Stub API · preview only/i)[0]).toBeVisible()
     expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
     expect(screen.getByText(/0 submitted/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/Readiness: 5 ready \/ 0 blocked/i)[0]
+    ).toBeVisible()
+    expect(screen.getAllByText(/Reveal: preview ready/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/Delete: preview ready/i)[0]).toBeVisible()
     expect(screen.getAllByText(/SESSION_SIGNING_KEY/i)[0]).toBeVisible()
     expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
     expect(screen.getAllByText(/Controlled reveal/i)[0]).toBeVisible()
@@ -109,6 +116,7 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(screen.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
     expect(screen.getByText(/Metadata matches: 1/i)).toBeVisible()
+    expect(screen.getByText(/Readiness: 0 ready \/ 5 blocked/i)).toBeVisible()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
@@ -598,6 +606,16 @@ describe('Secrets Broker secrets management page', () => {
         name: /Apply disabled until dry-run preview is accepted/i,
       })
     ).toBeDisabled()
+
+    await user.type(
+      screen.getByPlaceholderText(/Search secret metadata/i),
+      'payments'
+    )
+    await user.click(screen.getByRole('button', { name: /Delete dry-run/i }))
+    expect(screen.getByText(/Selected action readiness/i)).toBeVisible()
+    expect(screen.getAllByText(/blocked fail closed/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/ref unavailable/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/delete dry-run unsupported/i)[0]).toBeVisible()
   })
 
   it('covers stub update reset delete reveal preview states and gated apply readiness', async () => {
@@ -749,6 +767,27 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(
       false
     )
+
+    const actionReadiness = buildManagedSecretActionReadiness(
+      managedSecretRows[0]
+    )
+    expect(actionReadiness).toHaveLength(5)
+    expect(actionReadiness.every((item) => item.canPreview)).toBe(true)
+    expect(managedSecretActionReadinessHasSecretMaterial(actionReadiness)).toBe(
+      false
+    )
+
+    const missingActionReadiness = buildManagedSecretActionReadiness(
+      managedSecretRows[3]
+    )
+    expect(missingActionReadiness.every((item) => !item.canPreview)).toBe(true)
+    expect(missingActionReadiness[0].blockers).toContain('ref unavailable')
+    expect(missingActionReadiness[3].blockers).toContain(
+      'delete dry-run unsupported'
+    )
+    expect(
+      managedSecretActionReadinessHasSecretMaterial(missingActionReadiness)
+    ).toBe(false)
 
     const missingDeletePlan = buildSingleSecretOperationPlan(
       managedSecretRows[3],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -40,6 +40,17 @@ export type ManagedSecretActionPreview = {
   requiresConfirmation: boolean
 }
 
+export type ManagedSecretActionReadiness = {
+  action: Exclude<ManagedSecretAction, 'metadata'>
+  label: string
+  status: 'ready' | 'blocked'
+  badge: string
+  blockers: string[]
+  safeChecks: string[]
+  nextStep: string
+  canPreview: boolean
+}
+
 export type SingleSecretOperationPlan = {
   action: ManagedSecretAction
   operationId: string
@@ -1153,6 +1164,80 @@ function capabilityRequirementForAction(action: ManagedSecretAction) {
   }
 }
 
+function managedSecretActionLabel(action: ManagedSecretAction) {
+  switch (action) {
+    case 'reveal':
+      return 'Reveal'
+    case 'edit':
+      return 'Edit'
+    case 'reset':
+      return 'Rotate'
+    case 'delete':
+      return 'Delete'
+    case 'policy':
+      return 'Policy'
+    case 'metadata':
+    default:
+      return 'Metadata'
+  }
+}
+
+export function buildManagedSecretActionReadiness(
+  row: ManagedSecretRow
+): ManagedSecretActionReadiness[] {
+  const actions: Array<Exclude<ManagedSecretAction, 'metadata'>> = [
+    'reveal',
+    'edit',
+    'reset',
+    'delete',
+    'policy',
+  ]
+
+  return actions.map((action) => {
+    const requirement = capabilityRequirementForAction(action)
+    const blockers: string[] = []
+
+    if (row.state === 'missing') {
+      blockers.push('ref unavailable')
+    }
+    if (!row.backendCapability.includes(requirement)) {
+      blockers.push(`${requirement} unsupported`)
+    }
+    if (
+      action !== 'reveal' &&
+      row.policy.includes('readonly') &&
+      !blockers.includes('readonly policy review required')
+    ) {
+      blockers.push('readonly policy review required')
+    }
+    if (
+      row.auditStatus.includes('required before reveal') &&
+      action === 'reveal'
+    ) {
+      blockers.push('fresh audit reason required')
+    }
+
+    const canPreview = blockers.length === 0
+
+    return {
+      action,
+      label: managedSecretActionLabel(action),
+      status: canPreview ? 'ready' : 'blocked',
+      badge: canPreview ? 'preview ready' : 'blocked fail closed',
+      blockers,
+      safeChecks: [
+        `${requirement} capability evaluated from broker metadata`,
+        'policy and audit posture shown before dry-run',
+        'raw value remains hidden from table, route, storage, and diagnostics',
+      ],
+      nextStep: canPreview
+        ? `Open ${managedSecretActionLabel(action).toLowerCase()} dry-run preview with audit reason and confirmation.`
+        : `Resolve ${blockers[0]} before this action can preview.`,
+      canPreview,
+    }
+  })
+}
+
 function endpointForSingleSecretAction(action: ManagedSecretAction) {
   switch (action) {
     case 'reveal':
@@ -1401,4 +1486,10 @@ export function managedSecretSingleHistoryHasSecretMaterial(
   entries: SingleSecretOperationHistoryEntry[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretActionReadinessHasSecretMaterial(
+  readiness: ManagedSecretActionReadiness[]
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(readiness))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -143,10 +143,16 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Stub preview · values hidden/i)).toBeVisible()
     await expect(page.getByText(/SESSION_SIGNING_KEY/i).first()).toBeVisible()
     await expect(page.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
+    await expect(
+      page.getByText(/Readiness: 5 ready \/ 0 blocked/i).first()
+    ).toBeVisible()
 
     await page.getByPlaceholder(/Search secret metadata/i).fill('payments')
     await expect(page.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
     await expect(page.getByText(/Metadata matches: 1/i)).toBeVisible()
+    await expect(
+      page.getByText(/Readiness: 0 ready \/ 5 blocked/i)
+    ).toBeVisible()
 
     await page.getByLabel(/Broker-backed value search/i).fill('session')
     await expect(page.getByText(/Value search unsupported/i)).toBeVisible()
@@ -200,6 +206,20 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/targetPolicyRef/i)).toBeVisible()
 
+    await page.getByPlaceholder(/Search secret metadata/i).fill('payments')
+    await page.getByRole('button', { name: /Delete dry-run/ }).click()
+    await expect(page.getByText(/Selected action readiness/i)).toBeVisible()
+    await expect(page.getByText(/blocked fail closed/i).first()).toBeVisible()
+    await expect(page.getByText(/ref unavailable/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/delete dry-run unsupported/i).first()
+    ).toBeVisible()
+
+    await page.getByPlaceholder(/Search secret metadata/i).fill('')
+    await page
+      .getByRole('button', { name: /Reset\/rotate dry-run/i })
+      .first()
+      .click()
     await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
     await expect(
       page.getByText(/Single-secret operation history/i)


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add metadata-only row-level readiness for reveal, edit, rotate, delete, and policy actions on the Secrets page.
- Surface ready/blocked counts and selected-action blockers before the dry-run submit gate.
- Extend unit and browser coverage for unsupported/missing refs and raw-value leakage guards.

## Scope
- In scope: Service Admin Secrets page readiness modeling/UI and focused tests.
- Out of scope: production Secrets Broker mutation API wiring, full #231 closure, release/demo pinning before this PR merges.

## Spec / contract / fixture impact
- Updated: local Service Admin fixture/model for Secrets action readiness only.
- Not required because: no public backend API/schema/manifest changes.

## Nash invariant impact
- Invariant: Secrets UI remains metadata-only and fail-closed before unsupported or missing-row actions.
- Preservation proof: readiness helper exposes blockers and safe checks only; tests assert no `DEMO_REVEAL_VALUE_42` or forbidden secret material is rendered.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-action-readiness.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table"` — `.work-agent/logs/issue-231/playwright-secrets-action-readiness.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-action-readiness.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-action-readiness.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-action-readiness.log`

## Approval trail
- Required: no documented approval requirement found for this focused UI/test advancement.
- Evidence: branch created from clean `master`; open PR gate was empty before work.

## Cleanup
- Branch cleanup after merge: delete `agent/issue-231-action-readiness` locally/remotely.
- Release-to-demo gate: applicable after merge/release because Service Admin is demo-consumed; do not claim #231 done until a release is pinned into core and canonical demo verifies the exact installed tag.