### PR TITLE
feat(secrets): add bulk provider outage outcomes

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1283,6 +1283,9 @@ export function SecretsManagementPage() {
                       Audit {bulkApplyResult.auditUnavailableCount}
                     </Badge>
                     <Badge variant='outline'>
+                      Provider {bulkApplyResult.providerUnavailableCount}
+                    </Badge>
+                    <Badge variant='outline'>
                       Stale {bulkApplyResult.staleCount}
                     </Badge>
                   </div>
@@ -1342,7 +1345,8 @@ export function SecretsManagementPage() {
                                   ? 'default'
                                   : item.outcome === 'failed'
                                     ? 'destructive'
-                                    : item.outcome === 'audit-unavailable'
+                                    : item.outcome === 'audit-unavailable' ||
+                                        item.outcome === 'provider-unavailable'
                                       ? 'secondary'
                                       : 'outline'
                               }

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1840,6 +1840,36 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretBulkApplyResultHasSecretMaterial(bulkAuditUnavailableResult)
     ).toBe(false)
 
+    const bulkProviderUnavailableResult = buildBulkSecretCampaignApplyResult(
+      cleanPlan,
+      'provider-unavailable'
+    )
+    expect(bulkProviderUnavailableResult.outcome).toBe('provider_unavailable')
+    expect(bulkProviderUnavailableResult.appliedCount).toBe(0)
+    expect(bulkProviderUnavailableResult.providerUnavailableCount).toBe(1)
+    expect(bulkProviderUnavailableResult.auditStatus).toMatch(
+      /provider connector unavailable/i
+    )
+    expect(bulkProviderUnavailableResult.nextAction).toMatch(
+      /restore provider connectivity/i
+    )
+    expect(bulkProviderUnavailableResult.items[0]).toMatchObject({
+      outcome: 'provider-unavailable',
+      applied: false,
+      retrySafe: false,
+      auditStatus:
+        'campaign audit recorded; provider unavailable and item mutation not applied',
+      recovery:
+        'mutation failed closed because provider connector was unavailable',
+      nextAction:
+        'restore provider connectivity then create a fresh campaign preview',
+    })
+    expect(
+      managedSecretBulkApplyResultHasSecretMaterial(
+        bulkProviderUnavailableResult
+      )
+    ).toBe(false)
+
     const policyPlan = buildBulkSecretCampaignPlan(
       managedSecretRows,
       managedSecretRows.map((row) => row.id),

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -300,6 +300,7 @@ export type BulkSecretCampaignApplyMode =
   | 'success'
   | 'partial-failure'
   | 'audit-unavailable'
+  | 'provider-unavailable'
   | 'retryable-failure'
   | 'non-retryable-failure'
   | 'stale-plan'
@@ -312,6 +313,7 @@ export type BulkSecretCampaignApplyItemOutcome =
   | 'unsupported'
   | 'auth-required'
   | 'audit-unavailable'
+  | 'provider-unavailable'
   | 'stale-plan'
 
 export type BulkSecretCampaignApplyItem = {
@@ -339,6 +341,7 @@ export type BulkSecretCampaignApplyResult = {
     | 'partial_failure'
     | 'failed'
     | 'audit_unavailable'
+    | 'provider_unavailable'
     | 'stale_plan'
   appliedCount: number
   failedCount: number
@@ -347,6 +350,7 @@ export type BulkSecretCampaignApplyResult = {
   unsupportedCount: number
   authRequiredCount: number
   auditUnavailableCount: number
+  providerUnavailableCount: number
   staleCount: number
   auditStatus: string
   nextAction: string
@@ -502,6 +506,7 @@ export const bulkSecretCampaignApplyModes: Array<{
   { id: 'success', label: 'Apply success' },
   { id: 'partial-failure', label: 'Partial failure' },
   { id: 'audit-unavailable', label: 'Audit unavailable after submit' },
+  { id: 'provider-unavailable', label: 'Provider unavailable after submit' },
   { id: 'retryable-failure', label: 'Retryable failure' },
   { id: 'non-retryable-failure', label: 'Non-retryable failure' },
   { id: 'stale-plan', label: 'Stale plan rejected' },
@@ -1073,6 +1078,7 @@ function applyOutcomeForItem(
   const blockerOutcome = itemOutcomeFromBlockers(item)
   if (blockerOutcome) return blockerOutcome
   if (mode === 'audit-unavailable') return 'audit-unavailable'
+  if (mode === 'provider-unavailable') return 'provider-unavailable'
   if (mode === 'stale-plan') return 'stale-plan'
   if (mode === 'retryable-failure' || mode === 'non-retryable-failure') {
     return 'failed'
@@ -1097,6 +1103,8 @@ function nextActionForApplyOutcome(
       return 'complete provider auth then create a fresh plan'
     case 'audit-unavailable':
       return 'restore audit persistence then create a fresh campaign preview'
+    case 'provider-unavailable':
+      return 'restore provider connectivity then create a fresh campaign preview'
     case 'stale-plan':
       return 'create a fresh dry-run plan before applying'
     case 'skipped':
@@ -1118,6 +1126,9 @@ function recoveryForApplyOutcome(
   }
   if (outcome === 'audit-unavailable') {
     return 'mutation failed closed because item audit could not be persisted'
+  }
+  if (outcome === 'provider-unavailable') {
+    return 'mutation failed closed because provider connector was unavailable'
   }
   if (outcome === 'applied') return item.recovery
   return 'create a fresh plan after resolving the typed blocker'
@@ -1150,7 +1161,9 @@ export function buildBulkSecretCampaignApplyResult(
           ? 'campaign and item audit recorded'
           : outcome === 'audit-unavailable'
             ? 'campaign audit unavailable; item mutation not applied'
-            : 'campaign audit recorded; item mutation not applied',
+            : outcome === 'provider-unavailable'
+              ? 'campaign audit recorded; provider unavailable and item mutation not applied'
+              : 'campaign audit recorded; item mutation not applied',
       recovery: recoveryForApplyOutcome(item, outcome, mode),
       nextAction: nextActionForApplyOutcome(outcome),
     }
@@ -1171,6 +1184,9 @@ export function buildBulkSecretCampaignApplyResult(
   const auditUnavailableCount = items.filter(
     (item) => item.outcome === 'audit-unavailable'
   ).length
+  const providerUnavailableCount = items.filter(
+    (item) => item.outcome === 'provider-unavailable'
+  ).length
   const skippedCount = items.filter((item) => item.outcome === 'skipped').length
   const nonAppliedCount =
     failedCount +
@@ -1179,17 +1195,20 @@ export function buildBulkSecretCampaignApplyResult(
     unsupportedCount +
     authRequiredCount +
     auditUnavailableCount +
+    providerUnavailableCount +
     skippedCount
   const outcome =
     auditUnavailableCount > 0
       ? 'audit_unavailable'
-      : staleCount > 0
-        ? 'stale_plan'
-        : appliedCount > 0 && nonAppliedCount === 0
-          ? 'applied'
-          : appliedCount > 0
-            ? 'partial_failure'
-            : 'failed'
+      : providerUnavailableCount > 0
+        ? 'provider_unavailable'
+        : staleCount > 0
+          ? 'stale_plan'
+          : appliedCount > 0 && nonAppliedCount === 0
+            ? 'applied'
+            : appliedCount > 0
+              ? 'partial_failure'
+              : 'failed'
 
   return {
     campaignId: plan.campaignId,
@@ -1205,19 +1224,24 @@ export function buildBulkSecretCampaignApplyResult(
     unsupportedCount,
     authRequiredCount,
     auditUnavailableCount,
+    providerUnavailableCount,
     staleCount,
     auditStatus:
       auditUnavailableCount > 0
         ? 'campaign-level audit unavailable; no item mutation applied without audit persistence'
-        : 'campaign-level audit summary recorded',
+        : providerUnavailableCount > 0
+          ? 'campaign-level audit recorded; provider connector unavailable and no item mutation applied'
+          : 'campaign-level audit summary recorded',
     nextAction:
       outcome === 'applied'
         ? 'monitor campaign status'
         : outcome === 'audit_unavailable'
           ? 'restore audit sink availability and create a fresh campaign preview'
-          : outcome === 'stale_plan'
-            ? 'create a fresh plan'
-            : 'review per-item outcomes and retry only by operation id',
+          : outcome === 'provider_unavailable'
+            ? 'restore provider connectivity and create a fresh campaign preview'
+            : outcome === 'stale_plan'
+              ? 'create a fresh plan'
+              : 'review per-item outcomes and retry only by operation id',
     items,
   }
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -520,7 +520,7 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
-  test('shows bulk campaign audit-unavailable apply outcomes without secret material', async ({
+  test('shows bulk campaign audit and provider-unavailable apply outcomes without secret material', async ({
     page,
   }) => {
     await page.goto('/secrets-broker/secrets')
@@ -562,6 +562,29 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/campaign audit unavailable; item mutation not applied/i)
     ).toBeVisible()
     await expect(page.getByText(/restore audit persistence/i)).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+
+    await page
+      .getByLabel(/Apply result mode/i)
+      .selectOption('provider-unavailable')
+    await page.getByRole('button', { name: /Apply bulk campaign/i }).click()
+
+    await expect(
+      page.getByText(/Campaign apply result: provider_unavailable/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Provider 1/i)).toBeVisible()
+    await expect(
+      page.getByText(/provider connector unavailable/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /campaign audit recorded; provider unavailable and item mutation not applied/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/restore provider connectivity/i).first()
+    ).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds an explicit metadata-only bulk campaign `provider-unavailable` apply result mode.
- Counts provider outage outcomes separately in the campaign result summary and item status table.
- Extends unit and browser coverage for fail-closed provider outage recovery without raw secret material.

## Scope
- In scope: focused bulk campaign provider outage outcome state for the Secrets Broker > Secrets workflow.
- Out of scope: full #231 closure, production broker mutation API wiring, release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: existing Service Admin UI model/test fixtures for the stubbed bulk campaign operation result contract.
- Not required: no public backend API/schema changes.

## Service Lasso invariant impact
- Invariant: secrets and provider credentials stay broker-owned and are not exposed in Service Admin.
- Preservation proof: new result carries operation IDs, refs, provider/capability metadata, audit status, and recovery guidance only; tests assert no raw secret material renders.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/unit-secrets-bulk-provider-unavailable.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "provider-unavailable apply"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/playwright-secrets-bulk-provider-unavailable.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/format-check-bulk-provider-unavailable.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/lint-bulk-provider-unavailable.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T023517/build-bulk-provider-unavailable.log`

## Approval trail
- Required: no special approval documented for this focused UI/test advancement.
- Evidence: #231 is Ready / Ready for Agent and prior focused slices have merged through the same path.

## Cleanup
- Branch: `agent/issue-231-bulk-provider-unavailable`
- Release-to-demo gate applies after merge/release: this PR changes demo-consumed Service Admin UI and must be released, pinned in core, recycled on canonical port 17883, and verified before claiming this slice demo-gated.