### PR TITLE
feat(secrets): model single-secret status outcomes

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -70,6 +70,7 @@ import {
   bulkSecretCampaignOperations,
   bulkSecretCampaignRevalidationStates,
   managedSecretRows,
+  singleSecretOperationOutcomes,
   stubSecretMutationStates,
   valueSearchManagedSecrets,
   type BulkSecretCampaignApplyMode,
@@ -80,6 +81,7 @@ import {
   type ManagedSecretRow,
   type ManagedSecretState,
   type SingleSecretOperationHistoryEntry,
+  type SingleSecretOperationOutcome,
   type SingleSecretOperationResult,
   type StubSecretMutationState,
 } from './secrets-management'
@@ -130,6 +132,8 @@ export function SecretsManagementPage() {
   const [confirmed, setConfirmed] = useState(false)
   const [singleApplyResult, setSingleApplyResult] =
     useState<SingleSecretOperationResult | null>(null)
+  const [singleOperationOutcome, setSingleOperationOutcome] =
+    useState<SingleSecretOperationOutcome>('submitted')
   const [singleOperationHistory, setSingleOperationHistory] = useState<
     SingleSecretOperationHistoryEntry[]
   >([])
@@ -263,14 +267,16 @@ export function SecretsManagementPage() {
   function applySingleSecretOperation() {
     const result = buildSingleSecretOperationResult(
       selectedRow,
-      singleOperationPlan
+      singleOperationPlan,
+      singleOperationOutcome
     )
     setSingleApplyResult(result)
     setSingleOperationHistory((current) => [
       buildSingleSecretOperationHistoryEntry(
         selectedRow,
         singleOperationPlan,
-        current.length + 1
+        current.length + 1,
+        singleOperationOutcome
       ),
       ...current,
     ])
@@ -1514,7 +1520,7 @@ export function SecretsManagementPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className='space-y-4 text-sm'>
-            <div className='grid gap-4 lg:grid-cols-3'>
+            <div className='grid gap-4 lg:grid-cols-4'>
               <div className='rounded-lg border p-3'>
                 <div className='text-xs font-medium text-muted-foreground uppercase'>
                   Selected ref
@@ -1542,6 +1548,31 @@ export function SecretsManagementPage() {
                   {stubSecretMutationStates.map((state) => (
                     <option key={state.id} value={state.id}>
                       {state.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className='rounded-lg border p-3'>
+                <label
+                  htmlFor='single-operation-outcome'
+                  className='text-xs font-medium text-muted-foreground uppercase'
+                >
+                  Result status
+                </label>
+                <select
+                  id='single-operation-outcome'
+                  className='mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm'
+                  value={singleOperationOutcome}
+                  onChange={(event) => {
+                    setSingleOperationOutcome(
+                      event.target.value as SingleSecretOperationOutcome
+                    )
+                    setSingleApplyResult(null)
+                  }}
+                >
+                  {singleSecretOperationOutcomes.map((outcome) => (
+                    <option key={outcome.id} value={outcome.id}>
+                      {outcome.label}
                     </option>
                   ))}
                 </select>
@@ -1642,6 +1673,9 @@ export function SecretsManagementPage() {
                     Single-secret operation result: {singleApplyResult.outcome}
                   </div>
                   <Badge variant='secondary'>Metadata only</Badge>
+                  <Badge variant='outline'>
+                    {singleApplyResult.resultBadge}
+                  </Badge>
                   <Badge variant='outline'>
                     {singleApplyResult.applied ? 'Applied' : 'Not applied'}
                   </Badge>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -569,7 +569,7 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
     expect(screen.getByText(/1 submitted/i)).toBeVisible()
     expect(screen.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
-    expect(screen.getByText(/submitted to stub broker/i)).toBeVisible()
+    expect(screen.getAllByText(/submitted to broker/i)[0]).toBeVisible()
     expect(screen.getByText(/raw value was not revealed/i)).toBeVisible()
     expect(
       screen.getByText(/rotation can be requested without controlled reveal/i)
@@ -581,6 +581,23 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/track rotation operation id until provider status/i)
     ).toBeVisible()
+
+    await user.selectOptions(screen.getByLabelText(/Result status/i), 'applied')
+    await user.selectOptions(screen.getByLabelText(/Stub API state/i), 'ready')
+    await user.click(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    )
+    expect(
+      screen.getByText(/Single-secret operation result: applied/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/broker applied/i)[0]).toBeVisible()
+    expect(
+      screen.getAllByText(/operation settled with broker success metadata/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/no retry needed after broker success/i)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/2 submitted/i)).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Delete dry-run/i })[0]
@@ -684,6 +701,20 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Stub apply failure/i)[0]).toBeVisible()
     expect(screen.getByText(/deterministic fake apply failed/i)).toBeVisible()
 
+    await user.selectOptions(
+      screen.getByLabelText(/Result status/i),
+      'policy-denied'
+    )
+    await user.selectOptions(screen.getByLabelText(/Stub API state/i), 'ready')
+    await user.click(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    )
+    expect(
+      screen.getByText(/Single-secret operation result: policy-denied/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/policy denied/i)[0]).toBeVisible()
+    expect(screen.getByText(/no value was read or written/i)).toBeVisible()
+
     await user.click(
       screen.getByRole('button', { name: /Cancel stub preview/i })
     )
@@ -748,6 +779,7 @@ describe('Secrets Broker secrets management page', () => {
       action: 'reset',
       outcome: 'submitted',
       applied: false,
+      resultBadge: 'submitted to broker',
       auditStatus: 'stub audit event recorded with metadata only',
       nextAction:
         'monitor broker rotation outcome and dependent service restart notes',
@@ -768,17 +800,63 @@ describe('Secrets Broker secrets management page', () => {
         'rotation can be requested without controlled reveal',
       ])
     )
+    const appliedResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'applied'
+    )
+    expect(appliedResult).toMatchObject({
+      outcome: 'applied',
+      applied: true,
+      resultBadge: 'broker applied',
+      auditStatus: 'stub audit event and broker success metadata recorded',
+      recoveryStatus: 'operation settled with broker success metadata',
+      retryPolicy: 'no retry needed after broker success',
+      nextAction:
+        'monitor dependent service restart notes and rotation freshness',
+    })
+
+    const deniedResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'policy-denied'
+    )
+    expect(deniedResult).toMatchObject({
+      outcome: 'policy-denied',
+      applied: false,
+      resultBadge: 'policy denied',
+      recoveryStatus:
+        'policy denial is fail-closed and requires a new authorized plan',
+      retryPolicy: 'fresh plan required before any retry',
+      nextAction:
+        'update policy assignment or request least-privilege approval',
+    })
+
+    const staleResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'stale-plan'
+    )
+    expect(staleResult).toMatchObject({
+      outcome: 'stale-plan',
+      applied: false,
+      resultBadge: 'stale plan',
+      recoveryStatus: 'stale plan recovery requires a fresh audited preview',
+      nextAction: 'create a fresh dry-run plan before retry',
+    })
+
     const historyEntry = buildSingleSecretOperationHistoryEntry(
       managedSecretRows[0],
       rotatePlan,
-      1
+      1,
+      'failed'
     )
     expect(historyEntry).toMatchObject({
       operationId: rotatePlan.operationId,
       rowName: 'SESSION_SIGNING_KEY',
       provider: 'local encrypted store',
       auditEventId: 'audit-reset-serviceadmin-session-signing-1',
-      statusBadge: 'submitted to stub broker',
+      statusBadge: 'apply failed',
       submittedAt: 'stub-sequence-1',
     })
     expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -66,12 +66,21 @@ export type SingleSecretOperationPlan = {
   canSubmit: boolean
 }
 
+export type SingleSecretOperationOutcome =
+  | 'submitted'
+  | 'applied'
+  | 'policy-denied'
+  | 'auth-required'
+  | 'failed'
+  | 'stale-plan'
+
 export type SingleSecretOperationResult = {
   operationId: string
   ref: string
   action: ManagedSecretAction
-  outcome: 'submitted'
-  applied: false
+  outcome: SingleSecretOperationOutcome
+  applied: boolean
+  resultBadge: string
   auditStatus: string
   resultStatus: string
   recoveryStatus: string
@@ -327,6 +336,18 @@ export const stubSecretMutationStates: Array<{
   { id: 'cancelled', label: 'Operator cancelled' },
   { id: 'success', label: 'Stub apply success' },
   { id: 'failure', label: 'Stub apply failure' },
+]
+
+export const singleSecretOperationOutcomes: Array<{
+  id: SingleSecretOperationOutcome
+  label: string
+}> = [
+  { id: 'submitted', label: 'Submitted for broker status' },
+  { id: 'applied', label: 'Broker apply success' },
+  { id: 'policy-denied', label: 'Policy denied after submit' },
+  { id: 'auth-required', label: 'Auth required after submit' },
+  { id: 'failed', label: 'Broker apply failed' },
+  { id: 'stale-plan', label: 'Stale plan rejected' },
 ]
 
 export const bulkSecretCampaignOperations: Array<{
@@ -1403,7 +1424,8 @@ export function buildSingleSecretOperationPlan(
 
 export function buildSingleSecretOperationResult(
   row: ManagedSecretRow,
-  plan: SingleSecretOperationPlan
+  plan: SingleSecretOperationPlan,
+  outcome: SingleSecretOperationOutcome = 'submitted'
 ): SingleSecretOperationResult {
   const actionLabel =
     plan.action === 'reset'
@@ -1445,29 +1467,97 @@ export function buildSingleSecretOperationResult(
                 'let the short-lived reveal expire after the audit window',
                 'request a fresh reveal instead of reusing stale metadata',
               ]
+  const applied = outcome === 'applied'
+  const resultBadge =
+    outcome === 'applied'
+      ? 'broker applied'
+      : outcome === 'policy-denied'
+        ? 'policy denied'
+        : outcome === 'auth-required'
+          ? 'auth required'
+          : outcome === 'failed'
+            ? 'apply failed'
+            : outcome === 'stale-plan'
+              ? 'stale plan'
+              : 'submitted to broker'
+  const auditStatus =
+    outcome === 'submitted'
+      ? 'stub audit event recorded with metadata only'
+      : outcome === 'applied'
+        ? 'stub audit event and broker success metadata recorded'
+        : 'stub audit event recorded with typed failure metadata only'
+  const resultStatus =
+    outcome === 'submitted'
+      ? `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`
+      : outcome === 'applied'
+        ? `${actionLabel} accepted by broker status callback; Service Admin records metadata only`
+        : outcome === 'policy-denied'
+          ? `${actionLabel} denied by broker policy after final revalidation; no value was read or written`
+          : outcome === 'auth-required'
+            ? `${actionLabel} paused because broker requires fresh operator authentication`
+            : outcome === 'stale-plan'
+              ? `${actionLabel} rejected because the dry-run plan is stale`
+              : `${actionLabel} failed with broker-owned safe error metadata`
+  const nextAction =
+    outcome === 'applied'
+      ? plan.action === 'reset'
+        ? 'monitor dependent service restart notes and rotation freshness'
+        : 'monitor broker operation audit and dependent service status'
+      : outcome === 'policy-denied'
+        ? 'update policy assignment or request least-privilege approval'
+        : outcome === 'auth-required'
+          ? 'complete broker auth challenge and create a fresh preview'
+          : outcome === 'stale-plan'
+            ? 'create a fresh dry-run plan before retry'
+            : outcome === 'failed'
+              ? 'review safe broker failure metadata and retry only when marked safe'
+              : plan.action === 'reset'
+                ? 'monitor broker rotation outcome and dependent service restart notes'
+                : 'monitor broker operation status and typed policy/audit result'
+  const recoveryStatus =
+    outcome === 'applied'
+      ? 'operation settled with broker success metadata'
+      : outcome === 'policy-denied'
+        ? 'policy denial is fail-closed and requires a new authorized plan'
+        : outcome === 'auth-required'
+          ? 'authentication challenge must complete outside the table'
+          : outcome === 'stale-plan'
+            ? 'stale plan recovery requires a fresh audited preview'
+            : outcome === 'failed'
+              ? 'broker failure recovery depends on retry-safe operation metadata'
+              : plan.action === 'delete'
+                ? 'delete/decommission requires recovery-guided broker ownership'
+                : plan.action === 'policy'
+                  ? 'policy rollback requires a fresh audited preview'
+                  : plan.action === 'reset'
+                    ? 'rotation retry is operation-id scoped and provider-owned'
+                    : plan.action === 'edit'
+                      ? 'edit retry waits for broker retry-safe metadata'
+                      : 'reveal recovery is fresh-challenge only'
+  const retryPolicy =
+    outcome === 'applied'
+      ? 'no retry needed after broker success'
+      : outcome === 'policy-denied' ||
+          outcome === 'auth-required' ||
+          outcome === 'stale-plan'
+        ? 'fresh plan required before any retry'
+        : outcome === 'failed'
+          ? 'retry only with the same operation id when broker marks retry safe'
+          : plan.action === 'delete' || plan.action === 'policy'
+            ? 'fresh plan required before any retry'
+            : 'retry only by operation id when broker marks the attempt retry-safe'
 
   return {
     operationId: plan.operationId,
     ref: row.ref,
     action: plan.action,
-    outcome: 'submitted',
-    applied: false,
-    auditStatus: 'stub audit event recorded with metadata only',
-    resultStatus: `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`,
-    recoveryStatus:
-      plan.action === 'delete'
-        ? 'delete/decommission requires recovery-guided broker ownership'
-        : plan.action === 'policy'
-          ? 'policy rollback requires a fresh audited preview'
-          : plan.action === 'reset'
-            ? 'rotation retry is operation-id scoped and provider-owned'
-            : plan.action === 'edit'
-              ? 'edit retry waits for broker retry-safe metadata'
-              : 'reveal recovery is fresh-challenge only',
-    retryPolicy:
-      plan.action === 'delete' || plan.action === 'policy'
-        ? 'fresh plan required before any retry'
-        : 'retry only by operation id when broker marks the attempt retry-safe',
+    outcome,
+    applied,
+    resultBadge,
+    auditStatus,
+    resultStatus,
+    recoveryStatus,
+    retryPolicy,
     recoverySteps,
     safetyRows: [
       'raw value was not revealed',
@@ -1481,19 +1571,17 @@ export function buildSingleSecretOperationResult(
             : 'operator action used the selected dry-run gate',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
-    nextAction:
-      plan.action === 'reset'
-        ? 'monitor broker rotation outcome and dependent service restart notes'
-        : 'monitor broker operation status and typed policy/audit result',
+    nextAction,
   }
 }
 
 export function buildSingleSecretOperationHistoryEntry(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
-  sequence: number
+  sequence: number,
+  outcome: SingleSecretOperationOutcome = 'submitted'
 ): SingleSecretOperationHistoryEntry {
-  const result = buildSingleSecretOperationResult(row, plan)
+  const result = buildSingleSecretOperationResult(row, plan, outcome)
   const safeSequence = Math.max(1, sequence)
 
   return {
@@ -1502,7 +1590,7 @@ export function buildSingleSecretOperationHistoryEntry(
     provider: row.provider,
     policy: row.policy,
     auditEventId: `audit-${safeOperationSlug(plan.action, row)}-${safeSequence}`,
-    statusBadge: 'submitted to stub broker',
+    statusBadge: result.resultBadge,
     submittedAt: `stub-sequence-${safeSequence}`,
   }
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -273,7 +273,7 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/1 submitted/i)).toBeVisible()
     await expect(page.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
-    await expect(page.getByText(/submitted to stub broker/i)).toBeVisible()
+    await expect(page.getByText(/submitted to broker/i).first()).toBeVisible()
     await expect(page.getByText(/raw value was not revealed/i)).toBeVisible()
     await expect(
       page.getByText(/rotation can be requested without controlled reveal/i)
@@ -287,6 +287,20 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/track rotation operation id until provider status/i)
     ).toBeVisible()
+    await page.getByLabel(/Result status/i).selectOption('applied')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: applied/i)
+    ).toBeVisible()
+    await expect(page.getByText(/broker applied/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/operation settled with broker success metadata/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/no retry needed after broker success/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/2 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add typed single-secret operation outcomes after dry-run submit: submitted, applied, policy denied, auth required, failed, and stale plan.
- Surface the selected metadata-only result status in the Secrets page result panel and operation history.
- Extend unit and focused Playwright coverage for applied/denied/stale outcome safety without raw value exposure.

## Scope
- In scope: Service Admin stub-preview model/UI for single-secret operation status feedback.
- Out of scope: live Secrets Broker mutation API wiring, production backend enforcement, and full #231 closure.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin fixture/model contract for typed single-secret result feedback.
- Not required: backend API contract changes, because this remains a stub-preview UI slice until production broker mutation endpoints land.

## Nash invariant impact
- Invariant: Secrets surfaces must remain metadata-only by default and must not expose raw values or credentials.
- Preservation proof: result payloads include refs, operation ids, status/audit/recovery metadata, and tests assert no `DEMO_REVEAL_VALUE_42` or forbidden secret material appears.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-single-status-outcomes.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-single-status-outcomes.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-single-status-outcomes.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-single-status-outcomes.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-single-status-outcomes.log`

## Approval trail
- Required: no special approval requirement identified for this focused UI/test advancement.
- Evidence: issue #231 is Ready / Ready for Agent; previous slices have been merged with validator classification `Validated advanced`.

## Cleanup
- Branch: `agent/issue-231-single-status-outcomes`
- Release-to-demo gate: pending after merge. This Service Admin UI change is demo-consumed and must be released, pinned in core, recycled on canonical demo port 17883, and verified before claiming this slice demo-gated.