### PR TITLE
feat(secrets): show single-secret action audit timeline

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -63,6 +63,7 @@ import {
   buildManagedSecretActionPreview,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
+  buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
   buildSingleSecretRevealPreview,
@@ -235,6 +236,13 @@ export function SecretsManagementPage() {
     bulkRevalidated,
     bulkPlan.applyAvailable
   )
+  const singleOperationAuditTrail = singleApplyResult
+    ? buildSingleSecretOperationAuditTrail(
+        selectedRow,
+        singleOperationPlan,
+        singleApplyResult.outcome
+      )
+    : []
 
   const resetBulkApplyGate = useCallback(() => {
     setBulkRevalidated(false)
@@ -2091,6 +2099,52 @@ export function SecretsManagementPage() {
                     <li key={row}>{row}</li>
                   ))}
                 </ul>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Operation audit timeline
+                  </div>
+                  <div className='mt-2 overflow-x-auto rounded-md border bg-background'>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Step</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead>Actor</TableHead>
+                          <TableHead>Evidence</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {singleOperationAuditTrail.map((step) => (
+                          <TableRow key={step.id}>
+                            <TableCell className='min-w-56 align-top'>
+                              <div className='font-medium'>{step.label}</div>
+                              <div className='text-xs text-muted-foreground'>
+                                {step.occurredAt}
+                              </div>
+                            </TableCell>
+                            <TableCell className='min-w-64 align-top'>
+                              <Badge
+                                variant={step.terminal ? 'default' : 'outline'}
+                              >
+                                {step.terminal ? 'Terminal' : 'In progress'}
+                              </Badge>
+                              <div className='mt-2'>{step.status}</div>
+                            </TableCell>
+                            <TableCell className='min-w-44 align-top'>
+                              {step.actorRef}
+                            </TableCell>
+                            <TableCell className='min-w-80 align-top'>
+                              <div className='break-all'>{step.evidence}</div>
+                              <div className='mt-2 text-xs text-muted-foreground'>
+                                {step.redaction}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
               </div>
             ) : null}
 

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -8,6 +8,7 @@ import {
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
+  buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
   buildSingleSecretRevealPreview,
@@ -21,6 +22,7 @@ import {
   managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
+  managedSecretSingleAuditTrailHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -597,6 +599,16 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getByText(/Single-secret operation history/i)).toBeVisible()
     expect(screen.getByText(/1 submitted/i)).toBeVisible()
+    expect(screen.getByText(/Operation audit timeline/i)).toBeVisible()
+    expect(screen.getByText(/Dry-run preview recorded/i)).toBeVisible()
+    expect(screen.getByText(/Apply gate evaluated/i)).toBeVisible()
+    expect(screen.getByText(/Broker status callback/i)).toBeVisible()
+    expect(screen.getByText(/Audit sink retention/i)).toBeVisible()
+    expect(screen.getByText(/serviceadmin-ui/i)).toBeVisible()
+    expect(screen.getAllByText(/@secretsbroker/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/callback evidence stores typed outcome/i)
+    ).toBeVisible()
     expect(screen.getAllByText(/audit-reset-serviceadmin/i)[0]).toBeVisible()
     expect(screen.getAllByText(/submitted to broker/i)[0]).toBeVisible()
     expect(screen.getByText(/raw value was not revealed/i)).toBeVisible()
@@ -605,7 +617,9 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getAllByText(/Audit event/i)[0]).toBeVisible()
     expect(
-      screen.getByText(/audit-reset-serviceadmin-session-signing-preview/i)
+      screen.getAllByText(
+        /audit-reset-serviceadmin-session-signing-preview/i
+      )[0]
     ).toBeVisible()
     expect(
       screen.getAllByText(
@@ -959,6 +973,40 @@ describe('Secrets Broker secrets management page', () => {
       eventState: 'recorded as safe broker failure metadata',
     })
     expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(
+      false
+    )
+    const auditTrail = buildSingleSecretOperationAuditTrail(
+      managedSecretRows[0],
+      rotatePlan,
+      'applied'
+    )
+    expect(auditTrail).toHaveLength(4)
+    expect(auditTrail[0]).toMatchObject({
+      label: 'Dry-run preview recorded',
+      actorRef: 'serviceadmin-ui',
+      terminal: false,
+    })
+    expect(auditTrail[1]).toMatchObject({
+      label: 'Apply gate evaluated',
+      actorRef: 'secretsbroker-policy',
+      evidence: 'confirmation, capability, policy, and audit metadata accepted',
+    })
+    expect(auditTrail[2]).toMatchObject({
+      label: 'Broker status callback',
+      actorRef: '@secretsbroker',
+      status: 'terminal success',
+      evidence: 'corr-reset-serviceadmin-session-signing-applied',
+      terminal: true,
+    })
+    expect(auditTrail[3]).toMatchObject({
+      label: 'Audit sink retention',
+      actorRef: '@secretsbroker-audit',
+      evidence: 'audit-reset-serviceadmin-session-signing-preview',
+    })
+    expect(auditTrail.map((step) => step.redaction).join(' ')).toMatch(
+      /omits payloads, tokens, cookies, keys, and raw secret material/i
+    )
+    expect(managedSecretSingleAuditTrailHasSecretMaterial(auditTrail)).toBe(
       false
     )
 

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -162,6 +162,17 @@ export type SingleSecretOperationHistoryEntry = SingleSecretOperationResult & {
   submittedAt: string
 }
 
+export type SingleSecretOperationAuditTrailStep = {
+  id: string
+  label: string
+  status: string
+  actorRef: string
+  evidence: string
+  redaction: string
+  occurredAt: string
+  terminal: boolean
+}
+
 export type StubSecretMutationState =
   | 'ready'
   | 'denied'
@@ -465,6 +476,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:stub-mutation-preview',
     'secrets-management:stub-mutation-apply-status',
     'secrets-management:single-secret-operation-history',
+    'secrets-management:single-secret-operation-audit-trail',
     'secrets-management:single-secret-decommission-preview',
     'secrets-management:single-secret-policy-preview',
     'secrets-management:stub-delete-preview',
@@ -1926,6 +1938,79 @@ export function buildSingleSecretOperationHistoryEntry(
   }
 }
 
+export function buildSingleSecretOperationAuditTrail(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  outcome: SingleSecretOperationOutcome = 'submitted'
+): SingleSecretOperationAuditTrailStep[] {
+  const auditEventId = auditEventIdForSingleSecretAction(plan.action, row)
+  const slug = safeOperationSlug(plan.action, row)
+  const terminalStatus =
+    outcome === 'applied'
+      ? 'terminal success'
+      : outcome === 'submitted'
+        ? 'pending broker terminal status'
+        : outcome === 'policy-denied'
+          ? 'terminal policy denial'
+          : outcome === 'auth-required'
+            ? 'paused for broker auth'
+            : outcome === 'stale-plan'
+              ? 'terminal stale-plan rejection'
+              : 'terminal safe failure'
+
+  return [
+    {
+      id: `${auditEventId}:preview`,
+      label: 'Dry-run preview recorded',
+      status: plan.dryRunStatus,
+      actorRef: 'serviceadmin-ui',
+      evidence: `${plan.operationId} created for ${row.name}`,
+      redaction:
+        'preview evidence stores ref, action, policy, provider, owner, and audit metadata only',
+      occurredAt: 'stub-step-1',
+      terminal: false,
+    },
+    {
+      id: `${auditEventId}:gate`,
+      label: 'Apply gate evaluated',
+      status: plan.applyGate,
+      actorRef: 'secretsbroker-policy',
+      evidence:
+        plan.blockers.length > 0
+          ? `blocked by ${plan.blockers.join(', ')}`
+          : 'confirmation, capability, policy, and audit metadata accepted',
+      redaction:
+        'gate evidence excludes raw values, request bodies, credentials, and environment values',
+      occurredAt: 'stub-step-2',
+      terminal: false,
+    },
+    {
+      id: `${auditEventId}:broker-status`,
+      label: 'Broker status callback',
+      status: terminalStatus,
+      actorRef: '@secretsbroker',
+      evidence: `corr-${slug}-${outcome}`,
+      redaction:
+        'callback evidence stores typed outcome and correlation id only',
+      occurredAt: 'stub-step-3',
+      terminal: outcome !== 'submitted',
+    },
+    {
+      id: `${auditEventId}:audit-sink`,
+      label: 'Audit sink retention',
+      status: row.auditStatus.includes('available')
+        ? 'retained by available audit sink'
+        : 'waiting for audit sink confirmation',
+      actorRef: '@secretsbroker-audit',
+      evidence: auditEventId,
+      redaction:
+        'audit payload uses allowlisted fields and omits payloads, tokens, cookies, keys, and raw secret material',
+      occurredAt: 'stub-step-4',
+      terminal: false,
+    },
+  ]
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -1951,6 +2036,12 @@ export function managedSecretBulkApplyResultHasSecretMaterial(
 
 export function managedSecretSingleHistoryHasSecretMaterial(
   entries: SingleSecretOperationHistoryEntry[]
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretSingleAuditTrailHasSecretMaterial(
+  entries: SingleSecretOperationAuditTrailStep[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -326,6 +326,16 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/Single-secret operation result: submitted/i)
     ).toBeVisible()
     await expect(page.getByText(/1 submitted/i)).toBeVisible()
+    await expect(page.getByText(/Operation audit timeline/i)).toBeVisible()
+    await expect(page.getByText(/Dry-run preview recorded/i)).toBeVisible()
+    await expect(page.getByText(/Apply gate evaluated/i)).toBeVisible()
+    await expect(page.getByText(/Broker status callback/i)).toBeVisible()
+    await expect(page.getByText(/Audit sink retention/i)).toBeVisible()
+    await expect(page.getByText(/serviceadmin-ui/i)).toBeVisible()
+    await expect(page.getByText(/@secretsbroker/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/callback evidence stores typed outcome/i)
+    ).toBeVisible()
     await expect(
       page.getByText(/audit-reset-serviceadmin/i).first()
     ).toBeVisible()
@@ -335,7 +345,9 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/rotation can be requested without controlled reveal/i)
     ).toBeVisible()
     await expect(
-      page.getByText(/audit-reset-serviceadmin-session-signing-preview/i)
+      page
+        .getByText(/audit-reset-serviceadmin-session-signing-preview/i)
+        .first()
     ).toBeVisible()
     await expect(
       page


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only operation audit timeline for single-secret preview/apply results.
- Shows dry-run, apply-gate, broker callback, and audit-sink retention steps with safe actors, correlation evidence, and redaction notes.
- Extends unit and browser coverage for the audit timeline and safe-material guards.

## Scope
- In scope: Service Admin `Secrets Broker > Secrets` stub preview surface for single-secret operation audit evidence.
- Out of scope: live Secrets Broker mutation API integration, raw reveal display, production apply, and full #231 closure.

## Spec / contract / fixture impact
- Updated: UI/model fixture contract for metadata-only single-secret action audit trail evidence.
- Not required: backend/API schema changes, because this remains a deterministic Service Admin UI preview slice until the live broker mutation contract is wired.

## Nash invariant impact
- Invariant: no raw secret values, provider credentials, tokens, cookies, private keys, recovery material, or raw env values are rendered or persisted.
- Preservation proof: audit trail fields are allowlisted metadata only; tests cover model redaction and browser no-secret-material assertions.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-audit-timeline.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-audit-timeline.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-audit-timeline.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-audit-timeline.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-audit-timeline.log`
- PASS canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: Project #1 shows #231 `Ready` / `Ready for Agent`; previous validated #231 slices followed the same focused PR/release/demo gate pattern.

## Release-to-demo gate
- Applies after merge because `lasso-serviceadmin` is demo-consumed.
- Current expected Service Admin PR commit: `4929dea5682551899b97296aa907106fa61b8b73`.
- Current live demo Service Admin tag remains the previous release until this PR is merged, released, pinned in `service-lasso/service-lasso`, recycled on port `17883`, and verified with `npm run demo:verify-canonical`.

## Cleanup
- Branch: `agent/issue-231-secret-action-audit-log`
- Post-merge: release Service Admin, update core `@serviceadmin` pin, recycle/verify canonical demo, then delete branch after merge.