### PR TITLE
feat(secrets): show safe submit envelope

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -69,6 +69,7 @@ import {
   buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
   bulkSecretCampaignApplyModes,
   bulkSecretCampaignOperations,
@@ -206,6 +207,10 @@ export function SecretsManagementPage() {
     auditReason,
     confirmed,
     stubState
+  )
+  const singleSubmitEnvelope = buildSingleSecretSubmitEnvelope(
+    selectedRow,
+    singleOperationPlan
   )
   const revealPreview =
     selectedAction === 'reveal'
@@ -1522,6 +1527,116 @@ export function SecretsManagementPage() {
                     policy, and broker-state checks pass.
                   </div>
                 )}
+              </div>
+            </div>
+            <div className='rounded-md border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <ShieldCheck className='size-4 text-primary' />
+                <div className='font-medium'>Metadata-only submit envelope</div>
+                <Badge
+                  variant={
+                    singleSubmitEnvelope.readyForSubmit
+                      ? 'default'
+                      : 'secondary'
+                  }
+                >
+                  {singleSubmitEnvelope.readyForSubmit
+                    ? 'Ready for broker submit'
+                    : 'Submit blocked'}
+                </Badge>
+                <Badge variant='outline'>No raw payload</Badge>
+              </div>
+              <div className='grid gap-3 lg:grid-cols-4'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Endpoint
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleSubmitEnvelope.endpoint}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Idempotency
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleSubmitEnvelope.idempotencyKey}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Correlation
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleSubmitEnvelope.correlationId}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Gate
+                  </div>
+                  <div className='mt-1'>
+                    {singleSubmitEnvelope.blockedReason}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 lg:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Allowed payload fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleSubmitEnvelope.payloadFields.map((field) => (
+                      <Badge key={field} variant='outline'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted unsafe fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleSubmitEnvelope.omittedFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Transport
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleSubmitEnvelope.transportGuardrails.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Storage
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleSubmitEnvelope.storageGuardrails.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Diagnostics
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleSubmitEnvelope.diagnosticsGuardrails.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             </div>
             {revealPreview ? (

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -14,6 +14,7 @@ import {
   buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretBulkApplyResultHasSecretMaterial,
@@ -23,6 +24,7 @@ import {
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
   managedSecretSingleAuditTrailHasSecretMaterial,
+  managedSecretSubmitEnvelopeHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
   managedSecretSingleHistoryHasSecretMaterial,
@@ -84,7 +86,16 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/Broker operation contract/i)).toBeVisible()
     expect(screen.getByText(/single-metadata/i)).toBeVisible()
     expect(
-      screen.getByText(/GET \/v1\/management\/secrets\/\{ref\}\/metadata/i)
+      screen.getAllByText(
+        /GET \/v1\/management\/secrets\/\{ref\}\/metadata/i
+      )[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    expect(screen.getByText(/Submit blocked/i)).toBeVisible()
+    expect(screen.getByText(/No raw payload/i)).toBeVisible()
+    expect(screen.getByText(/Omitted unsafe fields/i)).toBeVisible()
+    expect(
+      screen.getByText(/no local storage or session storage/i)
     ).toBeVisible()
     expect(screen.getAllByText(/Raw values hidden/i)[0]).toBeVisible()
     expect(screen.getByText(/No bulk mutation/i)).toBeVisible()
@@ -581,9 +592,9 @@ describe('Secrets Broker secrets management page', () => {
       screen.getByText(/rotation preview required before apply/i)
     ).toBeVisible()
     expect(
-      screen.getByText(
+      screen.getAllByText(
         /POST \/v1\/management\/secrets\/\{ref\}\/rotate:dry-run/i
-      )
+      )[0]
     ).toBeVisible()
     expect(screen.getByText(/reset dry-run capability checked/i)).toBeVisible()
     await user.type(
@@ -671,7 +682,7 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getAllByText(/recovery guidance/i)[0]).toBeVisible()
     expect(screen.getByText(/dependent service references/i)).toBeVisible()
-    expect(screen.getByText(/recoveryPlanRef/i)).toBeVisible()
+    expect(screen.getAllByText(/recoveryPlanRef/i)[0]).toBeVisible()
     expect(
       screen.getByText(/Delete\/decommission safety preview/i)
     ).toBeVisible()
@@ -701,7 +712,9 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getAllByText(/target policy assignment diff checked/i)[0]
     ).toBeVisible()
-    expect(screen.getByText('targetPolicyRef', { exact: true })).toBeVisible()
+    expect(
+      screen.getAllByText('targetPolicyRef', { exact: true })[0]
+    ).toBeVisible()
     expect(screen.getByText(/Policy assignment safety preview/i)).toBeVisible()
     expect(screen.getByText(/policy preview ready/i)).toBeVisible()
     expect(
@@ -894,6 +907,54 @@ describe('Secrets Broker secrets management page', () => {
         'rotation can be requested without controlled reveal',
       ])
     )
+    const rotateSubmitEnvelope = buildSingleSecretSubmitEnvelope(
+      managedSecretRows[0],
+      rotatePlan
+    )
+    expect(rotateSubmitEnvelope).toMatchObject({
+      operationId: rotatePlan.operationId,
+      endpoint: 'POST /v1/management/secrets/{ref}/rotate:dry-run',
+      idempotencyKey: 'idem-reset-serviceadmin-session-signing-metadata-submit',
+      correlationId: 'corr-reset-serviceadmin-session-signing-metadata-submit',
+      readyForSubmit: true,
+      blockedReason: 'ready after final broker revalidation',
+    })
+    expect(rotateSubmitEnvelope.payloadFields).toEqual(
+      expect.arrayContaining([
+        'ref',
+        'operationId',
+        'auditReasonMetadata',
+        'rotationReason',
+      ])
+    )
+    expect(rotateSubmitEnvelope.omittedFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'providerCredentials',
+        'providerTokens',
+        'environmentValues',
+        'requestBodyEcho',
+      ])
+    )
+    expect(rotateSubmitEnvelope.transportGuardrails).toEqual(
+      expect.arrayContaining([
+        'ref stays in the broker route template and is not copied into query strings',
+      ])
+    )
+    expect(rotateSubmitEnvelope.storageGuardrails).toEqual(
+      expect.arrayContaining([
+        'no local storage or session storage writes are required for submit',
+      ])
+    )
+    expect(rotateSubmitEnvelope.diagnosticsGuardrails).toEqual(
+      expect.arrayContaining([
+        'failure evidence records typed status and correlation id only',
+      ])
+    )
+    expect(
+      managedSecretSubmitEnvelopeHasSecretMaterial(rotateSubmitEnvelope)
+    ).toBe(false)
+
     const appliedResult = buildSingleSecretOperationResult(
       managedSecretRows[0],
       rotatePlan,
@@ -1108,6 +1169,20 @@ describe('Secrets Broker secrets management page', () => {
         'dependent service references and recovery guidance checked',
       ])
     )
+    const blockedDeleteSubmitEnvelope = buildSingleSecretSubmitEnvelope(
+      managedSecretRows[3],
+      missingDeletePlan
+    )
+    expect(blockedDeleteSubmitEnvelope).toMatchObject({
+      readyForSubmit: false,
+      blockedReason: 'ref unavailable',
+    })
+    expect(blockedDeleteSubmitEnvelope.payloadFields).toEqual(
+      expect.arrayContaining(['recoveryPlanRef', 'dependentServiceRefs'])
+    )
+    expect(
+      managedSecretSubmitEnvelopeHasSecretMaterial(blockedDeleteSubmitEnvelope)
+    ).toBe(false)
 
     const singlePolicyPlan = buildSingleSecretOperationPlan(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -66,6 +66,20 @@ export type SingleSecretOperationPlan = {
   canSubmit: boolean
 }
 
+export type SingleSecretSubmitEnvelope = {
+  operationId: string
+  endpoint: string
+  idempotencyKey: string
+  correlationId: string
+  payloadFields: string[]
+  omittedFields: string[]
+  transportGuardrails: string[]
+  storageGuardrails: string[]
+  diagnosticsGuardrails: string[]
+  readyForSubmit: boolean
+  blockedReason: string
+}
+
 export type SingleSecretOperationOutcome =
   | 'submitted'
   | 'applied'
@@ -1507,6 +1521,50 @@ export function buildSingleSecretOperationPlan(
   }
 }
 
+export function buildSingleSecretSubmitEnvelope(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretSubmitEnvelope {
+  const slug = safeOperationSlug(plan.action, row)
+
+  return {
+    operationId: plan.operationId,
+    endpoint: plan.endpoint,
+    idempotencyKey: `idem-${slug}-metadata-submit`,
+    correlationId: `corr-${slug}-metadata-submit`,
+    payloadFields: plan.safePayloadFields,
+    omittedFields: [
+      'rawValue',
+      'clearValueBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'environmentValues',
+      'requestBodyEcho',
+    ],
+    transportGuardrails: [
+      'ref stays in the broker route template and is not copied into query strings',
+      'operation id and correlation id are metadata-only and retry scoped',
+      'submit body is allowlisted from the dry-run plan fields only',
+    ],
+    storageGuardrails: [
+      'no local storage or session storage writes are required for submit',
+      'audit reason is retained as broker audit metadata only',
+      'recovery, rollback, and tombstone refs never embed secret values',
+    ],
+    diagnosticsGuardrails: [
+      'console events use action and operation id only',
+      'screenshots and support bundles may include metadata ids but not payload values',
+      'failure evidence records typed status and correlation id only',
+    ],
+    readyForSubmit: plan.canSubmit,
+    blockedReason: plan.canSubmit
+      ? 'ready after final broker revalidation'
+      : (plan.blockers[0] ?? plan.applyGate),
+  }
+}
+
 function revealConsumerRefsForRow(row: ManagedSecretRow) {
   if (row.owningService === '@serviceadmin') {
     return ['@serviceadmin operator session', '@secretsbroker audit writer']
@@ -2044,6 +2102,12 @@ export function managedSecretSingleAuditTrailHasSecretMaterial(
   entries: SingleSecretOperationAuditTrailStep[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretSubmitEnvelopeHasSecretMaterial(
+  envelope: SingleSecretSubmitEnvelope
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(envelope))
 }
 
 export function managedSecretDecommissionPreviewHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -212,7 +212,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/dependent service references and recovery guidance/i)
     ).toBeVisible()
-    await expect(page.getByText(/recoveryPlanRef/i)).toBeVisible()
+    await expect(page.getByText(/recoveryPlanRef/i).first()).toBeVisible()
     await expect(
       page.getByText(/Delete\/decommission safety preview/i)
     ).toBeVisible()
@@ -238,7 +238,7 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/target policy assignment diff checked/i).first()
     ).toBeVisible()
     await expect(
-      page.getByText('targetPolicyRef', { exact: true })
+      page.getByText('targetPolicyRef', { exact: true }).first()
     ).toBeVisible()
     await expect(
       page.getByText(/Policy assignment safety preview/i)
@@ -277,6 +277,14 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
     await expect(
       page.getByText(/Single-secret operation history/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    await expect(page.getByText(/No raw payload/i)).toBeVisible()
+    await expect(page.getByText(/Omitted unsafe fields/i)).toBeVisible()
+    await expect(page.getByText(/requestBodyEcho/i)).toBeVisible()
+    await expect(page.getByText(/not copied into query strings/i)).toBeVisible()
+    await expect(
+      page.getByText(/no local storage or session storage/i)
     ).toBeVisible()
     await expect(page.getByText(/0 submitted/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
@@ -343,6 +351,18 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/raw value was not revealed/i)).toBeVisible()
     await expect(
       page.getByText(/rotation can be requested without controlled reveal/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    await expect(
+      page.getByText(/idem-reset-serviceadmin-session-signing-metadata-submit/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/corr-reset-serviceadmin-session-signing-metadata-submit/i)
+    ).toBeVisible()
+    await expect(page.getByText(/rotationReason/i).first()).toBeVisible()
+    await expect(page.getByText(/providerCredentials/i)).toBeVisible()
+    await expect(
+      page.getByText(/allowlisted from the dry-run plan fields only/i)
     ).toBeVisible()
     await expect(
       page


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only single-secret submit envelope beside the existing dry-run preview gate.
- Show endpoint, idempotency key, correlation id, allowed payload fields, omitted unsafe fields, and transport/storage/diagnostics guardrails.
- Extend model, unit, and browser coverage so the envelope remains free of raw secret material and credential-like payloads.

## Scope
- In scope: Service Admin stub/preview surface for safe per-secret reveal/edit/reset/delete/policy handoff metadata.
- Out of scope: live Secrets Broker mutation API wiring, production apply execution, release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: preview model contract in `src/features/secrets-broker/secrets-management.ts`.
- Not required: no public backend API/schema change; this is a UI/model safety preview around the existing stub dry-run contract.

## Nash invariant impact
- Invariant: Secrets UI must not expose raw values, provider credentials, tokens, cookies, private keys, recovery material, route/query payloads, diagnostics payloads, or storage-backed secret material.
- Preservation proof: new submit envelope explicitly allowlists payload fields and lists omitted unsafe fields; tests assert the modeled envelope has no forbidden material and browser coverage asserts the visible guardrails.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-submit-envelope.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-submit-envelope.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-submit-envelope.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-submit-envelope.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-submit-envelope.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: issue #231 is Ready / Ready for Agent; previous #231 slices used the same Service Admin PR flow.

## Cleanup
- Branch: `agent/issue-231-safe-submit-envelope`
- Post-merge: release Service Admin, update core `@serviceadmin` demo pin, recycle canonical demo on port 17883, run `npm run demo:verify-canonical`, then clean local/remote branches.
