### PR TITLE
fix(secretsbroker): make Providers page actions usable

### DIFF
--- a/src/features/secrets-broker/providers-management-page.tsx
+++ b/src/features/secrets-broker/providers-management-page.tsx
@@ -27,6 +27,13 @@ import { usePageMetadata } from '@/lib/page-metadata'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -52,6 +59,7 @@ import { ProfileDropdown } from '@/components/profile-dropdown'
 import { Search } from '@/components/search'
 import { ThemeSwitch } from '@/components/theme-switch'
 import {
+  getAddableSecretsBrokerProviders,
   getConfiguredSecretsBrokerProviders,
   type SecretsBrokerProviderLifecycle,
   type SecretsBrokerSourceBackend,
@@ -93,10 +101,113 @@ function EnabledBadge({ enabled }: { enabled: boolean }) {
   )
 }
 
+type ProviderAction =
+  | 'add'
+  | 'edit'
+  | 'test'
+  | 'reconnect'
+  | 'disable'
+  | 'remove'
+
+type SelectedProviderAction = {
+  provider: SecretsBrokerSourceBackend
+  action: ProviderAction
+}
+
+const actionTitles: Record<ProviderAction, string> = {
+  add: 'Add provider metadata setup',
+  edit: 'Provider configuration',
+  test: 'Provider connection test',
+  reconnect: 'Provider reconnect workflow',
+  disable: 'Disable provider preview',
+  remove: 'Remove provider preview',
+}
+
+function actionSummary({ provider, action }: SelectedProviderAction): {
+  status: string
+  nextAction: string
+  details: string[]
+} {
+  if (action === 'add') {
+    return {
+      status: 'setup preview ready',
+      nextAction: provider.nextAction,
+      details: [
+        'metadata-only setup is staged before provider enablement',
+        'provider credentials stay outside Service Admin',
+        'test connection remains disabled until required handles are configured',
+      ],
+    }
+  }
+
+  if (action === 'test') {
+    return {
+      status:
+        provider.testResult.outcome === 'success'
+          ? 'latest metadata test succeeded'
+          : provider.testResult.outcome === 'failure'
+            ? 'latest metadata test failed closed'
+            : 'metadata test has not run',
+      nextAction: provider.lifecycleDetail?.nextAction ?? provider.nextAction,
+      details: provider.testResult.metadata,
+    }
+  }
+
+  if (action === 'reconnect') {
+    return {
+      status: ['auth-required', 'locked', 'invalid', 'setup-needed'].includes(
+        provider.lifecycle
+      )
+        ? 'reconnect required before provider-backed actions'
+        : 'reconnect is not currently required',
+      nextAction: provider.lifecycleDetail?.nextAction ?? provider.nextAction,
+      details: [
+        'reconnect accepts safe credential references only',
+        'raw provider credentials are never entered here',
+        'affected refs stay blocked until provider status is refreshed',
+      ],
+    }
+  }
+
+  if (action === 'disable') {
+    return {
+      status: 'disable requires broker confirmation',
+      nextAction: 'preview dependent refs and service impact before disable',
+      details: [
+        'disable is confirmation-gated',
+        'default provider cannot be disabled without replacement metadata',
+        'no secret values are exported during disable preview',
+      ],
+    }
+  }
+
+  if (action === 'remove') {
+    return {
+      status: 'remove requires dependency and recovery review',
+      nextAction: 'verify dependent refs and recovery plan before removal',
+      details: [
+        'remove is blocked while namespaces still route to this provider',
+        'recovery metadata must be retained for audit',
+        'provider-owned credentials are not revealed or copied',
+      ],
+    }
+  }
+
+  return {
+    status: provider.configured
+      ? 'configuration metadata available'
+      : 'configuration metadata setup required',
+    nextAction: provider.nextAction,
+    details: [provider.connection, provider.summary, `mode: ${provider.mode}`],
+  }
+}
+
 function ProviderActions({
   provider,
+  onSelect,
 }: {
   provider: SecretsBrokerSourceBackend
+  onSelect: (action: ProviderAction) => void
 }) {
   const canEdit = provider.supportedActions.includes('edit-configuration')
   const canTest = provider.supportedActions.includes('test-source')
@@ -115,19 +226,25 @@ function ProviderActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end' className='w-48'>
-        <DropdownMenuItem disabled={!canEdit}>
+        <DropdownMenuItem disabled={!canEdit} onSelect={() => onSelect('edit')}>
           <Settings className='size-4' /> View/Edit configuration
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={!canTest}>
+        <DropdownMenuItem disabled={!canTest} onSelect={() => onSelect('test')}>
           <ShieldCheck className='size-4' /> Test connection
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={!needsReconnect}>
+        <DropdownMenuItem
+          disabled={!needsReconnect}
+          onSelect={() => onSelect('reconnect')}
+        >
           <RefreshCw className='size-4' /> Reconnect / reauth
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSelect('disable')}>
           <Ban className='size-4' /> Disable provider
         </DropdownMenuItem>
