### PR TITLE
feat(secrets): add single-secret audit feedback

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1704,6 +1704,40 @@ export function SecretsManagementPage() {
                     <div className='mt-1'>{singleApplyResult.auditStatus}</div>
                   </div>
                 </div>
+                <div className='mt-3 grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Audit event
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.auditFeedback.auditEventId}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Correlation
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.auditFeedback.correlationId}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Audit status
+                    </div>
+                    <div className='mt-1'>
+                      {singleApplyResult.auditFeedback.eventState}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Sink
+                    </div>
+                    <div className='mt-1'>
+                      {singleApplyResult.auditFeedback.sinkStatus}
+                    </div>
+                  </div>
+                </div>
                 <div className='mt-3 rounded-md border bg-muted/40 p-3'>
                   <div>{singleApplyResult.resultStatus}</div>
                   <div className='mt-2 text-muted-foreground'>
@@ -1732,6 +1766,22 @@ export function SecretsManagementPage() {
                       ))}
                     </ul>
                   </div>
+                </div>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Redaction and dependent service evidence
+                  </div>
+                  <div className='mt-2'>
+                    {singleApplyResult.auditFeedback.redactionStatus}
+                  </div>
+                  <div className='mt-2 text-muted-foreground'>
+                    {singleApplyResult.auditFeedback.dependentServiceStatus}
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleApplyResult.auditFeedback.evidenceRows.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
                 </div>
                 <ul className='mt-3 list-disc space-y-1 ps-5 text-muted-foreground'>
                   {singleApplyResult.safetyRows.map((row) => (
@@ -1787,6 +1837,12 @@ export function SecretsManagementPage() {
                               {entry.auditEventId}
                             </div>
                             <div className='mt-2 text-xs break-all text-muted-foreground'>
+                              {entry.auditFeedback.correlationId}
+                            </div>
+                            <div className='mt-2 text-xs text-muted-foreground'>
+                              {entry.auditFeedback.eventState}
+                            </div>
+                            <div className='mt-2 text-xs break-all text-muted-foreground'>
                               {entry.policy}
                             </div>
                           </TableCell>
@@ -1794,6 +1850,9 @@ export function SecretsManagementPage() {
                             <div>{entry.nextAction}</div>
                             <div className='mt-2 text-muted-foreground'>
                               {entry.recoveryStatus}
+                            </div>
+                            <div className='mt-2 text-muted-foreground'>
+                              {entry.auditFeedback.dependentServiceStatus}
                             </div>
                             <div className='mt-2 text-xs text-muted-foreground'>
                               {entry.retryPolicy}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -568,11 +568,29 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
     expect(screen.getByText(/1 submitted/i)).toBeVisible()
-    expect(screen.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
+    expect(screen.getAllByText(/audit-reset-serviceadmin/i)[0]).toBeVisible()
     expect(screen.getAllByText(/submitted to broker/i)[0]).toBeVisible()
     expect(screen.getByText(/raw value was not revealed/i)).toBeVisible()
     expect(
       screen.getByText(/rotation can be requested without controlled reveal/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/Audit event/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/audit-reset-serviceadmin-session-signing-preview/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(
+        /corr-reset-serviceadmin-session-signing-submitted/i
+      )[0]
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/recorded and waiting for broker terminal status/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getByText(/allowlisted fields only: ref, action/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/dependent service restart remains pending/i)[0]
     ).toBeVisible()
     expect(
       screen.getAllByText(/rotation retry is operation-id scoped/i)[0]
@@ -815,6 +833,20 @@ describe('Secrets Broker secrets management page', () => {
       nextAction:
         'monitor dependent service restart notes and rotation freshness',
     })
+    expect(appliedResult.auditFeedback).toMatchObject({
+      auditEventId: 'audit-reset-serviceadmin-session-signing-preview',
+      correlationId: 'corr-reset-serviceadmin-session-signing-applied',
+      eventState: 'settled with broker success metadata',
+      dependentServiceStatus:
+        'dependent service restart metadata ready for operator review',
+      sinkStatus: 'audit sink available in stub metadata model',
+    })
+    expect(appliedResult.auditFeedback.evidenceRows).toEqual(
+      expect.arrayContaining([
+        'audit payload excludes raw values and credential material',
+        'route, query string, local storage, and diagnostics receive no secret material',
+      ])
+    )
 
     const deniedResult = buildSingleSecretOperationResult(
       managedSecretRows[0],
@@ -858,6 +890,11 @@ describe('Secrets Broker secrets management page', () => {
       auditEventId: 'audit-reset-serviceadmin-session-signing-1',
       statusBadge: 'apply failed',
       submittedAt: 'stub-sequence-1',
+    })
+    expect(historyEntry.auditFeedback).toMatchObject({
+      auditEventId: 'audit-reset-serviceadmin-session-signing-1',
+      correlationId: 'corr-reset-serviceadmin-session-signing-failed',
+      eventState: 'recorded as safe broker failure metadata',
     })
     expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(
       false

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -74,6 +74,16 @@ export type SingleSecretOperationOutcome =
   | 'failed'
   | 'stale-plan'
 
+export type SingleSecretAuditFeedback = {
+  auditEventId: string
+  correlationId: string
+  eventState: string
+  redactionStatus: string
+  dependentServiceStatus: string
+  sinkStatus: string
+  evidenceRows: string[]
+}
+
 export type SingleSecretOperationResult = {
   operationId: string
   ref: string
@@ -86,6 +96,7 @@ export type SingleSecretOperationResult = {
   recoveryStatus: string
   retryPolicy: string
   recoverySteps: string[]
+  auditFeedback: SingleSecretAuditFeedback
   safetyRows: string[]
   nextAction: string
 }
@@ -1287,6 +1298,14 @@ function safeOperationSlug(action: ManagedSecretAction, row: ManagedSecretRow) {
     .replace(/^-+|-+$/g, '')
 }
 
+function auditEventIdForSingleSecretAction(
+  action: ManagedSecretAction,
+  row: ManagedSecretRow,
+  suffix = 'preview'
+) {
+  return `audit-${safeOperationSlug(action, row)}-${suffix}`
+}
+
 function safePayloadFieldsForSingleSecretAction(action: ManagedSecretAction) {
   const baseFields = [
     'ref',
@@ -1546,6 +1565,12 @@ export function buildSingleSecretOperationResult(
           : plan.action === 'delete' || plan.action === 'policy'
             ? 'fresh plan required before any retry'
             : 'retry only by operation id when broker marks the attempt retry-safe'
+  const auditFeedback = buildSingleSecretAuditFeedback(
+    row,
+    plan,
+    outcome,
+    auditEventIdForSingleSecretAction(plan.action, row)
+  )
 
   return {
     operationId: plan.operationId,
@@ -1559,6 +1584,7 @@ export function buildSingleSecretOperationResult(
     recoveryStatus,
     retryPolicy,
     recoverySteps,
+    auditFeedback,
     safetyRows: [
       'raw value was not revealed',
       'request body is limited to ref, operation id, action, owner, provider, policy, and audit reason metadata',
@@ -1575,6 +1601,53 @@ export function buildSingleSecretOperationResult(
   }
 }
 
+export function buildSingleSecretAuditFeedback(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  outcome: SingleSecretOperationOutcome,
+  auditEventId: string
+): SingleSecretAuditFeedback {
+  const eventState =
+    outcome === 'applied'
+      ? 'settled with broker success metadata'
+      : outcome === 'submitted'
+        ? 'recorded and waiting for broker terminal status'
+        : outcome === 'policy-denied'
+          ? 'recorded as policy denial with no source access'
+          : outcome === 'auth-required'
+            ? 'recorded as auth challenge with no source access'
+            : outcome === 'stale-plan'
+              ? 'recorded as stale-plan rejection'
+              : 'recorded as safe broker failure metadata'
+  const dependentServiceStatus =
+    plan.action === 'reset'
+      ? outcome === 'applied'
+        ? 'dependent service restart metadata ready for operator review'
+        : 'dependent service restart remains pending broker success metadata'
+      : plan.action === 'delete'
+        ? 'dependent service refs retained for decommission review'
+        : plan.action === 'policy'
+          ? 'policy consumers require fresh authorization metadata review'
+          : 'no dependent service restart requested by this action'
+
+  return {
+    auditEventId,
+    correlationId: `corr-${safeOperationSlug(plan.action, row)}-${outcome}`,
+    eventState,
+    redactionStatus:
+      'allowlisted fields only: ref, action, operation id, policy, owner, provider, outcome, and timestamps',
+    dependentServiceStatus,
+    sinkStatus: row.auditStatus.includes('available')
+      ? 'audit sink available in stub metadata model'
+      : 'audit sink requires broker confirmation before apply',
+    evidenceRows: [
+      'audit payload excludes raw values and credential material',
+      'operator reason is stored as metadata, not as a secret field',
+      'route, query string, local storage, and diagnostics receive no secret material',
+    ],
+  }
+}
+
 export function buildSingleSecretOperationHistoryEntry(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -1586,10 +1659,22 @@ export function buildSingleSecretOperationHistoryEntry(
 
   return {
     ...result,
+    auditFeedback: {
+      ...result.auditFeedback,
+      auditEventId: auditEventIdForSingleSecretAction(
+        plan.action,
+        row,
+        String(safeSequence)
+      ),
+    },
     rowName: row.name,
     provider: row.provider,
     policy: row.policy,
-    auditEventId: `audit-${safeOperationSlug(plan.action, row)}-${safeSequence}`,
+    auditEventId: auditEventIdForSingleSecretAction(
+      plan.action,
+      row,
+      String(safeSequence)
+    ),
     statusBadge: result.resultBadge,
     submittedAt: `stub-sequence-${safeSequence}`,
   }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -272,11 +272,30 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/Single-secret operation result: submitted/i)
     ).toBeVisible()
     await expect(page.getByText(/1 submitted/i)).toBeVisible()
-    await expect(page.getByText(/audit-reset-serviceadmin/i)).toBeVisible()
+    await expect(
+      page.getByText(/audit-reset-serviceadmin/i).first()
+    ).toBeVisible()
     await expect(page.getByText(/submitted to broker/i).first()).toBeVisible()
     await expect(page.getByText(/raw value was not revealed/i)).toBeVisible()
     await expect(
       page.getByText(/rotation can be requested without controlled reveal/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/audit-reset-serviceadmin-session-signing-preview/i)
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(/corr-reset-serviceadmin-session-signing-submitted/i)
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/recorded and waiting for broker terminal status/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/allowlisted fields only: ref, action/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/dependent service restart remains pending/i).first()
     ).toBeVisible()
     await expect(
       page.getByText(/rotation retry is operation-id scoped/i).first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds metadata-only audit/status feedback to single-secret operation results and history.
- Shows audit event id, correlation id, audit state, sink state, dependent-service status, and redaction evidence after a simulated single-secret submit.
- Extends unit and Playwright coverage for the audit feedback path while preserving no raw value rendering.

## Scope
- In scope: single-secret stub status/audit feedback for the existing Secrets page workflow.
- Out of scope: live Secrets Broker mutation API wiring, full #231 completion, and bulk campaign changes.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin stub model for single-secret operation feedback.
- Not required because: no production API/schema/route contract changed.

## Nash invariant impact
- Invariant: secrets UI must remain metadata-only by default and must not render raw values or credential material.
- Preservation proof: audit feedback uses allowlisted metadata only and existing leakage tests were extended.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-audit-status-feedback.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-audit-status-feedback.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-audit-status-feedback.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-audit-status-feedback.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-audit-status-feedback.log`

## Approval trail
- Required: no special approval requirement documented for this focused UI/test advancement.
- Evidence: branch pushed from clean `master` and this PR awaits hosted CI.

## Release / demo gate
- Pending. This Service Admin UI change is demo-consumed and must be merged, released, pinned in `service-lasso/service-lasso`, recycled on canonical port `17883`, and verified before #231 can be claimed done.

## Cleanup
- Branch cleanup after merge/release/demo pin: delete `agent/issue-231-audit-status-feedback` once safe.