### PR TITLE
fix(secrets): add single-secret recovery guidance

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1676,6 +1676,29 @@ export function SecretsManagementPage() {
                     {singleApplyResult.nextAction}
                   </div>
                 </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Recovery guidance
+                    </div>
+                    <div className='mt-1'>
+                      {singleApplyResult.recoveryStatus}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      {singleApplyResult.retryPolicy}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Recovery steps
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {singleApplyResult.recoverySteps.map((step) => (
+                        <li key={step}>{step}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
                 <ul className='mt-3 list-disc space-y-1 ps-5 text-muted-foreground'>
                   {singleApplyResult.safetyRows.map((row) => (
                     <li key={row}>{row}</li>
@@ -1703,7 +1726,7 @@ export function SecretsManagementPage() {
                         <TableHead>Ref</TableHead>
                         <TableHead>Action / status</TableHead>
                         <TableHead>Audit event</TableHead>
-                        <TableHead>Next action</TableHead>
+                        <TableHead>Recovery</TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -1734,7 +1757,13 @@ export function SecretsManagementPage() {
                             </div>
                           </TableCell>
                           <TableCell className='min-w-64 align-top'>
-                            {entry.nextAction}
+                            <div>{entry.nextAction}</div>
+                            <div className='mt-2 text-muted-foreground'>
+                              {entry.recoveryStatus}
+                            </div>
+                            <div className='mt-2 text-xs text-muted-foreground'>
+                              {entry.retryPolicy}
+                            </div>
                           </TableCell>
                         </TableRow>
                       ))}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -574,6 +574,13 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/rotation can be requested without controlled reveal/i)
     ).toBeVisible()
+    expect(
+      screen.getAllByText(/rotation retry is operation-id scoped/i)[0]
+    ).toBeVisible()
+    expect(screen.getAllByText(/retry only by operation id/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/track rotation operation id until provider status/i)
+    ).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Delete dry-run/i })[0]
@@ -744,7 +751,17 @@ describe('Secrets Broker secrets management page', () => {
       auditStatus: 'stub audit event recorded with metadata only',
       nextAction:
         'monitor broker rotation outcome and dependent service restart notes',
+      recoveryStatus:
+        'rotation retry is operation-id scoped and provider-owned',
+      retryPolicy:
+        'retry only by operation id when broker marks the attempt retry-safe',
     })
+    expect(rotateResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'track rotation operation id until provider status settles',
+        'retry by operation id when the provider marks the retry safe',
+      ])
+    )
     expect(rotateResult.safetyRows).toEqual(
       expect.arrayContaining([
         'raw value was not revealed',
@@ -830,6 +847,39 @@ describe('Secrets Broker secrets management page', () => {
     expect(policyResult.safetyRows).toEqual(
       expect.arrayContaining([
         'policy change carries target policy metadata only',
+      ])
+    )
+    expect(policyResult).toMatchObject({
+      recoveryStatus: 'policy rollback requires a fresh audited preview',
+      retryPolicy: 'fresh plan required before any retry',
+    })
+    expect(policyResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'record previous policy reference as audit metadata',
+        'reapply previous policy only through a fresh audited preview',
+      ])
+    )
+
+    const deletePlan = buildSingleSecretOperationPlan(
+      managedSecretRows[0],
+      'delete',
+      'operator requested delete preview',
+      true,
+      'ready'
+    )
+    const deleteResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      deletePlan
+    )
+    expect(deleteResult).toMatchObject({
+      recoveryStatus:
+        'delete/decommission requires recovery-guided broker ownership',
+      retryPolicy: 'fresh plan required before any retry',
+    })
+    expect(deleteResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'verify dependent service references before broker decommission',
+        'restore only through a fresh broker plan if apply fails',
       ])
     )
 

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -74,6 +74,9 @@ export type SingleSecretOperationResult = {
   applied: false
   auditStatus: string
   resultStatus: string
+  recoveryStatus: string
+  retryPolicy: string
+  recoverySteps: string[]
   safetyRows: string[]
   nextAction: string
 }
