### PR TITLE
feat(secrets): show stale single-secret recovery

### DIFF
--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -845,6 +845,26 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/provider outage/i)[0]).toBeVisible()
     expect(screen.getByText(/connector status metadata only/i)).toBeVisible()
 
+    await user.selectOptions(
+      screen.getByLabelText(/Result status/i),
+      'stale-plan'
+    )
+    await user.selectOptions(screen.getByLabelText(/Stub API state/i), 'ready')
+    await user.click(
+      screen.getByRole('button', { name: /Simulate stub apply/i })
+    )
+    expect(
+      screen.getByText(/Single-secret operation result: stale-plan/i)
+    ).toBeVisible()
+    expect(screen.getAllByText(/stale plan/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/dry-run plan token expired before final broker/i)
+    ).toBeVisible()
+    expect(screen.getByText(/stale preview: broker rejected/i)).toBeVisible()
+    expect(
+      screen.getByText(/stale-plan recovery creates a new dry-run/i)
+    ).toBeVisible()
+
     await user.click(
       screen.getByRole('button', { name: /Cancel stub preview/i })
     )
@@ -1168,9 +1188,44 @@ describe('Secrets Broker secrets management page', () => {
       outcome: 'stale-plan',
       applied: false,
       resultBadge: 'stale plan',
+      auditStatus: 'stub stale-plan rejection recorded; mutation failed closed',
       recoveryStatus: 'stale plan recovery requires a fresh audited preview',
+      retryPolicy: 'fresh plan required before any retry',
       nextAction: 'create a fresh dry-run plan before retry',
     })
+    expect(staleResult.resultStatus).toMatch(
+      /dry-run plan token expired before final broker revalidation/i
+    )
+    expect(staleResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'discard the expired dry-run token and operation submit envelope',
+        'refresh policy, provider capability, audit sink, and ref metadata before retry',
+        'create a fresh audited preview before any broker submit is attempted',
+      ])
+    )
+    expect(staleResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'stale-plan evidence is limited to operation id, ref, action, and expired preview metadata',
+      ])
+    )
+    expect(staleResult.auditFeedback).toMatchObject({
+      eventState: 'recorded as stale-plan rejection',
+    })
+    expect(staleResult.auditFeedback.evidenceRows).toEqual(
+      expect.arrayContaining([
+        'stale-plan evidence contains expired preview metadata only and never request or response bodies',
+      ])
+    )
+    expect(
+      managedSecretSingleHistoryHasSecretMaterial([
+        buildSingleSecretOperationHistoryEntry(
+          managedSecretRows[0],
+          rotatePlan,
+          2,
+          'stale-plan'
+        ),
+      ])
+    ).toBe(false)
 
     const historyEntry = buildSingleSecretOperationHistoryEntry(
       managedSecretRows[0],
@@ -1373,6 +1428,46 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretStatusMonitorHasSecretMaterial(providerUnavailableMonitor)
     ).toBe(false)
