### PR TITLE
ISS-231 add decommission preview gate

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -62,6 +62,7 @@ import {
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionPreview,
   buildManagedSecretActionReadiness,
+  buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
@@ -203,6 +204,10 @@ export function SecretsManagementPage() {
     confirmed,
     stubState
   )
+  const decommissionPreview =
+    selectedAction === 'delete'
+      ? buildSingleSecretDecommissionPreview(selectedRow, singleOperationPlan)
+      : null
   const bulkPlan = useMemo(
     () =>
       buildBulkSecretCampaignPlan(
@@ -1501,6 +1506,88 @@ export function SecretsManagementPage() {
                 )}
               </div>
             </div>
+            {decommissionPreview ? (
+              <div className='rounded-md border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <Trash2 className='size-4 text-primary' />
+                  <div className='font-medium'>
+                    Delete/decommission safety preview
+                  </div>
+                  <Badge
+                    variant={
+                      decommissionPreview.eligible ? 'default' : 'secondary'
+                    }
+                  >
+                    {decommissionPreview.badge}
+                  </Badge>
+                  <Badge variant='outline'>{decommissionPreview.mode}</Badge>
+                </div>
+                <div className='grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Recovery plan
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {decommissionPreview.recoveryPlanRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Tombstone
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {decommissionPreview.tombstoneRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Retention
+                    </div>
+                    <div className='mt-1'>
+                      {decommissionPreview.retentionStatus}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Apply gate
+                    </div>
+                    <div className='mt-1'>{decommissionPreview.applyGate}</div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Dependent services
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {decommissionPreview.dependentServiceRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Safe metadata proof
+                    </div>
+                    <div className='mt-2'>{decommissionPreview.auditTrail}</div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {decommissionPreview.safeMetadataRows.map((row) => (
+                        <li key={row}>{row}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                {decommissionPreview.blockers.length > 0 ? (
+                  <div className='mt-3 flex flex-wrap gap-1'>
+                    {decommissionPreview.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             <div className='flex flex-wrap gap-2'>
               <Button type='button' disabled>
                 Apply disabled until dry-run preview is accepted

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -7,6 +7,7 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionReadiness,
+  buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
@@ -15,6 +16,7 @@ import {
   managedSecretBulkApplyResultHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
+  managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -629,6 +631,22 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/recovery guidance/i)[0]).toBeVisible()
     expect(screen.getByText(/dependent service references/i)).toBeVisible()
     expect(screen.getByText(/recoveryPlanRef/i)).toBeVisible()
+    expect(
+      screen.getByText(/Delete\/decommission safety preview/i)
+    ).toBeVisible()
+    expect(screen.getByText(/decommission preview ready/i)).toBeVisible()
+    expect(
+      screen.getByText(/recovery-delete-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /tombstone-delete-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/@serviceadmin runtime session loader/i)
+    ).toBeVisible()
+    expect(screen.getByText(/current secret value is not read/i)).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Apply policy preview/i })[0]
@@ -982,6 +1000,50 @@ describe('Secrets Broker secrets management page', () => {
       true,
       'ready'
     )
+    const decommissionPreview = buildSingleSecretDecommissionPreview(
+      managedSecretRows[0],
+      deletePlan
+    )
+    expect(decommissionPreview).toMatchObject({
+      mode: 'decommission',
+      eligible: true,
+      badge: 'decommission preview ready',
+      recoveryPlanRef: 'recovery-delete-serviceadmin-session-signing-metadata',
+      tombstoneRef: 'tombstone-delete-serviceadmin-session-signing-metadata',
+      applyGate:
+        'ready for broker-owned delete/decommission submit after final revalidation',
+    })
+    expect(decommissionPreview.dependentServiceRefs).toEqual(
+      expect.arrayContaining(['@serviceadmin runtime session loader'])
+    )
+    expect(decommissionPreview.safeMetadataRows).toEqual(
+      expect.arrayContaining([
+        'current secret value is not read before delete/decommission preview',
+        'recovery plan reference is metadata-only and does not embed secret material',
+      ])
+    )
+    expect(
+      managedSecretDecommissionPreviewHasSecretMaterial(decommissionPreview)
+    ).toBe(false)
+
+    const blockedDecommissionPreview = buildSingleSecretDecommissionPreview(
+      managedSecretRows[3],
+      missingDeletePlan
+    )
+    expect(blockedDecommissionPreview).toMatchObject({
+      eligible: false,
+      badge: 'disable preview blocked',
+      applyGate: 'ref unavailable',
+    })
+    expect(blockedDecommissionPreview.blockers).toEqual(
+      expect.arrayContaining(['ref unavailable', 'delete dry-run unsupported'])
+    )
+    expect(
+      managedSecretDecommissionPreviewHasSecretMaterial(
+        blockedDecommissionPreview
+      )
+    ).toBe(false)
+
     const deleteResult = buildSingleSecretOperationResult(
       managedSecretRows[0],
       deletePlan

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -101,6 +101,22 @@ export type SingleSecretOperationResult = {
   nextAction: string
 }
 
+export type SingleSecretDecommissionPreview = {
+  ref: string
+  operationId: string
+  mode: 'disable' | 'decommission'
+  eligible: boolean
+  badge: string
+  dependentServiceRefs: string[]
+  recoveryPlanRef: string
+  tombstoneRef: string
+  retentionStatus: string
+  auditTrail: string
+  applyGate: string
+  blockers: string[]
+  safeMetadataRows: string[]
+}
+
 export type SingleSecretOperationHistoryEntry = SingleSecretOperationResult & {
   rowName: string
   provider: string
@@ -413,6 +429,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:stub-mutation-preview',
     'secrets-management:stub-mutation-apply-status',
     'secrets-management:single-secret-operation-history',
+    'secrets-management:single-secret-decommission-preview',
     'secrets-management:stub-delete-preview',
     'secrets-management:bulk-campaign-dry-run',
     'secrets-management:bulk-campaign-apply',
@@ -1441,6 +1458,58 @@ export function buildSingleSecretOperationPlan(
   }
 }
 
+export function buildSingleSecretDecommissionPreview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretDecommissionPreview {
+  const blockers = [...plan.blockers]
+
+  if (plan.action !== 'delete') {
+    blockers.push('select delete action')
+  }
+
+  const providerBacked = row.provider === 'provider connection'
+  const dependentServiceRefs =
+    row.owningService === '@serviceadmin'
+      ? ['@serviceadmin runtime session loader', '@secretsbroker audit sink']
+      : [
+          `${row.owningService} runtime binding`,
+          `${row.workspace} workspace policy reference`,
+        ]
+  const mode = providerBacked ? 'disable' : 'decommission'
+  const eligible = blockers.length === 0
+  const actionLabel = mode === 'disable' ? 'disable' : 'decommission'
+
+  return {
+    ref: row.ref,
+    operationId: plan.operationId,
+    mode,
+    eligible,
+    badge: eligible
+      ? `${actionLabel} preview ready`
+      : `${actionLabel} preview blocked`,
+    dependentServiceRefs,
+    recoveryPlanRef: `recovery-${safeOperationSlug('delete', row)}-metadata`,
+    tombstoneRef: `tombstone-${safeOperationSlug('delete', row)}-metadata`,
+    retentionStatus: eligible
+      ? 'redacted tombstone and recovery metadata retained for audit review'
+      : 'no tombstone or recovery metadata will be written while blocked',
+    auditTrail: eligible
+      ? 'audit reason, operation id, dependency refs, and policy metadata are ready for broker submit'
+      : 'audit trail records blocker metadata only; no source access or deletion attempted',
+    applyGate: eligible
+      ? 'ready for broker-owned delete/decommission submit after final revalidation'
+      : blockers[0],
+    blockers,
+    safeMetadataRows: [
+      'current secret value is not read before delete/decommission preview',
+      'dependent service refs are names only and contain no environment values',
+      'recovery plan reference is metadata-only and does not embed secret material',
+      'tombstone reference is redacted and cannot restore a value by itself',
+    ],
+  }
+}
+
 export function buildSingleSecretOperationResult(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -1707,6 +1776,12 @@ export function managedSecretSingleHistoryHasSecretMaterial(
   entries: SingleSecretOperationHistoryEntry[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretDecommissionPreviewHasSecretMaterial(
+  preview: SingleSecretDecommissionPreview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(preview))
 }
 
 export function managedSecretActionReadinessHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -197,6 +197,23 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/dependent service references and recovery guidance/i)
     ).toBeVisible()
     await expect(page.getByText(/recoveryPlanRef/i)).toBeVisible()
+    await expect(
+      page.getByText(/Delete\/decommission safety preview/i)
+    ).toBeVisible()
+    await expect(page.getByText(/decommission preview blocked/i)).toBeVisible()
+    await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/recovery-delete-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/tombstone-delete-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/@serviceadmin runtime session loader/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/current secret value is not read/i)
+    ).toBeVisible()
     await page
       .getByRole('button', { name: /Apply policy preview/i })
       .first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only delete/decommission safety preview for the Secrets page single-secret delete path.
- Shows recovery plan ref, redacted tombstone ref, retention status, dependent service refs, apply gate, blockers, and safe metadata proof before any simulated submit.
- Extends unit and browser coverage to prove the preview stays fail-closed and raw values remain hidden.

## Scope
- In scope: single-secret delete/decommission preview modeling and UI evidence for the existing #231 Secrets workflow.
- Out of scope: production Secrets Broker mutation API wiring, issue-wide closure, release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin stub model for delete/decommission preview metadata.
- Not required because: no public backend API/schema contract changes; this remains a UI/model slice for the existing stub preview surface.

## Nash invariant impact
- Invariant: Secrets Broker UI must not reveal raw values or credential material.
- Preservation proof: preview payload is metadata-only; tests assert no forbidden secret material in fixtures, modeled preview, and browser text.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-decommission-preview.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table search"` — `.work-agent/logs/issue-231/playwright-secrets-decommission-preview.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-decommission-preview.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-decommission-preview.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-decommission-preview.log`

## Approval trail
- Required: no special approval documented for this focused UI/model advancement.
- Evidence: #231 is Project #1 Ready / Ready for Agent; prior validated slices are continuing the same issue.

## Cleanup
- Branch: `agent/issue-231-decommission-preview`
- Release-to-demo gate remains pending until this PR is merged, Service Admin releases, core `@serviceadmin` pin is updated, and the canonical demo on port `17883` is recycled/verified.