@@ -1412,6 +1415,36 @@ export function buildSingleSecretOperationResult(
           : plan.action === 'policy'
             ? 'policy change'
             : plan.action
+  const recoverySteps =
+    plan.action === 'delete'
+      ? [
+          'verify dependent service references before broker decommission',
+          'retain recovery plan reference until audit review completes',
+          'restore only through a fresh broker plan if apply fails',
+        ]
+      : plan.action === 'policy'
+        ? [
+            'compare target policy metadata before broker submit',
+            'record previous policy reference as audit metadata',
+            'reapply previous policy only through a fresh audited preview',
+          ]
+        : plan.action === 'reset'
+          ? [
+              'track rotation operation id until provider status settles',
+              'restart dependent service only after broker success metadata',
+              'retry by operation id when the provider marks the retry safe',
+            ]
+          : plan.action === 'edit'
+            ? [
+                'review metadata diff before broker submit',
+                'retry by operation id only when broker marks the update safe',
+                'create a fresh preview after policy or provider state changes',
+              ]
+            : [
+                'complete controlled reveal challenge outside the table',
+                'let the short-lived reveal expire after the audit window',
+                'request a fresh reveal instead of reusing stale metadata',
+              ]
 
   return {
     operationId: plan.operationId,
@@ -1421,6 +1454,21 @@ export function buildSingleSecretOperationResult(
     applied: false,
     auditStatus: 'stub audit event recorded with metadata only',
     resultStatus: `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`,
+    recoveryStatus:
+      plan.action === 'delete'
+        ? 'delete/decommission requires recovery-guided broker ownership'
+        : plan.action === 'policy'
+          ? 'policy rollback requires a fresh audited preview'
+          : plan.action === 'reset'
+            ? 'rotation retry is operation-id scoped and provider-owned'
+            : plan.action === 'edit'
+              ? 'edit retry waits for broker retry-safe metadata'
+              : 'reveal recovery is fresh-challenge only',
+    retryPolicy:
+      plan.action === 'delete' || plan.action === 'policy'
+        ? 'fresh plan required before any retry'
+        : 'retry only by operation id when broker marks the attempt retry-safe',
+    recoverySteps,
     safetyRows: [
       'raw value was not revealed',
       'request body is limited to ref, operation id, action, owner, provider, policy, and audit reason metadata',

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -278,6 +278,15 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/rotation can be requested without controlled reveal/i)
     ).toBeVisible()
+    await expect(
+      page.getByText(/rotation retry is operation-id scoped/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/retry only by operation id/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/track rotation operation id until provider status/i)
+    ).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds metadata-only recovery guidance to submitted single-secret operation results.
- Shows retry policy and recovery steps in the result panel and operation history.
- Extends unit and browser coverage for rotation recovery guidance, delete fresh-plan recovery, policy rollback guidance, and no raw value leakage.

## Scope
- In scope: Service Admin Secrets page stub-model recovery guidance for single-secret operations.
- Out of scope: production Secrets Broker mutation API wiring, completing all remaining #231 workflow scope, release/demo pin after merge.

## Spec / contract / fixture impact
- Updated the existing UI model fixture only; no public API/schema change.
- Recovery fields are safe metadata and remain production-stub scoped until the backend mutation contract lands.

## Service Lasso invariant impact
- Preserves metadata-only handling. No raw values, provider credentials, tokens, copy/export, route/query, local/session storage, or diagnostic payloads are introduced.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-recovery-guidance.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-recovery-guidance.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-recovery-guidance.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-recovery-guidance.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-recovery-guidance.log`

## Approval trail
- Required: no special approval documented for this focused UI/test advancement.
- Evidence: existing issue trail has prior validator classifications as `Validated advanced`; this PR is another focused advancement, not full issue completion.

## Cleanup
- Branch: `agent/issue-231-recovery-guidance`
- Post-merge release-to-demo gate is required before claiming this slice demo-gated or #231 done.