+    const stalePlanTrail = buildSingleSecretOperationAuditTrail(
+      managedSecretRows[0],
+      rotatePlan,
+      'stale-plan'
+    )
+    expect(stalePlanTrail[2]).toMatchObject({
+      status: 'terminal stale-plan rejection',
+      terminal: true,
+    })
+    expect(managedSecretSingleAuditTrailHasSecretMaterial(stalePlanTrail)).toBe(
+      false
+    )
+    const stalePlanMonitor = buildSingleSecretStatusMonitor(
+      managedSecretRows[0],
+      rotatePlan,
+      staleResult
+    )
+    expect(stalePlanMonitor).toMatchObject({
+      terminalState: 'terminal stale-plan rejection',
+      stateBadge: 'stale-plan',
+      retryAllowed: false,
+      retryToken: 'fresh broker preview required before retry',
+      operatorNextAction: 'create a fresh dry-run plan before retry',
+    })
+    expect(stalePlanMonitor.stalePlanGuard).toMatch(
+      /existing dry-run token rejected/i
+    )
+    expect(stalePlanMonitor.statusRows).toEqual(
+      expect.arrayContaining([
+        'stale preview: broker rejected the expired dry-run token',
+      ])
+    )
+    expect(stalePlanMonitor.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'stale-plan recovery creates a new dry-run and omits request and response body echoes',
+      ])
+    )
+    expect(managedSecretStatusMonitorHasSecretMaterial(stalePlanMonitor)).toBe(
+      false
+    )
 
     const actionReadiness = buildManagedSecretActionReadiness(
       managedSecretRows[0]

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -1838,7 +1838,13 @@ export function buildSingleSecretOperationResult(
             'keep the current operation id for support evidence only',
             'create a fresh audited preview after provider capability metadata refreshes',
           ]
-        : []
+        : outcome === 'stale-plan'
+          ? [
+              'discard the expired dry-run token and operation submit envelope',
+              'refresh policy, provider capability, audit sink, and ref metadata before retry',
+              'create a fresh audited preview before any broker submit is attempted',
+            ]
+          : []
   const recoverySteps = [...actionRecoverySteps, ...outcomeRecoverySteps]
   const applied = outcome === 'applied'
   const resultBadge =
@@ -1866,7 +1872,9 @@ export function buildSingleSecretOperationResult(
           ? 'stub audit outage metadata recorded; mutation failed closed'
           : outcome === 'provider-unavailable'
             ? 'stub provider outage metadata recorded; mutation failed closed'
-            : 'stub audit event recorded with typed failure metadata only'
+            : outcome === 'stale-plan'
+              ? 'stub stale-plan rejection recorded; mutation failed closed'
+              : 'stub audit event recorded with typed failure metadata only'
   const resultStatus =
     outcome === 'submitted'
       ? `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`
@@ -1881,7 +1889,7 @@ export function buildSingleSecretOperationResult(
               : outcome === 'provider-unavailable'
                 ? `${actionLabel} blocked because the provider connector is unavailable or unsupported; no value was read or written`
                 : outcome === 'stale-plan'
-                  ? `${actionLabel} rejected because the dry-run plan is stale`
+                  ? `${actionLabel} rejected because the dry-run plan token expired before final broker revalidation; no value was read or written`
                   : `${actionLabel} failed with broker-owned safe error metadata`
   const nextAction =
     outcome === 'applied'
@@ -1975,7 +1983,9 @@ export function buildSingleSecretOperationResult(
         ? 'provider reauthentication uses broker-owned challenge refs; credentials are never entered in the Service Admin table'
         : outcome === 'provider-unavailable'
           ? 'provider outage details are limited to connector state, capability metadata, and correlation id'
-          : 'broker result metadata excludes provider auth challenge secrets',
+          : outcome === 'stale-plan'
+            ? 'stale-plan evidence is limited to operation id, ref, action, and expired preview metadata'
+            : 'broker result metadata excludes provider auth challenge secrets',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction,
@@ -2034,7 +2044,9 @@ export function buildSingleSecretAuditFeedback(
         ? 'provider auth challenge refs contain status metadata only and never provider credentials'
         : outcome === 'provider-unavailable'
           ? 'provider outage evidence contains connector status metadata only and never provider credentials'
-          : 'provider auth material is omitted from audit evidence',
+          : outcome === 'stale-plan'
+            ? 'stale-plan evidence contains expired preview metadata only and never request or response bodies'
+            : 'provider auth material is omitted from audit evidence',
       'route, query string, local storage, and diagnostics receive no secret material',
     ],
   }
@@ -2231,7 +2243,9 @@ export function buildSingleSecretStatusMonitor(
         ? 'auth challenge: broker-owned provider reauthentication required'
         : result.outcome === 'provider-unavailable'
           ? 'provider status: connector unavailable or unsupported'
-          : 'auth challenge: not requested by broker status',
+          : result.outcome === 'stale-plan'
+            ? 'stale preview: broker rejected the expired dry-run token'
+            : 'auth challenge: not requested by broker status',
     ],
     operatorNextAction: result.nextAction,
     safeEvidenceRows: [
@@ -2241,7 +2255,9 @@ export function buildSingleSecretStatusMonitor(
         ? 'provider reauthentication happens outside Service Admin and omits provider credentials'
         : result.outcome === 'provider-unavailable'
           ? 'provider recovery happens in broker/provider configuration and omits provider credentials'
-          : 'provider credentials remain omitted from status polling',
+          : result.outcome === 'stale-plan'
+            ? 'stale-plan recovery creates a new dry-run and omits request and response body echoes'
+            : 'provider credentials remain omitted from status polling',
       'retry guidance never reuses stale previews or blocked policy decisions',
       'support evidence may include ids, timestamps, and typed outcomes only',
     ],

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -491,6 +491,30 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/provider recovery happens in broker/i)
     ).toBeVisible()
     await expect(page.getByText(/5 submitted/i)).toBeVisible()
+    await page.getByLabel(/Result status/i).selectOption('stale-plan')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: stale-plan/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/dry-run plan token expired before final broker/i)
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(/stale plan recovery requires a fresh audited preview/i)
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/stale preview: broker rejected/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/terminal stale-plan rejection/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/stale-plan recovery creates a new dry-run/i)
+    ).toBeVisible()
+    await expect(page.getByText(/6 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds explicit metadata-only stale-plan recovery guidance for single-secret operation results.
- Surfaces stale preview rejection in result, audit feedback, status monitor, history, and browser coverage.
- Keeps the path fail-closed: no raw values, provider credentials, request/response body echoes, route/query payloads, local/session storage, or diagnostics material.

## Scope
- In scope: focused #231 single-secret stale-plan outcome slice for the existing Secrets page stub workflow.
- Out of scope: full #231 completion, live Secrets Broker mutation contract, bulk campaign changes, and release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin stub model/tests for single-secret stale-plan outcome metadata.
- Not required because: public backend API/schema behavior is still represented as stubbed metadata until the live Secrets Broker mutation contract lands.

## Nash invariant impact
- Invariant: Secrets Broker UI must never render or persist raw secret values or credential material.
- Preservation proof: tests assert no `DEMO_REVEAL_VALUE_42` and model leak scanners remain false for stale-plan result/history/audit/status monitor paths.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231/unit-secrets-stale-plan.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/issue-231/playwright-secrets-stale-plan.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/issue-231/format-check-stale-plan.log`
- PASS `npm run lint` — `.work-agent/logs/issue-231/lint-stale-plan.log`
- PASS `npm run build` — `.work-agent/logs/issue-231/build-stale-plan.log`
- PASS post-change canonical health check: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: existing #231 trail has prior same-scope PRs merged/released/demo-gated after green checks.

## Cleanup
- Branch: `agent/issue-231-single-stale-plan`
- Post-merge: release `lasso-serviceadmin`, update core `@serviceadmin` demo pin, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify expected tag/commit equals live installed tag/commit, then delete branch when safe.