### PR TITLE
feat(secrets): add broker status monitor

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -69,6 +69,7 @@ import {
   buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretStatusMonitor,
   buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
   bulkSecretCampaignApplyModes,
@@ -248,6 +249,13 @@ export function SecretsManagementPage() {
         singleApplyResult.outcome
       )
     : []
+  const singleStatusMonitor = singleApplyResult
+    ? buildSingleSecretStatusMonitor(
+        selectedRow,
+        singleOperationPlan,
+        singleApplyResult
+      )
+    : null
 
   const resetBulkApplyGate = useCallback(() => {
     setBulkRevalidated(false)
@@ -2214,6 +2222,125 @@ export function SecretsManagementPage() {
                     <li key={row}>{row}</li>
                   ))}
                 </ul>
+                {singleStatusMonitor ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <div className='font-medium'>Broker status monitor</div>
+                      <Badge variant='secondary'>Metadata only</Badge>
+                      <Badge variant='outline'>
+                        {singleStatusMonitor.stateBadge}
+                      </Badge>
+                      <Badge
+                        variant={
+                          singleStatusMonitor.retryAllowed
+                            ? 'default'
+                            : 'outline'
+                        }
+                      >
+                        {singleStatusMonitor.retryAllowed
+                          ? 'Retry safe'
+                          : 'Fresh preview first'}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 lg:grid-cols-4'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Status endpoint
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleStatusMonitor.statusEndpoint}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Polling
+                        </div>
+                        <div className='mt-1'>
+                          {singleStatusMonitor.pollCadence}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Terminal state
+                        </div>
+                        <div className='mt-1'>
+                          {singleStatusMonitor.terminalState}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Retry token
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleStatusMonitor.retryToken}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Stale-plan guard
+                      </div>
+                      <div className='mt-2'>
+                        {singleStatusMonitor.stalePlanGuard}
+                      </div>
+                      <div className='mt-2 text-muted-foreground'>
+                        {singleStatusMonitor.operatorNextAction}
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed status fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleStatusMonitor.allowedStatusFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted unsafe status fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleStatusMonitor.omittedStatusFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Status rows
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleStatusMonitor.statusRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe status evidence
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleStatusMonitor.safeEvidenceRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
                 <div className='mt-3 rounded-md border bg-muted/30 p-3'>
                   <div className='text-xs font-medium text-muted-foreground uppercase'>
                     Operation audit timeline

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -14,6 +14,7 @@ import {
   buildSingleSecretRevealPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretStatusMonitor,
   buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
   filterManagedSecrets,
@@ -24,6 +25,7 @@ import {
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
   managedSecretSingleAuditTrailHasSecretMaterial,
+  managedSecretStatusMonitorHasSecretMaterial,
   managedSecretSubmitEnvelopeHasSecretMaterial,
   managedSecretRows,
   managedSecretSafeSurfacesIncludeSecretMaterial,
@@ -1068,6 +1070,47 @@ describe('Secrets Broker secrets management page', () => {
       /omits payloads, tokens, cookies, keys, and raw secret material/i
     )
     expect(managedSecretSingleAuditTrailHasSecretMaterial(auditTrail)).toBe(
+      false
+    )
+    const statusMonitor = buildSingleSecretStatusMonitor(
+      managedSecretRows[0],
+      rotatePlan,
+      appliedResult
+    )
+    expect(statusMonitor).toMatchObject({
+      operationId: rotatePlan.operationId,
+      statusEndpoint: 'GET /v1/management/secret-operations/{operationId}',
+      terminalState: 'terminal success',
+      stateBadge: 'settled',
+      retryAllowed: false,
+      retryToken: 'fresh broker preview required before retry',
+      operatorNextAction:
+        'monitor dependent service restart notes and rotation freshness',
+    })
+    expect(statusMonitor.allowedStatusFields).toEqual(
+      expect.arrayContaining([
+        'operationId',
+        'ref',
+        'action',
+        'outcome',
+        'correlationId',
+      ])
+    )
+    expect(statusMonitor.omittedStatusFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBodyEcho',
+        'providerCredentials',
+        'environmentValues',
+      ])
+    )
+    expect(statusMonitor.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'status polling is keyed by operation id, not by secret value',
+        'terminal status records typed broker metadata only',
+      ])
+    )
+    expect(managedSecretStatusMonitorHasSecretMaterial(statusMonitor)).toBe(
       false
     )
 

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -115,6 +115,22 @@ export type SingleSecretOperationResult = {
   nextAction: string
 }
 
+export type SingleSecretStatusMonitor = {
+  operationId: string
+  statusEndpoint: string
+  pollCadence: string
+  terminalState: string
+  stateBadge: string
+  retryAllowed: boolean
+  retryToken: string
+  stalePlanGuard: string
+  allowedStatusFields: string[]
+  omittedStatusFields: string[]
+  statusRows: string[]
+  operatorNextAction: string
+  safeEvidenceRows: string[]
+}
+
 export type SingleSecretDecommissionPreview = {
   ref: string
   operationId: string
@@ -2069,6 +2085,85 @@ export function buildSingleSecretOperationAuditTrail(
   ]
 }
 
