### PR TITLE
feat(secrets): add reveal challenge preview

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -65,6 +65,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
+  buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -205,6 +206,10 @@ export function SecretsManagementPage() {
     confirmed,
     stubState
   )
+  const revealPreview =
+    selectedAction === 'reveal'
+      ? buildSingleSecretRevealPreview(selectedRow, singleOperationPlan)
+      : null
   const decommissionPreview =
     selectedAction === 'delete'
       ? buildSingleSecretDecommissionPreview(selectedRow, singleOperationPlan)
@@ -1511,6 +1516,110 @@ export function SecretsManagementPage() {
                 )}
               </div>
             </div>
+            {revealPreview ? (
+              <div className='rounded-md border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <Eye className='size-4 text-primary' />
+                  <div className='font-medium'>
+                    Controlled reveal challenge preview
+                  </div>
+                  <Badge
+                    variant={revealPreview.eligible ? 'default' : 'secondary'}
+                  >
+                    {revealPreview.badge}
+                  </Badge>
+                  <Badge variant='outline'>Value hidden</Badge>
+                </div>
+                <div className='grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Challenge
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {revealPreview.revealChallengeId}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Expires
+                    </div>
+                    <div className='mt-1'>
+                      {revealPreview.challengeExpiresAt}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Audit event
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {revealPreview.auditEventId}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Apply gate
+                    </div>
+                    <div className='mt-1'>{revealPreview.applyGate}</div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Reveal window and auth
+                    </div>
+                    <div className='mt-2'>{revealPreview.revealWindow}</div>
+                    <div className='mt-2 text-muted-foreground'>
+                      {revealPreview.authRequirement}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      {revealPreview.auditSinkStatus}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Dependent consumers
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {revealPreview.dependentConsumerRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Display guardrails
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {revealPreview.displayGuardrails.map((guardrail) => (
+                        <li key={guardrail}>{guardrail}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Safe metadata proof
+                    </div>
+                    <div className='mt-2'>{revealPreview.policyDecision}</div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {revealPreview.safeMetadataRows.map((row) => (
+                        <li key={row}>{row}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                {revealPreview.blockers.length > 0 ? (
+                  <div className='mt-3 flex flex-wrap gap-1'>
+                    {revealPreview.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
             {decommissionPreview ? (
               <div className='rounded-md border p-3'>
                 <div className='mb-3 flex flex-wrap items-center gap-2'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -10,6 +10,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
+  buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildStubSecretMutationPreview,
@@ -19,6 +20,7 @@ import {
   managedSecretActionReadinessHasSecretMaterial,
   managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
+  managedSecretRevealPreviewHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -533,6 +535,29 @@ describe('Secrets Broker secrets management page', () => {
       screen.getByText(/ready for controlled reveal handoff/i)
     ).toBeVisible()
     expect(screen.getByText(/Uses the #38 reveal pattern/i)).toBeVisible()
+    expect(
+      screen.getByText(/Controlled reveal challenge preview/i)
+    ).toBeVisible()
+    expect(screen.getByText(/reveal challenge blocked/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        /challenge-reveal-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/audit-reveal-serviceadmin-session-signing-preview/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/no reveal window is opened while blocked/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/value stays hidden until the broker returns/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /raw secret value is not fetched during preview generation/i
+      )
+    ).toBeVisible()
 
     await user.click(
       screen.getAllByRole('button', { name: /Edit\/update dry-run/i })[0]
@@ -956,6 +981,65 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(
       managedSecretActionReadinessHasSecretMaterial(missingActionReadiness)
+    ).toBe(false)
+
+    const revealPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[0],
+      'reveal',
+      'operator requested controlled reveal',
+      true,
+      'ready'
+    )
+    const revealPreview = buildSingleSecretRevealPreview(
+      managedSecretRows[0],
+      revealPlan
+    )
+    expect(revealPreview).toMatchObject({
+      eligible: true,
+      badge: 'reveal challenge ready',
+      revealChallengeId:
+        'challenge-reveal-serviceadmin-session-signing-metadata',
+      auditEventId: 'audit-reveal-serviceadmin-session-signing-preview',
+      applyGate:
+        'ready for broker-owned reveal challenge after final revalidation',
+    })
+    expect(revealPreview.displayGuardrails).toEqual(
+      expect.arrayContaining([
+        'value stays hidden until the broker returns an authorized short-lived display',
+        'copy and export remain unavailable from this management table',
+      ])
+    )
+    expect(revealPreview.safeMetadataRows).toEqual(
+      expect.arrayContaining([
+        'raw secret value is not fetched during preview generation',
+        'route, query string, local storage, diagnostics, and support bundles receive no secret material',
+      ])
+    )
+    expect(managedSecretRevealPreviewHasSecretMaterial(revealPreview)).toBe(
+      false
+    )
+
+    const missingRevealPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[3],
+      'reveal',
+      'operator requested controlled reveal',
+      true,
+      'ready'
+    )
+    const blockedRevealPreview = buildSingleSecretRevealPreview(
+      managedSecretRows[3],
+      missingRevealPlan
+    )
+    expect(blockedRevealPreview).toMatchObject({
+      eligible: false,
+      badge: 'reveal challenge blocked',
+      applyGate: 'ref unavailable',
+    })
+    expect(blockedRevealPreview.blockers).toEqual(
+      expect.arrayContaining(['ref unavailable', 'reveal unsupported'])
+    )
+    expect(
+      managedSecretRevealPreviewHasSecretMaterial(blockedRevealPreview)
     ).toBe(false)
 
     const missingDeletePlan = buildSingleSecretOperationPlan(

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -134,6 +134,25 @@ export type SingleSecretPolicyPreview = {
   safeMetadataRows: string[]
 }
 
+export type SingleSecretRevealPreview = {
+  ref: string
+  operationId: string
+  eligible: boolean
+  badge: string
+  revealChallengeId: string
+  challengeExpiresAt: string
+  revealWindow: string
+  auditEventId: string
+  auditSinkStatus: string
+  policyDecision: string
+  authRequirement: string
+  dependentConsumerRefs: string[]
+  displayGuardrails: string[]
+  applyGate: string
+  blockers: string[]
+  safeMetadataRows: string[]
+}
+
 export type SingleSecretOperationHistoryEntry = SingleSecretOperationResult & {
   rowName: string
   provider: string
@@ -1476,6 +1495,70 @@ export function buildSingleSecretOperationPlan(
   }
 }
 
+function revealConsumerRefsForRow(row: ManagedSecretRow) {
+  if (row.owningService === '@serviceadmin') {
+    return ['@serviceadmin operator session', '@secretsbroker audit writer']
+  }
+
+  return [
+    `${row.owningService} controlled reveal request`,
+    `${row.workspace} workspace audit trail`,
+  ]
+}
+
+export function buildSingleSecretRevealPreview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretRevealPreview {
+  const blockers = [...plan.blockers]
+
+  if (plan.action !== 'reveal') {
+    blockers.push('select reveal action')
+  }
+
+  const eligible = blockers.length === 0
+  const challengeSlug = safeOperationSlug('reveal', row)
+
+  return {
+    ref: row.ref,
+    operationId: plan.operationId,
+    eligible,
+    badge: eligible ? 'reveal challenge ready' : 'reveal challenge blocked',
+    revealChallengeId: `challenge-${challengeSlug}-metadata`,
+    challengeExpiresAt: '2026-06-21T07:20:00Z',
+    revealWindow: eligible
+      ? 'short-lived display window starts only after broker authorization'
+      : 'no reveal window is opened while blocked',
+    auditEventId: auditEventIdForSingleSecretAction('reveal', row),
+    auditSinkStatus: row.auditStatus.includes('available')
+      ? 'audit sink ready for challenge metadata'
+      : 'audit sink must be confirmed before reveal challenge',
+    policyDecision: plan.policyDecision,
+    authRequirement:
+      row.auditStatus.includes('required before reveal') ||
+      blockers.includes('operator auth required')
+        ? 'fresh operator authentication required before reveal'
+        : 'operator session can request broker challenge',
+    dependentConsumerRefs: revealConsumerRefsForRow(row),
+    displayGuardrails: [
+      'value stays hidden until the broker returns an authorized short-lived display',
+      'copy and export remain unavailable from this management table',
+      'expired challenge metadata cannot be reused to show a value',
+      'screen and diagnostics evidence contain challenge ids only',
+    ],
+    applyGate: eligible
+      ? 'ready for broker-owned reveal challenge after final revalidation'
+      : blockers[0],
+    blockers,
+    safeMetadataRows: [
+      'reveal preview carries challenge id, ref, policy, owner, provider, and audit metadata only',
+      'raw secret value is not fetched during preview generation',
+      'route, query string, local storage, diagnostics, and support bundles receive no secret material',
+      'audit event id and correlation metadata are safe to retain for review',
+    ],
+  }
+}
+
 export function buildSingleSecretDecommissionPreview(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan
@@ -1880,6 +1963,12 @@ export function managedSecretDecommissionPreviewHasSecretMaterial(
 
 export function managedSecretPolicyPreviewHasSecretMaterial(
   preview: SingleSecretPolicyPreview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(preview))
+}
+
+export function managedSecretRevealPreviewHasSecretMaterial(
+  preview: SingleSecretRevealPreview
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(preview))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -171,6 +171,22 @@ test.describe('Secrets Broker browser coverage', () => {
       .first()
       .click()
     await expect(page.getByText(/Uses the #38 reveal pattern/i)).toBeVisible()
+    await expect(
+      page.getByText(/Controlled reveal challenge preview/i)
+    ).toBeVisible()
+    await expect(page.getByText(/reveal challenge blocked/i)).toBeVisible()
+    await expect(
+      page.getByText(/challenge-reveal-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/audit-reveal-serviceadmin-session-signing-preview/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/no reveal window is opened while blocked/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/value stays hidden until the broker returns/i)
+    ).toBeVisible()
     await page
       .getByRole('button', { name: /Edit\/update dry-run/i })
       .first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only controlled reveal challenge preview model for the Secrets page.
- Show challenge id, expiry/status metadata, audit event, audit sink/auth status, dependent consumer refs, display guardrails, blockers, and safe metadata proof without rendering raw values.
- Extend unit and browser coverage for ready/blocked reveal challenge states and no secret-material leakage.

## Scope
- In scope: Service Admin stub/preview UI model and tests for single-secret reveal challenge metadata.
- Out of scope: production Secrets Broker reveal API wiring, actual raw value display, copy/export, and full #231 completion.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin fixture/model for the Secrets management surface.
- Not required: external API contract unchanged; this remains a production-shaped UI preview until the live Secrets Broker mutation/reveal contract is wired.

## Nash invariant impact
- Invariant: raw secret values and credential material must not appear in the table, routes, local/session storage, diagnostics, screenshots, exports, or tests.
- Preservation proof: reveal preview carries challenge/audit metadata only; tests assert no raw-value sentinel and `managedSecretRevealPreviewHasSecretMaterial(...) === false` for ready and blocked previews.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-reveal-preview.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "covers the Secrets sub-page table search"` — `.work-agent/logs/issue-231/playwright-secrets-reveal-preview.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-reveal-preview.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-reveal-preview.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-reveal-preview.log`
- PASS canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval rule found for this focused UI/test advancement.
- Evidence: existing #231 trail has prior focused slices merged/released after green checks; this PR is limited to the same Secrets page/test files.

## Cleanup
- Branch: `agent/issue-231-reveal-challenge-preview`
- Post-merge: release Service Admin, update core `@serviceadmin` demo pin, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, then delete merged branch.

Release-to-demo gate is not complete yet because this demo-consumed Service Admin UI change has not been merged/released/pinned/recycled into the canonical demo.
