### PR TITLE
feat(secrets): model single-secret auth challenge

### DIFF
--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1003,6 +1003,55 @@ describe('Secrets Broker secrets management page', () => {
         'update policy assignment or request least-privilege approval',
     })
 
+    const authRequiredResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'auth-required'
+    )
+    expect(authRequiredResult).toMatchObject({
+      outcome: 'auth-required',
+      applied: false,
+      resultBadge: 'auth required',
+      recoveryStatus:
+        'provider reauthentication must complete in the broker-owned auth flow',
+      retryPolicy: 'fresh plan required before any retry',
+      nextAction:
+        'complete broker provider reauthentication and create a fresh preview',
+    })
+    expect(authRequiredResult.resultStatus).toMatch(
+      /requires fresh operator authentication before source access/i
+    )
+    expect(authRequiredResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'complete provider reauthentication in the broker-owned auth flow',
+        'discard this dry-run token after auth challenge starts',
+        'create a fresh audited preview after provider session is refreshed',
+      ])
+    )
+    expect(authRequiredResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'provider reauthentication uses broker-owned challenge refs; credentials are never entered in the Service Admin table',
+      ])
+    )
+    expect(authRequiredResult.auditFeedback).toMatchObject({
+      eventState: 'recorded as auth challenge with no source access',
+    })
+    expect(authRequiredResult.auditFeedback.evidenceRows).toEqual(
+      expect.arrayContaining([
+        'provider auth challenge refs contain status metadata only and never provider credentials',
+      ])
+    )
+    expect(
+      managedSecretSingleHistoryHasSecretMaterial([
+        buildSingleSecretOperationHistoryEntry(
+          managedSecretRows[0],
+          rotatePlan,
+          2,
+          'auth-required'
+        ),
+      ])
+    ).toBe(false)
+
     const auditUnavailableResult = buildSingleSecretOperationResult(
       managedSecretRows[0],
       rotatePlan,
@@ -1107,6 +1156,18 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretSingleAuditTrailHasSecretMaterial(auditTrail)).toBe(
       false
     )
+    const authRequiredTrail = buildSingleSecretOperationAuditTrail(
+      managedSecretRows[0],
+      rotatePlan,
+      'auth-required'
+    )
+    expect(authRequiredTrail[2]).toMatchObject({
+      status: 'paused for broker reauthentication',
+      terminal: true,
+    })
+    expect(
+      managedSecretSingleAuditTrailHasSecretMaterial(authRequiredTrail)
+    ).toBe(false)
     const statusMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],
       rotatePlan,
@@ -1148,6 +1209,32 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretStatusMonitorHasSecretMaterial(statusMonitor)).toBe(
       false
     )