+export function buildSingleSecretStatusMonitor(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  result: SingleSecretOperationResult
+): SingleSecretStatusMonitor {
+  const retryAllowed = result.outcome === 'failed' && plan.action !== 'reveal'
+  const terminalState =
+    result.outcome === 'applied'
+      ? 'terminal success'
+      : result.outcome === 'submitted'
+        ? 'pending broker terminal status'
+        : result.outcome === 'policy-denied'
+          ? 'terminal policy denial'
+          : result.outcome === 'auth-required'
+            ? 'paused for broker authentication'
+            : result.outcome === 'stale-plan'
+              ? 'terminal stale-plan rejection'
+              : 'terminal safe failure'
+
+  return {
+    operationId: result.operationId,
+    statusEndpoint: 'GET /v1/management/secret-operations/{operationId}',
+    pollCadence:
+      result.outcome === 'submitted'
+        ? 'poll every 5 seconds until broker terminal metadata arrives'
+        : 'polling stopped after terminal metadata is recorded',
+    terminalState,
+    stateBadge:
+      result.outcome === 'applied'
+        ? 'settled'
+        : result.outcome === 'submitted'
+          ? 'monitoring'
+          : result.outcome === 'failed'
+            ? 'safe failure'
+            : result.outcome,
+    retryAllowed,
+    retryToken: retryAllowed
+      ? `retry-${safeOperationSlug(plan.action, row)}-operation-id-only`
+      : 'fresh broker preview required before retry',
+    stalePlanGuard:
+      result.outcome === 'stale-plan'
+        ? 'existing dry-run token rejected; generate a fresh audited preview'
+        : 'status updates are accepted only when operation id, ref, action, and correlation id match the latest preview',
+    allowedStatusFields: [
+      'operationId',
+      'ref',
+      'action',
+      'outcome',
+      'correlationId',
+      'auditEventId',
+      'retrySafe',
+      'updatedAt',
+    ],
+    omittedStatusFields: [
+      'rawValue',
+      'requestBodyEcho',
+      'responseBodyEcho',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'environmentValues',
+    ],
+    statusRows: [
+      `broker outcome: ${result.outcome}`,
+      `audit event: ${result.auditFeedback.auditEventId}`,
+      `correlation: ${result.auditFeedback.correlationId}`,
+      `dependent status: ${result.auditFeedback.dependentServiceStatus}`,
+    ],
+    operatorNextAction: result.nextAction,
+    safeEvidenceRows: [
+      'status polling is keyed by operation id, not by secret value',
+      'terminal status records typed broker metadata only',
+      'retry guidance never reuses stale previews or blocked policy decisions',
+      'support evidence may include ids, timestamps, and typed outcomes only',
+    ],
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -2102,6 +2197,12 @@ export function managedSecretSingleAuditTrailHasSecretMaterial(
   entries: SingleSecretOperationAuditTrailStep[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretStatusMonitorHasSecretMaterial(
+  monitor: SingleSecretStatusMonitor
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(monitor))
 }
 
 export function managedSecretSubmitEnvelopeHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -353,6 +353,19 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/rotation can be requested without controlled reveal/i)
     ).toBeVisible()
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    await expect(page.getByText(/Broker status monitor/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /GET \/v1\/management\/secret-operations\/\{operationId\}/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/poll every 5 seconds until broker terminal metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/pending broker terminal status/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/Fresh preview first/i)).toBeVisible()
     await expect(
       page.getByText(/idem-reset-serviceadmin-session-signing-metadata-submit/i)
     ).toBeVisible()
@@ -360,7 +373,7 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/corr-reset-serviceadmin-session-signing-metadata-submit/i)
     ).toBeVisible()
     await expect(page.getByText(/rotationReason/i).first()).toBeVisible()
-    await expect(page.getByText(/providerCredentials/i)).toBeVisible()
+    await expect(page.getByText(/providerCredentials/i).first()).toBeVisible()
     await expect(
       page.getByText(/allowlisted from the dry-run plan fields only/i)
     ).toBeVisible()
@@ -401,6 +414,10 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/broker applied/i).first()).toBeVisible()
     await expect(
       page.getByText(/operation settled with broker success metadata/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/terminal success/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/polling stopped after terminal metadata/i)
     ).toBeVisible()
     await expect(
       page.getByText(/no retry needed after broker success/i).first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only broker status monitor for single-secret reveal/edit/reset/delete/policy submissions.
- Surface status endpoint, polling cadence, terminal state, retry token, stale-plan guard, allowed status fields, omitted unsafe fields, and safe evidence rows after stub submission.
- Extend unit and browser coverage so status monitoring remains redaction-safe and value-hidden.

## Scope
- In scope: Service Admin Secrets Broker > Secrets single-secret status feedback after dry-run/apply submission.
- Out of scope: live Secrets Broker mutation API wiring, full #231 closure, bulk campaign changes.

## Spec / contract / fixture impact
- Updated: UI/model contract fixtures for the stubbed broker operation status monitor.
- Not required because: this is a frontend metadata/status surface only and does not change the live API schema.

## Nash invariant impact
- Invariant: raw secret values and provider credentials must not be rendered, logged, routed, exported, or persisted.
- Preservation proof: status monitor allowlists metadata fields and explicitly omits raw values, request/response body echoes, credentials, tokens, cookies, private keys, and environment values; tests assert no forbidden material.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-status-monitor.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-status-monitor.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-status-monitor.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-status-monitor.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-status-monitor.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: #231 remains open and this PR uses `Refs #231` because it advances but does not complete the broader issue.

## Cleanup
- Branch will be deleted after merge.
- Release-to-demo gate remains pending until this PR is merged, released, pinned in core, and canonical demo is recycled/verified with the new Service Admin release.