### PR TITLE
feat(secrets): add bulk audit-unavailable outcome

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1280,6 +1280,9 @@ export function SecretsManagementPage() {
                       Auth {bulkApplyResult.authRequiredCount}
                     </Badge>
                     <Badge variant='outline'>
+                      Audit {bulkApplyResult.auditUnavailableCount}
+                    </Badge>
+                    <Badge variant='outline'>
                       Stale {bulkApplyResult.staleCount}
                     </Badge>
                   </div>
@@ -1339,7 +1342,9 @@ export function SecretsManagementPage() {
                                   ? 'default'
                                   : item.outcome === 'failed'
                                     ? 'destructive'
-                                    : 'outline'
+                                    : item.outcome === 'audit-unavailable'
+                                      ? 'secondary'
+                                      : 'outline'
                               }
                             >
                               {item.outcome}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1817,6 +1817,29 @@ describe('Secrets Broker secrets management page', () => {
       false
     )
 
+    const bulkAuditUnavailableResult = buildBulkSecretCampaignApplyResult(
+      cleanPlan,
+      'audit-unavailable'
+    )
+    expect(bulkAuditUnavailableResult.outcome).toBe('audit_unavailable')
+    expect(bulkAuditUnavailableResult.appliedCount).toBe(0)
+    expect(bulkAuditUnavailableResult.auditUnavailableCount).toBe(1)
+    expect(bulkAuditUnavailableResult.auditStatus).toMatch(/audit unavailable/i)
+    expect(bulkAuditUnavailableResult.nextAction).toMatch(/restore audit sink/i)
+    expect(bulkAuditUnavailableResult.items[0]).toMatchObject({
+      outcome: 'audit-unavailable',
+      applied: false,
+      retrySafe: false,
+      auditStatus: 'campaign audit unavailable; item mutation not applied',
+      recovery:
+        'mutation failed closed because item audit could not be persisted',
+      nextAction:
+        'restore audit persistence then create a fresh campaign preview',
+    })
+    expect(
+      managedSecretBulkApplyResultHasSecretMaterial(bulkAuditUnavailableResult)
+    ).toBe(false)
+
     const policyPlan = buildBulkSecretCampaignPlan(
       managedSecretRows,
       managedSecretRows.map((row) => row.id),

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -299,6 +299,7 @@ export type BulkSecretCampaignApplyGate = {
 export type BulkSecretCampaignApplyMode =
   | 'success'
   | 'partial-failure'
+  | 'audit-unavailable'
   | 'retryable-failure'
   | 'non-retryable-failure'
   | 'stale-plan'
@@ -310,6 +311,7 @@ export type BulkSecretCampaignApplyItemOutcome =
   | 'skipped'
   | 'unsupported'
   | 'auth-required'
+  | 'audit-unavailable'
   | 'stale-plan'
 
 export type BulkSecretCampaignApplyItem = {
@@ -332,13 +334,19 @@ export type BulkSecretCampaignApplyResult = {
   planToken: string
   operation: BulkSecretCampaignOperation
   mode: 'apply'
-  outcome: 'applied' | 'partial_failure' | 'failed' | 'stale_plan'
+  outcome:
+    | 'applied'
+    | 'partial_failure'
+    | 'failed'
+    | 'audit_unavailable'
+    | 'stale_plan'
   appliedCount: number
   failedCount: number
   deniedCount: number
   skippedCount: number
   unsupportedCount: number
   authRequiredCount: number
+  auditUnavailableCount: number
   staleCount: number
   auditStatus: string
   nextAction: string
@@ -493,6 +501,7 @@ export const bulkSecretCampaignApplyModes: Array<{
 }> = [
   { id: 'success', label: 'Apply success' },
   { id: 'partial-failure', label: 'Partial failure' },
+  { id: 'audit-unavailable', label: 'Audit unavailable after submit' },
   { id: 'retryable-failure', label: 'Retryable failure' },
   { id: 'non-retryable-failure', label: 'Non-retryable failure' },
   { id: 'stale-plan', label: 'Stale plan rejected' },
@@ -1063,6 +1072,7 @@ function applyOutcomeForItem(
 ): BulkSecretCampaignApplyItemOutcome {
   const blockerOutcome = itemOutcomeFromBlockers(item)
   if (blockerOutcome) return blockerOutcome
+  if (mode === 'audit-unavailable') return 'audit-unavailable'
   if (mode === 'stale-plan') return 'stale-plan'
   if (mode === 'retryable-failure' || mode === 'non-retryable-failure') {
     return 'failed'
@@ -1085,6 +1095,8 @@ function nextActionForApplyOutcome(
       return 'choose a supported operation family or provider-specific workflow'
     case 'auth-required':
       return 'complete provider auth then create a fresh plan'
+    case 'audit-unavailable':
+      return 'restore audit persistence then create a fresh campaign preview'
     case 'stale-plan':
       return 'create a fresh dry-run plan before applying'
     case 'skipped':
@@ -1103,6 +1115,9 @@ function recoveryForApplyOutcome(
   }
   if (outcome === 'failed') {
     return 'retry with the same idempotency key after fixing the safe error'
+  }
+  if (outcome === 'audit-unavailable') {
+    return 'mutation failed closed because item audit could not be persisted'
   }
   if (outcome === 'applied') return item.recovery
   return 'create a fresh plan after resolving the typed blocker'
@@ -1133,7 +1148,9 @@ export function buildBulkSecretCampaignApplyResult(
       auditStatus:
         outcome === 'applied'
           ? 'campaign and item audit recorded'
-          : 'campaign audit recorded; item mutation not applied',
+          : outcome === 'audit-unavailable'
+            ? 'campaign audit unavailable; item mutation not applied'
+            : 'campaign audit recorded; item mutation not applied',
       recovery: recoveryForApplyOutcome(item, outcome, mode),
       nextAction: nextActionForApplyOutcome(outcome),
     }
@@ -1151,6 +1168,9 @@ export function buildBulkSecretCampaignApplyResult(
   const authRequiredCount = items.filter(
     (item) => item.outcome === 'auth-required'
   ).length
+  const auditUnavailableCount = items.filter(
+    (item) => item.outcome === 'audit-unavailable'
+  ).length
   const skippedCount = items.filter((item) => item.outcome === 'skipped').length
   const nonAppliedCount =
     failedCount +
@@ -1158,15 +1178,18 @@ export function buildBulkSecretCampaignApplyResult(
     deniedCount +
     unsupportedCount +
     authRequiredCount +
+    auditUnavailableCount +
     skippedCount
   const outcome =
-    staleCount > 0
-      ? 'stale_plan'
-      : appliedCount > 0 && nonAppliedCount === 0
-        ? 'applied'
-        : appliedCount > 0
-          ? 'partial_failure'
-          : 'failed'
+    auditUnavailableCount > 0
+      ? 'audit_unavailable'
+      : staleCount > 0
+        ? 'stale_plan'
+        : appliedCount > 0 && nonAppliedCount === 0
+          ? 'applied'
+          : appliedCount > 0
+            ? 'partial_failure'
+            : 'failed'
 
   return {
     campaignId: plan.campaignId,
@@ -1181,14 +1204,20 @@ export function buildBulkSecretCampaignApplyResult(
     skippedCount,
     unsupportedCount,
     authRequiredCount,
+    auditUnavailableCount,
     staleCount,
-    auditStatus: 'campaign-level audit summary recorded',
+    auditStatus:
+      auditUnavailableCount > 0
+        ? 'campaign-level audit unavailable; no item mutation applied without audit persistence'
+        : 'campaign-level audit summary recorded',
     nextAction:
       outcome === 'applied'
         ? 'monitor campaign status'
-        : outcome === 'stale_plan'
-          ? 'create a fresh plan'
-          : 'review per-item outcomes and retry only by operation id',
+        : outcome === 'audit_unavailable'
+          ? 'restore audit sink availability and create a fresh campaign preview'
+          : outcome === 'stale_plan'
+            ? 'create a fresh plan'
+            : 'review per-item outcomes and retry only by operation id',
     items,
   }
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -520,6 +520,53 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
+  test('shows bulk campaign audit-unavailable apply outcomes without secret material', async ({
+    page,
+  }) => {
+    await page.goto('/secrets-broker/secrets')
+    await expectNoBlankScreen(page)
+
+    await expect(page.getByText(/Bulk campaign dry-run planner/i)).toBeVisible()
+    await page
+      .getByRole('button', { name: /Generate bulk dry-run plan/i })
+      .click()
+    await expect(
+      page.getByText(/Campaign confirmation and revalidation/i)
+    ).toBeVisible()
+    await page
+      .getByLabel(/Campaign audit reason/i)
+      .fill('operator requested bulk audit outage coverage')
+    await page
+      .getByLabel(/Explicit confirmation/i)
+      .fill('CONFIRM HIGH RISK CAMPAIGN')
+    await page.getByRole('button', { name: /Revalidate dry-run/i }).click()
+    await expect(page.getByText(/revalidation passed/i).first()).toBeVisible()
+
+    await page
+      .getByLabel(/Apply result mode/i)
+      .selectOption('audit-unavailable')
+    await expect(
+      page.getByRole('button', { name: /Apply bulk campaign/i })
+    ).toBeEnabled()
+    await page.getByRole('button', { name: /Apply bulk campaign/i }).click()
+
+    await expect(
+      page.getByText(/Campaign apply result: audit_unavailable/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Audit 1/i)).toBeVisible()
+    await expect(
+      page.getByText(/campaign-level audit unavailable/i)
+    ).toBeVisible()
+    await expect(page.getByText(/audit-unavailable/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/campaign audit unavailable; item mutation not applied/i)
+    ).toBeVisible()
+    await expect(page.getByText(/restore audit persistence/i)).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+    expect(consoleErrors).toEqual([])
+  })
+
   test('covers healthy degraded offline and unconfigured broker states', async ({
     page,
   }) => {


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only bulk campaign apply outcome for `audit-unavailable` failures after submit.
- Surface an Audit count in the bulk campaign apply result summary and distinguish audit-unavailable item outcomes.
- Cover the unit model and browser workflow that generates a dry-run, confirms/revalidates, applies with audit unavailable, and verifies no secret material is rendered.

## Scope
- In scope: Service Admin Secrets Broker > Secrets bulk campaign apply outcome modeling/UI/tests for audit persistence outage after submit.
- Out of scope: backend mutation enforcement, raw secret reveal/export, full #231 completion, and release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: UI/model contract for the existing stubbed bulk campaign apply result states.
- Not required because: no public backend API/schema/service manifest change in this PR.

## Nash invariant impact
- Invariant: Secrets Broker UI must remain metadata-only and fail closed when audit persistence is unavailable.
- Preservation proof: audit-unavailable result contains operation IDs, refs, status/recovery metadata only; tests assert no raw reveal sentinel or forbidden secret material appears.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/issue-231/unit-secrets-bulk-audit-unavailable.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "bulk campaign audit-unavailable"` - `.work-agent/logs/issue-231/playwright-secrets-bulk-audit-unavailable.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/issue-231/format-check-bulk-audit-unavailable.log`
- PASS `npm run lint` - `.work-agent/logs/issue-231/lint-bulk-audit-unavailable.log`
- PASS `npm run build` - `.work-agent/logs/issue-231/build-bulk-audit-unavailable.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: issue #231 is Ready / Ready for Agent and this PR is a bounded continuation of the existing validated slices.

## Cleanup
- Branch: `agent/issue-231-bulk-audit-unavailable`
- Release-to-demo gate: pending. This Service Admin UI change is demo-consumed; after merge it must be released, pinned in core `services/@serviceadmin/service.json`, canonical demo recycled on port 17883, and `npm run demo:verify-canonical` must pass before claiming #231 done.