+    const authRequiredMonitor = buildSingleSecretStatusMonitor(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult
+    )
+    expect(authRequiredMonitor).toMatchObject({
+      terminalState: 'paused for broker authentication',
+      stateBadge: 'auth challenge',
+      retryAllowed: false,
+      retryToken: 'fresh broker preview required before retry',
+      operatorNextAction:
+        'complete broker provider reauthentication and create a fresh preview',
+    })
+    expect(authRequiredMonitor.statusRows).toEqual(
+      expect.arrayContaining([
+        'auth challenge: broker-owned provider reauthentication required',
+      ])
+    )
+    expect(authRequiredMonitor.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'provider reauthentication happens outside Service Admin and omits provider credentials',
+      ])
+    )
+    expect(
+      managedSecretStatusMonitorHasSecretMaterial(authRequiredMonitor)
+    ).toBe(false)
     const auditUnavailableTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],
       rotatePlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -1790,7 +1790,7 @@ export function buildSingleSecretOperationResult(
           : plan.action === 'policy'
             ? 'policy change'
             : plan.action
-  const recoverySteps =
+  const actionRecoverySteps =
     plan.action === 'delete'
       ? [
           'verify dependent service references before broker decommission',
@@ -1820,6 +1820,15 @@ export function buildSingleSecretOperationResult(
                 'let the short-lived reveal expire after the audit window',
                 'request a fresh reveal instead of reusing stale metadata',
               ]
+  const outcomeRecoverySteps =
+    outcome === 'auth-required'
+      ? [
+          'complete provider reauthentication in the broker-owned auth flow',
+          'discard this dry-run token after auth challenge starts',
+          'create a fresh audited preview after provider session is refreshed',
+        ]
+      : []
+  const recoverySteps = [...actionRecoverySteps, ...outcomeRecoverySteps]
   const applied = outcome === 'applied'
   const resultBadge =
     outcome === 'applied'
@@ -1851,7 +1860,7 @@ export function buildSingleSecretOperationResult(
         : outcome === 'policy-denied'
           ? `${actionLabel} denied by broker policy after final revalidation; no value was read or written`
           : outcome === 'auth-required'
-            ? `${actionLabel} paused because broker requires fresh operator authentication`
+            ? `${actionLabel} paused because broker requires fresh operator authentication before source access`
             : outcome === 'audit-unavailable'
               ? `${actionLabel} blocked because audit persistence is unavailable; no value was read or written`
               : outcome === 'stale-plan'
@@ -1865,7 +1874,7 @@ export function buildSingleSecretOperationResult(
       : outcome === 'policy-denied'
         ? 'update policy assignment or request least-privilege approval'
         : outcome === 'auth-required'
-          ? 'complete broker auth challenge and create a fresh preview'
+          ? 'complete broker provider reauthentication and create a fresh preview'
           : outcome === 'audit-unavailable'
             ? 'restore audit sink availability and create a fresh preview'
             : outcome === 'stale-plan'
@@ -1881,7 +1890,7 @@ export function buildSingleSecretOperationResult(
       : outcome === 'policy-denied'
         ? 'policy denial is fail-closed and requires a new authorized plan'
         : outcome === 'auth-required'
-          ? 'authentication challenge must complete outside the table'
+          ? 'provider reauthentication must complete in the broker-owned auth flow'
           : outcome === 'audit-unavailable'
             ? 'audit outage is fail-closed and requires a fresh audited preview'
             : outcome === 'stale-plan'
@@ -1940,6 +1949,9 @@ export function buildSingleSecretOperationResult(
           : plan.action === 'policy'
             ? 'policy change carries target policy metadata only'
             : 'operator action used the selected dry-run gate',
+      outcome === 'auth-required'
+        ? 'provider reauthentication uses broker-owned challenge refs; credentials are never entered in the Service Admin table'
+        : 'broker result metadata excludes provider auth challenge secrets',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction,
@@ -1992,6 +2004,9 @@ export function buildSingleSecretAuditFeedback(
     evidenceRows: [
       'audit payload excludes raw values and credential material',
       'operator reason is stored as metadata, not as a secret field',
+      outcome === 'auth-required'
+        ? 'provider auth challenge refs contain status metadata only and never provider credentials'
+        : 'provider auth material is omitted from audit evidence',
       'route, query string, local storage, and diagnostics receive no secret material',
     ],
   }
@@ -2044,7 +2059,7 @@ export function buildSingleSecretOperationAuditTrail(
         : outcome === 'policy-denied'
           ? 'terminal policy denial'
           : outcome === 'auth-required'
-            ? 'paused for broker auth'
+            ? 'paused for broker reauthentication'
             : outcome === 'audit-unavailable'
               ? 'terminal audit unavailable'
               : outcome === 'stale-plan'
@@ -2142,7 +2157,9 @@ export function buildSingleSecretStatusMonitor(
             ? 'safe failure'
             : result.outcome === 'audit-unavailable'
               ? 'audit blocked'
-              : result.outcome,
+              : result.outcome === 'auth-required'
+                ? 'auth challenge'
+                : result.outcome,
     retryAllowed,
     retryToken: retryAllowed
       ? `retry-${safeOperationSlug(plan.action, row)}-operation-id-only`
@@ -2176,11 +2193,17 @@ export function buildSingleSecretStatusMonitor(
       `audit event: ${result.auditFeedback.auditEventId}`,
       `correlation: ${result.auditFeedback.correlationId}`,
       `dependent status: ${result.auditFeedback.dependentServiceStatus}`,
+      result.outcome === 'auth-required'
+        ? 'auth challenge: broker-owned provider reauthentication required'
+        : 'auth challenge: not requested by broker status',
     ],
     operatorNextAction: result.nextAction,
     safeEvidenceRows: [
       'status polling is keyed by operation id, not by secret value',
       'terminal status records typed broker metadata only',
+      result.outcome === 'auth-required'
+        ? 'provider reauthentication happens outside Service Admin and omits provider credentials'
+        : 'provider credentials remain omitted from status polling',
       'retry guidance never reuses stale previews or blocked policy decisions',
       'support evidence may include ids, timestamps, and typed outcomes only',
     ],

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -423,6 +423,31 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/no retry needed after broker success/i).first()
     ).toBeVisible()
     await expect(page.getByText(/2 submitted/i)).toBeVisible()
+    await page.getByLabel(/Result status/i).selectOption('auth-required')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: auth-required/i)
+    ).toBeVisible()
+    await expect(page.getByText(/auth required/i).first()).toBeVisible()
+    await expect(
+      page.getByText(
+        /requires fresh operator authentication before source access/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/provider reauthentication must complete/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/broker-owned provider reauthentication required/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/provider reauthentication happens outside Service Admin/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/paused for broker reauthentication/i)
+    ).toBeVisible()
+    await expect(page.getByText(/3 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('audit-unavailable')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -443,7 +468,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/restore audit sink availability/i).first()
     ).toBeVisible()
-    await expect(page.getByText(/3 submitted/i)).toBeVisible()
+    await expect(page.getByText(/4 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds explicit metadata-only handling for the single-secret `auth-required` broker outcome.
- Shows broker-owned provider reauthentication guidance in the operation result, audit evidence, status monitor, and operation history.
- Extends unit and browser coverage to prove the auth challenge state stays redacted and does not expose provider credentials or raw secret values.

## Scope
- In scope: single-secret auth-required result metadata, recovery guidance, audit/status rows, and focused tests.
- Out of scope: real backend mutation, credential entry, provider login implementation, and full #231 closure.

## Spec / contract / fixture impact
- Not required because this is a UI/stub-state refinement of the existing single-secret operation model; no public API/schema or backend contract changes.

## Service Lasso invariant impact
- Invariant: raw secret values and provider credentials remain outside Service Admin tables, status rows, routes, query strings, local/session storage, diagnostics, and test fixtures.
- Preservation proof: added unit/browser assertions for auth-required no-secret-material behavior and provider credential omission.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-auth-required.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-auth-required.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-auth-required.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-auth-required.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-auth-required.log`
- PASS canonical preflight after implementation: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: #231 is open and Ready / Ready for Agent on Project #1.

## Release-to-demo gate
- This Service Admin UI change is demo-consumed.
- Gate is pending until this PR is merged, a Service Admin release is published, the core `@serviceadmin` pin is updated, and the canonical demo is recycled/verified on port `17883`.
- This PR intentionally does not claim #231 done.

## Cleanup
- Branch: `agent/issue-231-single-auth-required`
- Post-merge plan: delete branch after release/demo pin gate completes.