-        <DropdownMenuItem variant='destructive'>
+        <DropdownMenuItem
+          variant='destructive'
+          onSelect={() => onSelect('remove')}
+        >
           <Trash2 className='size-4' /> Remove provider
         </DropdownMenuItem>
       </DropdownMenuContent>
@@ -135,151 +252,278 @@ function ProviderActions({
   )
 }
 
-const columns: ColumnDef<SecretsBrokerSourceBackend>[] = [
-  {
-    id: 'provider',
-    accessorFn: (provider) =>
-      [
-        provider.title,
-        provider.type,
-        provider.provider,
-        provider.source,
-        provider.connection,
-        provider.namespaces.join(' '),
-        provider.summary,
-      ].join(' '),
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Provider' />
-    ),
-    cell: ({ row }) => (
-      <div className='flex max-w-[320px] min-w-0 flex-col'>
-        <span className='truncate font-medium' title={row.original.title}>
-          {row.original.title}
-        </span>
-        <span
-          className='truncate text-xs text-muted-foreground'
-          title={row.original.source}
-        >
-          {providerTypeLabel(row.original)} · {row.original.source}
-        </span>
+function ProviderActionPanel({
+  selection,
+  onClear,
+}: {
+  selection: SelectedProviderAction | null
+  onClear: () => void
+}) {
+  if (!selection) return null
+
+  const preview = actionSummary(selection)
+
+  return (
+    <section
+      aria-label='Provider action detail'
+      className='rounded-md border bg-muted/20 p-4'
+    >
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div className='min-w-0'>
+          <div className='text-sm font-medium'>
+            {actionTitles[selection.action]}
+          </div>
+          <div className='truncate text-sm text-muted-foreground'>
+            {selection.provider.title}
+          </div>
+        </div>
+        <div className='flex flex-wrap gap-2'>
+          <Badge variant='secondary'>Metadata only</Badge>
+          <Button type='button' size='sm' variant='outline' onClick={onClear}>
+            Clear
+          </Button>
+        </div>
       </div>
-    ),
-    enableHiding: false,
-  },
-  {
-    id: 'enabled',
-    accessorFn: (provider) => (provider.enabled ? 'enabled' : 'disabled'),
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Enabled' />
-    ),
-    cell: ({ row }) => <EnabledBadge enabled={row.original.enabled} />,
-    filterFn: (row, id, value) => value.includes(row.getValue(id)),
-  },
-  {
-    id: 'status',
-    accessorFn: (provider) => provider.state,
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Health' />
-    ),
-    cell: ({ row }) => (
-      <div className='flex flex-wrap gap-2'>
-        <Badge variant={stateVariant[row.original.state]}>
-          {row.original.state}
-        </Badge>
-        <Badge variant={lifecycleVariant[row.original.lifecycle]}>
-          {row.original.lifecycle}
-        </Badge>
+      <div className='mt-4 grid gap-3 md:grid-cols-3'>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Status
+          </div>
+          <div className='mt-1 text-sm'>{preview.status}</div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Next action
+          </div>
+          <div className='mt-1 text-sm'>{preview.nextAction}</div>
+        </div>
+        <div>
+          <div className='text-xs font-medium text-muted-foreground uppercase'>
+            Safe contract
+          </div>
+          <div className='mt-1 text-sm'>
+            refs, namespaces, state, and audit metadata only
+          </div>
+        </div>
       </div>
-    ),
-    filterFn: (row, id, value) => value.includes(row.getValue(id)),
-  },
-  {
-    id: 'lifecycle',
-    accessorFn: (provider) => provider.lifecycle,
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Lifecycle' />
-    ),
-    cell: ({ row }) => (
-      <div className='max-w-[260px] min-w-0'>
+      <ul className='mt-4 list-disc space-y-1 ps-5 text-sm text-muted-foreground'>
+        {preview.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function AddProviderDialog({
+  providers,
+  open,
+  onOpenChange,
+  onSelect,
+}: {
+  providers: SecretsBrokerSourceBackend[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (provider: SecretsBrokerSourceBackend) => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-h-[88vh] overflow-y-auto sm:max-w-3xl'>
+        <DialogHeader>
+          <DialogTitle>Add provider</DialogTitle>
+          <DialogDescription>
+            Choose a provider setup path. This page stages metadata only; raw
+            credentials stay in the provider or Secrets Broker.
+          </DialogDescription>
+        </DialogHeader>
+        <div className='grid gap-3 md:grid-cols-2'>
+          {providers.map((provider) => (
+            <button
+              key={provider.id}
+              type='button'
+              className='rounded-md border p-4 text-left transition-colors hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none'
+              onClick={() => {
+                onSelect(provider)
+                onOpenChange(false)
+              }}
+            >
+              <div className='flex flex-wrap items-center gap-2'>
+                <div className='font-medium'>{provider.title}</div>
+                <Badge variant={stateVariant[provider.state]}>
+                  {provider.state}
+                </Badge>
+              </div>
+              <div className='mt-2 text-sm text-muted-foreground'>
+                {provider.connection}
+              </div>
+              <div className='mt-3 text-xs text-muted-foreground'>
+                {provider.nextAction}
+              </div>
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function providerColumns(
+  onActionSelect: (
+    provider: SecretsBrokerSourceBackend,
+    action: ProviderAction
+  ) => void
+): ColumnDef<SecretsBrokerSourceBackend>[] {
+  return [
+    {
+      id: 'provider',
+      accessorFn: (provider) =>
+        [
+          provider.title,
+          provider.type,
+          provider.provider,
+          provider.source,
+          provider.connection,
+          provider.namespaces.join(' '),
+          provider.summary,
+        ].join(' '),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Provider' />
+      ),
+      cell: ({ row }) => (
+        <div className='flex min-w-0 flex-col'>
+          <span className='truncate font-medium' title={row.original.title}>
+            {row.original.title}
+          </span>
+          <span
+            className='truncate text-xs text-muted-foreground'
+            title={row.original.source}
+          >
+            {providerTypeLabel(row.original)} · {row.original.source}
+          </span>
+        </div>
+      ),
+      enableHiding: false,
+    },
+    {
+      id: 'enabled',
+      accessorFn: (provider) => (provider.enabled ? 'enabled' : 'disabled'),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Enabled' />
+      ),
+      cell: ({ row }) => <EnabledBadge enabled={row.original.enabled} />,
+      filterFn: (row, id, value) => value.includes(row.getValue(id)),
+    },
+    {
+      id: 'status',
+      accessorFn: (provider) => provider.state,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Health' />
+      ),
+      cell: ({ row }) => (
+        <div className='flex flex-wrap gap-2'>
+          <Badge variant={stateVariant[row.original.state]}>
+            {row.original.state}
+          </Badge>
+          <Badge variant={lifecycleVariant[row.original.lifecycle]}>
+            {row.original.lifecycle}
+          </Badge>
+        </div>
+      ),
+      filterFn: (row, id, value) => value.includes(row.getValue(id)),
+    },
+    {
+      id: 'lifecycle',
+      accessorFn: (provider) => provider.lifecycle,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Lifecycle' />
+      ),
+      cell: ({ row }) => (
+        <div className='min-w-0'>
+          <div
+            className='truncate text-sm'
+            title={
+              row.original.lifecycleDetail?.state ??
+              row.original.testResult.outcome
+            }
+          >
+            {row.original.lifecycleDetail?.state ??
+              row.original.testResult.outcome}
+          </div>
+          <div
+            className='truncate text-xs text-muted-foreground'
+            title={row.original.nextAction}
+          >
+            {row.original.nextAction}
+          </div>
+        </div>
+      ),
+      filterFn: (row, id, value) => value.includes(row.getValue(id)),
+    },
+    {
+      id: 'priority',
+      accessorFn: (provider) => provider.priority ?? 999,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Priority' />
+      ),
+      cell: ({ row }) => (
+        <div className='whitespace-nowrap'>
+          {row.original.priority ?? 'Not assigned'}
+        </div>
+      ),
+    },
+    {
+      id: 'namespaces',
+      accessorFn: (provider) =>
+        provider.namespaces.length
+          ? provider.namespaces.join(', ')
+          : 'not mapped',
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Namespaces' />
+      ),
+      cell: ({ row }) => (
         <div
           className='truncate text-sm'
           title={
-            row.original.lifecycleDetail?.state ??
-            row.original.testResult.outcome
+            row.original.namespaces.length
+              ? row.original.namespaces.join(', ')
+              : 'not mapped'
           }
         >
-          {row.original.lifecycleDetail?.state ??
-            row.original.testResult.outcome}
-        </div>
-        <div
-          className='truncate text-xs text-muted-foreground'
-          title={row.original.nextAction}
-        >
-          {row.original.nextAction}
-        </div>
-      </div>
-    ),
-    filterFn: (row, id, value) => value.includes(row.getValue(id)),
-  },
-  {
-    id: 'priority',
-    accessorFn: (provider) => provider.priority ?? 999,
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Priority' />
-    ),
-    cell: ({ row }) => (
-      <div className='whitespace-nowrap'>
-        {row.original.priority ?? 'Not assigned'}
-      </div>
-    ),
-  },
-  {
-    id: 'namespaces',
-    accessorFn: (provider) =>
-      provider.namespaces.length
-        ? provider.namespaces.join(', ')
-        : 'not mapped',
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Namespaces' />
-    ),
-    cell: ({ row }) => (
-      <div
-        className='max-w-[240px] truncate text-sm'
-        title={
-          row.original.namespaces.length
+          {row.original.namespaces.length
             ? row.original.namespaces.join(', ')
-            : 'not mapped'
-        }
-      >
-        {row.original.namespaces.length
-          ? row.original.namespaces.join(', ')
-          : 'not mapped'}
-      </div>
-    ),
-  },
-  {
-    id: 'lastCheckedAt',
-    accessorFn: (provider) => provider.lastCheckedAt,
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title='Last checked' />
-    ),
-    cell: ({ row }) => (
-      <div
-        className='max-w-[190px] truncate whitespace-nowrap'
-        title={row.original.lastCheckedAt}
-      >
-        {row.original.lastCheckedAt}
-      </div>
-    ),
-  },
-  {
-    id: 'actions',
-    header: 'Actions',
-    cell: ({ row }) => <ProviderActions provider={row.original} />,
-    enableSorting: false,
-    enableHiding: false,
-  },
-]
+            : 'not mapped'}
+        </div>
+      ),
+    },
+    {
+      id: 'lastCheckedAt',
+      accessorFn: (provider) => provider.lastCheckedAt,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title='Last checked' />
+      ),
+      cell: ({ row }) => (
+        <div
+          className='truncate whitespace-nowrap'
+          title={row.original.lastCheckedAt}
+        >
+          {row.original.lastCheckedAt}
+        </div>
+      ),
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => (
+        <ProviderActions
+          provider={row.original}
+          onSelect={(action) => onActionSelect(row.original, action)}
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    },
+  ]
+}
 
 export function ProvidersManagementPage() {
   usePageMetadata({
@@ -295,11 +539,22 @@ export function ProvidersManagementPage() {
       ),
     []
   )
+  const addableProviders = useMemo(() => getAddableSecretsBrokerProviders(), [])
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'priority', desc: false },
     { id: 'provider', desc: false },
   ])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [addProviderOpen, setAddProviderOpen] = useState(false)
