### PR TITLE
feat(secrets): add single-secret policy preview detail

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -64,6 +64,7 @@ import {
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
+  buildSingleSecretPolicyPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -207,6 +208,10 @@ export function SecretsManagementPage() {
   const decommissionPreview =
     selectedAction === 'delete'
       ? buildSingleSecretDecommissionPreview(selectedRow, singleOperationPlan)
+      : null
+  const policyPreview =
+    selectedAction === 'policy'
+      ? buildSingleSecretPolicyPreview(selectedRow, singleOperationPlan)
       : null
   const bulkPlan = useMemo(
     () =>
@@ -1580,6 +1585,108 @@ export function SecretsManagementPage() {
                 {decommissionPreview.blockers.length > 0 ? (
                   <div className='mt-3 flex flex-wrap gap-1'>
                     {decommissionPreview.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            {policyPreview ? (
+              <div className='rounded-md border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <ShieldCheck className='size-4 text-primary' />
+                  <div className='font-medium'>
+                    Policy assignment safety preview
+                  </div>
+                  <Badge
+                    variant={policyPreview.eligible ? 'default' : 'secondary'}
+                  >
+                    {policyPreview.badge}
+                  </Badge>
+                  <Badge variant='outline'>Metadata only</Badge>
+                </div>
+                <div className='grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Current policy
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {policyPreview.currentPolicyRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Target policy
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {policyPreview.targetPolicyRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Rollback plan
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {policyPreview.rollbackPlanRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Apply gate
+                    </div>
+                    <div className='mt-1'>{policyPreview.applyGate}</div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Policy diff metadata
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {policyPreview.policyDiffMetadata.map((row) => (
+                        <li key={row}>{row}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Affected consumers
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {policyPreview.affectedConsumerRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Enforcement checks
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {policyPreview.enforcementChecks.map((check) => (
+                        <li key={check}>{check}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Safe metadata proof
+                    </div>
+                    <div className='mt-2'>{policyPreview.auditTrail}</div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {policyPreview.safeMetadataRows.map((row) => (
+                        <li key={row}>{row}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                {policyPreview.blockers.length > 0 ? (
+                  <div className='mt-3 flex flex-wrap gap-1'>
+                    {policyPreview.blockers.map((blocker) => (
                       <Badge key={blocker} variant='outline'>
                         {blocker}
                       </Badge>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -9,6 +9,7 @@ import {
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
+  buildSingleSecretPolicyPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -17,6 +18,7 @@ import {
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
   managedSecretDecommissionPreviewHasSecretMaterial,
+  managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -658,9 +660,26 @@ describe('Secrets Broker secrets management page', () => {
       screen.getAllByText(/policy preview required before apply/i)[0]
     ).toBeVisible()
     expect(
-      screen.getByText(/target policy assignment diff checked/i)
+      screen.getAllByText(/target policy assignment diff checked/i)[0]
     ).toBeVisible()
-    expect(screen.getByText(/targetPolicyRef/i)).toBeVisible()
+    expect(screen.getByText('targetPolicyRef', { exact: true })).toBeVisible()
+    expect(screen.getByText(/Policy assignment safety preview/i)).toBeVisible()
+    expect(screen.getByText(/policy preview ready/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        'policy/openclaw/service-lasso/serviceadmin/least-privilege-single-ref',
+        { exact: true }
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/rollback-policy-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    expect(screen.getByText(/@serviceadmin operator API/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        /policy preview never reads or writes the current secret value/i
+      )
+    ).toBeVisible()
     expect(
       screen.getByRole('button', {
         name: /Apply disabled until dry-run preview is accepted/i,
@@ -992,6 +1011,69 @@ describe('Secrets Broker secrets management page', () => {
         'reapply previous policy only through a fresh audited preview',
       ])
     )
+    const policyPreview = buildSingleSecretPolicyPreview(
+      managedSecretRows[0],
+      singlePolicyPlan
+    )
+    expect(policyPreview).toMatchObject({
+      eligible: true,
+      badge: 'policy preview ready',
+      currentPolicyRef: 'policy/openclaw/service-lasso/read-single-secret',
+      targetPolicyRef:
+        'policy/openclaw/service-lasso/serviceadmin/least-privilege-single-ref',
+      rollbackPlanRef: 'rollback-policy-serviceadmin-session-signing-metadata',
+      applyGate:
+        'ready for broker-owned policy assignment submit after final revalidation',
+    })
+    expect(policyPreview.policyDiffMetadata).toEqual(
+      expect.arrayContaining([
+        'previousPolicyRef: policy/openclaw/service-lasso/read-single-secret',
+        'targetPolicyRef: policy/openclaw/service-lasso/serviceadmin/least-privilege-single-ref',
+      ])
+    )
+    expect(policyPreview.affectedConsumerRefs).toEqual(
+      expect.arrayContaining(['@serviceadmin operator API'])
+    )
+    expect(policyPreview.enforcementChecks).toEqual(
+      expect.arrayContaining([
+        'per-service resolve policy is revalidated before submit',
+        'audit writer availability is required before apply',
+      ])
+    )
+    expect(policyPreview.safeMetadataRows).toEqual(
+      expect.arrayContaining([
+        'policy preview never reads or writes the current secret value',
+        'rollback plan reference contains previous policy metadata only',
+      ])
+    )
+    expect(managedSecretPolicyPreviewHasSecretMaterial(policyPreview)).toBe(
+      false
+    )
+
+    const missingPolicyPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[3],
+      'policy',
+      'operator requested policy assignment preview',
+      true,
+      'ready'
+    )
+    const blockedPolicyPreview = buildSingleSecretPolicyPreview(
+      managedSecretRows[3],
+      missingPolicyPlan
+    )
+    expect(blockedPolicyPreview).toMatchObject({
+      eligible: false,
+      badge: 'policy preview blocked',
+      targetPolicyRef:
+        'policy/openclaw/service-lasso/payments-single-ref-review',
+      applyGate: 'ref unavailable',
+    })
+    expect(blockedPolicyPreview.blockers).toEqual(
+      expect.arrayContaining(['ref unavailable', 'policy preview unsupported'])
+    )
+    expect(
+      managedSecretPolicyPreviewHasSecretMaterial(blockedPolicyPreview)
+    ).toBe(false)
 
     const deletePlan = buildSingleSecretOperationPlan(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -117,6 +117,23 @@ export type SingleSecretDecommissionPreview = {
   safeMetadataRows: string[]
 }
 
+export type SingleSecretPolicyPreview = {
+  ref: string
+  operationId: string
+  eligible: boolean
+  badge: string
+  currentPolicyRef: string
+  targetPolicyRef: string
+  policyDiffMetadata: string[]
+  affectedConsumerRefs: string[]
+  rollbackPlanRef: string
+  auditTrail: string
+  applyGate: string
+  blockers: string[]
+  enforcementChecks: string[]
+  safeMetadataRows: string[]
+}
+
 export type SingleSecretOperationHistoryEntry = SingleSecretOperationResult & {
   rowName: string
   provider: string
@@ -430,6 +447,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:stub-mutation-apply-status',
     'secrets-management:single-secret-operation-history',
     'secrets-management:single-secret-decommission-preview',
+    'secrets-management:single-secret-policy-preview',
     'secrets-management:stub-delete-preview',
     'secrets-management:bulk-campaign-dry-run',
     'secrets-management:bulk-campaign-apply',
@@ -1510,6 +1528,82 @@ export function buildSingleSecretDecommissionPreview(
   }
 }
 
+function singlePolicyTargetForRow(row: ManagedSecretRow) {
+  if (row.owningService === 'payments-api') {
+    return 'policy/openclaw/service-lasso/payments-single-ref-review'
+  }
+
+  const ownerSlug = row.owningService
+    .replace(/^@/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return `policy/openclaw/service-lasso/${ownerSlug || 'service'}/least-privilege-single-ref`
+}
+
+function policyConsumerRefsForRow(row: ManagedSecretRow) {
+  if (row.owningService === '@serviceadmin') {
+    return ['@serviceadmin operator API', '@serviceadmin secret action UI']
+  }
+
+  return [
+    `${row.owningService} runtime resolve policy`,
+    `${row.workspace} workspace authorization map`,
+  ]
+}
+
+export function buildSingleSecretPolicyPreview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretPolicyPreview {
+  const blockers = [...plan.blockers]
+
+  if (plan.action !== 'policy') {
+    blockers.push('select policy action')
+  }
+
+  const eligible = blockers.length === 0
+  const targetPolicyRef = singlePolicyTargetForRow(row)
+  const affectedConsumerRefs = policyConsumerRefsForRow(row)
+
+  return {
+    ref: row.ref,
+    operationId: plan.operationId,
+    eligible,
+    badge: eligible ? 'policy preview ready' : 'policy preview blocked',
+    currentPolicyRef: row.policy,
+    targetPolicyRef,
+    policyDiffMetadata: [
+      `previousPolicyRef: ${row.policy}`,
+      `targetPolicyRef: ${targetPolicyRef}`,
+      `scope: ${row.owningService} / ${row.workspace}`,
+      'decision fields: allow, deny, audit-required, auth-required',
+    ],
+    affectedConsumerRefs,
+    rollbackPlanRef: `rollback-${safeOperationSlug('policy', row)}-metadata`,
+    auditTrail: eligible
+      ? 'audit reason, operation id, previous policy, target policy, and consumer refs are ready for broker submit'
+      : 'audit trail records blocker metadata only; no policy assignment will be written while blocked',
+    applyGate: eligible
+      ? 'ready for broker-owned policy assignment submit after final revalidation'
+      : blockers[0],
+    blockers,
+    enforcementChecks: [
+      'target policy assignment diff checked as metadata only',
+      'per-service resolve policy is revalidated before submit',
+      'audit writer availability is required before apply',
+      'readonly or missing refs fail closed before policy assignment',
+    ],
+    safeMetadataRows: [
+      'policy preview never reads or writes the current secret value',
+      'affected consumers are service or workspace refs, not environment values',
+      'rollback plan reference contains previous policy metadata only',
+      'policy diff excludes raw payloads, tokens, cookies, keys, and provider credentials',
+    ],
+  }
+}
+
 export function buildSingleSecretOperationResult(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -1780,6 +1874,12 @@ export function managedSecretSingleHistoryHasSecretMaterial(
 
 export function managedSecretDecommissionPreviewHasSecretMaterial(
   preview: SingleSecretDecommissionPreview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(preview))
+}
+
+export function managedSecretPolicyPreviewHasSecretMaterial(
+  preview: SingleSecretPolicyPreview
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(preview))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -219,9 +219,30 @@ test.describe('Secrets Broker browser coverage', () => {
       .first()
       .click()
     await expect(
-      page.getByText(/target policy assignment diff checked/i)
+      page.getByText(/target policy assignment diff checked/i).first()
     ).toBeVisible()
-    await expect(page.getByText(/targetPolicyRef/i)).toBeVisible()
+    await expect(
+      page.getByText('targetPolicyRef', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Policy assignment safety preview/i)
+    ).toBeVisible()
+    await expect(page.getByText(/policy preview blocked/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        'policy/openclaw/service-lasso/serviceadmin/least-privilege-single-ref',
+        { exact: true }
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/rollback-policy-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(page.getByText(/@serviceadmin operator API/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /policy preview never reads or writes the current secret value/i
+      )
+    ).toBeVisible()
 
     await page.getByPlaceholder(/Search secret metadata/i).fill('payments')
     await page.getByRole('button', { name: /Delete dry-run/ }).click()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Added a metadata-only single-secret policy assignment preview model for the Secrets page.
- Surfaces current policy, target policy, policy diff metadata, affected consumers, rollback plan ref, enforcement checks, blockers, and safe audit proof before any apply path.
- Extended unit and browser coverage for ready/blocked policy previews and no raw secret material leakage.

## Scope
- In scope: focused #231 policy-preview detail for one selected secret ref.
- Out of scope: full production mutation API wiring, bulk policy campaigns beyond existing scaffolding, release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin fixture/model contract for single-secret policy preview only.
- Not required because: no public backend API/schema change; this remains a Service Admin stub/preview model until Secrets Broker mutation contracts are wired.

## Nash invariant impact
- Invariant: raw secret values, provider credentials, tokens, cookies, private keys, recovery material, and raw environment values must not render or persist.
- Preservation proof: policy preview fields are policy refs, operation ids, consumer refs, rollback metadata refs, and audit metadata only; tests assert modeled previews and browser surface do not reveal forbidden secret material.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-policy-preview.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table search"` — `.work-agent/logs/issue-231/playwright-secrets-policy-preview.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-policy-preview.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-policy-preview.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-policy-preview.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: branch is scoped to #231 and PR CI will run on GitHub.

## Cleanup
- Branch cleanup after merge/release/pin/demo gate: delete `agent/issue-231-policy-preview-detail` after PR merge and Service Admin release is pinned into core demo.
- Release-to-demo gate: pending. This Service Admin UI change is demo-consumed and must be merged, released, pinned in `service-lasso/service-lasso`, recycled on canonical port `17883`, and verified before claiming #231 done.