+  const [selectedAction, setSelectedAction] =
+    useState<SelectedProviderAction | null>(null)
+  const columns = useMemo(
+    () =>
+      providerColumns((provider, action) =>
+        setSelectedAction({ provider, action })
+      ),
+    []
+  )
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -342,13 +597,22 @@ export function ProvidersManagementPage() {
           </div>
           <div className='flex flex-wrap gap-2'>
             <Badge variant='secondary'>Metadata only</Badge>
-            <Button type='button' size='sm'>
+            <Button
+              type='button'
+              size='sm'
+              onClick={() => setAddProviderOpen(true)}
+            >
               <CirclePlus className='size-4' /> Add provider
             </Button>
           </div>
         </div>
 
         <div className='flex flex-1 flex-col gap-4'>
+          <ProviderActionPanel
+            selection={selectedAction}
+            onClear={() => setSelectedAction(null)}
+          />
+
           <DataTableToolbar
             table={table}
             searchPlaceholder='Search providers, namespaces, source, or health...'
@@ -390,7 +654,7 @@ export function ProvidersManagementPage() {
 
           <div className='overflow-hidden rounded-md border'>
             <div className='overflow-x-auto'>
-              <Table className='min-w-[1180px] table-fixed'>
+              <Table className='min-w-[940px] table-fixed'>
                 <TableHeader>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <TableRow key={headerGroup.id} className='group/row'>
@@ -449,6 +713,14 @@ export function ProvidersManagementPage() {
           </div>
           <DataTablePagination table={table} className='mt-auto' />
         </div>
+        <AddProviderDialog
+          providers={addableProviders}
+          open={addProviderOpen}
+          onOpenChange={setAddProviderOpen}
+          onSelect={(provider) =>
+            setSelectedAction({ provider, action: 'add' })
+          }
+        />
       </Main>
     </>
   )

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -389,7 +389,25 @@ describe('Secrets Broker overview dashboard', () => {
     expect(
       screen.getByRole('menuitem', { name: /Remove provider/i })
     ).toBeVisible()
-    await user.keyboard('{Escape}')
+    await user.click(screen.getByRole('menuitem', { name: /Test connection/i }))
+    expect(screen.getByLabelText(/Provider action detail/i)).toBeVisible()
+    expect(screen.getByText(/Provider connection test/i)).toBeVisible()
+    expect(
+      screen.getByText(/latest metadata test failed closed/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/refs, namespaces, state, and audit metadata only/i)
+    ).toBeVisible()
+
+    await user.click(screen.getByRole('button', { name: /^Actions$/i }))
+    await user.click(screen.getByRole('menuitem', { name: /Reconnect/i }))
+    expect(screen.getByText(/Provider reconnect workflow/i)).toBeVisible()
+    expect(
+      screen.getByText(/reconnect required before provider-backed actions/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/raw provider credentials are never entered here/i)
+    ).toBeVisible()
     expect(screen.getAllByText(/reconnect_required/i)[0]).toBeVisible()
     expect(screen.getAllByText(/locked/i)[0]).toBeVisible()
     expect(screen.getAllByText(/unlock_or_unseal_source/i)[0]).toBeVisible()
@@ -402,6 +420,24 @@ describe('Secrets Broker overview dashboard', () => {
     expect(
       screen.queryByText(/Insecure path override/i)
     ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^Add provider$/i }))
+    expect(
+      screen.getByRole('dialog', { name: /^Add provider$/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Choose a provider setup path/i)).toBeVisible()
+    expect(screen.getByText(/Environment provider/i)).toBeVisible()
+    expect(screen.getByText(/AWS Secrets Manager CLI/i)).toBeVisible()
+    await user.click(
+      screen.getByRole('button', { name: /Environment provider/i })
+    )
+    expect(screen.queryByRole('dialog', { name: /^Add provider$/i })).toBeNull()
+    expect(screen.getByText(/Add provider metadata setup/i)).toBeVisible()
+    expect(screen.getByText(/setup preview ready/i)).toBeVisible()
+    expect(
+      screen.getByText(/provider credentials stay outside Service Admin/i)
+    ).toBeVisible()
+    await user.click(screen.getByRole('button', { name: /^Clear$/i }))
 
     await user.type(screen.getByPlaceholderText(/Search providers/i), 'aws')
     expect(screen.getByText(/No enabled providers match/i)).toBeVisible()

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -392,4 +392,51 @@ test.describe('Secrets Broker browser coverage', () => {
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])
   })
+
+  test('covers Providers page actions and add-provider setup dialog', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker/sources')
+    await expectNoBlankScreen(page)
+    await expect(
+      page.getByRole('heading', { name: /Secrets Broker providers/i })
+    ).toBeVisible()
+    await expect(page.getByText(/Local encrypted store/i).first()).toBeVisible()
+
+    await page.getByRole('button', { name: /^Actions$/i }).click()
+    await page.getByRole('menuitem', { name: /Test connection/i }).click()
+    await expect(page.getByText(/Provider connection test/i)).toBeVisible()
+    await expect(
+      page.getByText(/latest metadata test failed closed/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/refs, namespaces, state, and audit metadata only/i)
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: /^Actions$/i }).click()
+    await page.getByRole('menuitem', { name: /Reconnect/i }).click()
+    await expect(page.getByText(/Provider reconnect workflow/i)).toBeVisible()
+    await expect(
+      page.getByText(/raw provider credentials are never entered here/i)
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: /^Add provider$/i }).click()
+    await expect(
+      page.getByRole('dialog', { name: /^Add provider$/i })
+    ).toBeVisible()
+    await expect(page.getByText(/Environment provider/i)).toBeVisible()
+    await expect(page.getByText(/AWS Secrets Manager CLI/i)).toBeVisible()
+    await page.getByRole('button', { name: /Environment provider/i }).click()
+    await expect(page.getByText(/Add provider metadata setup/i)).toBeVisible()
+    await expect(page.getByText(/setup preview ready/i)).toBeVisible()
+    await expect(
+      page.getByText(/provider credentials stay outside Service Admin/i)
+    ).toBeVisible()
+
+    await page.getByPlaceholder(/Search providers/i).fill('aws')
+    await expect(page.getByText(/No enabled providers match/i)).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+    expect(consoleErrors).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #247.
- Makes the Providers page Add provider control open a metadata-only setup dialog with addable provider choices.
- Makes row Actions menu items populate a real provider action detail panel for configuration, test, reconnect, disable, and remove previews.
- Keeps provider workflow detail metadata-only and reduces the fixed table width from the screenshot-heavy layout.

## Validation
- PASS npm run test:unit -- src/features/secrets-broker/secrets-broker-setup.test.tsx
- PASS npx playwright test tests/ui/secrets-broker.spec.ts --grep "Providers page actions"
- PASS npm run format:check
- PASS npm run lint
- PASS npm run build

## Demo gate
Pending after merge/release: update core @serviceadmin pin, recycle canonical demo, verify LAN runtime and UI.
