### PR TITLE
feat(secrets): add bulk policy denied outcome

### DIFF
--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1817,6 +1817,31 @@ describe('Secrets Broker secrets management page', () => {
       false
     )
 
+    const bulkPolicyDeniedResult = buildBulkSecretCampaignApplyResult(
+      cleanPlan,
+      'policy-denied'
+    )
+    expect(bulkPolicyDeniedResult.outcome).toBe('policy_denied')
+    expect(bulkPolicyDeniedResult.appliedCount).toBe(0)
+    expect(bulkPolicyDeniedResult.deniedCount).toBe(1)
+    expect(bulkPolicyDeniedResult.auditStatus).toMatch(/policy denied/i)
+    expect(bulkPolicyDeniedResult.nextAction).toMatch(
+      /least-privilege policy approval/i
+    )
+    expect(bulkPolicyDeniedResult.items[0]).toMatchObject({
+      outcome: 'denied',
+      applied: false,
+      retrySafe: false,
+      auditStatus:
+        'campaign audit recorded; policy denied and item mutation not applied',
+      recovery:
+        'mutation failed closed because broker policy denied this item after final revalidation',
+      nextAction: 'request policy change or remove this ref from the campaign',
+    })
+    expect(
+      managedSecretBulkApplyResultHasSecretMaterial(bulkPolicyDeniedResult)
+    ).toBe(false)
+
     const bulkAuditUnavailableResult = buildBulkSecretCampaignApplyResult(
       cleanPlan,
       'audit-unavailable'

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -299,6 +299,7 @@ export type BulkSecretCampaignApplyGate = {
 export type BulkSecretCampaignApplyMode =
   | 'success'
   | 'partial-failure'
+  | 'policy-denied'
   | 'audit-unavailable'
   | 'provider-unavailable'
   | 'retryable-failure'
@@ -340,6 +341,7 @@ export type BulkSecretCampaignApplyResult = {
     | 'applied'
     | 'partial_failure'
     | 'failed'
+    | 'policy_denied'
     | 'audit_unavailable'
     | 'provider_unavailable'
     | 'stale_plan'
@@ -505,6 +507,7 @@ export const bulkSecretCampaignApplyModes: Array<{
 }> = [
   { id: 'success', label: 'Apply success' },
   { id: 'partial-failure', label: 'Partial failure' },
+  { id: 'policy-denied', label: 'Policy denied after submit' },
   { id: 'audit-unavailable', label: 'Audit unavailable after submit' },
   { id: 'provider-unavailable', label: 'Provider unavailable after submit' },
   { id: 'retryable-failure', label: 'Retryable failure' },
@@ -1077,6 +1080,7 @@ function applyOutcomeForItem(
 ): BulkSecretCampaignApplyItemOutcome {
   const blockerOutcome = itemOutcomeFromBlockers(item)
   if (blockerOutcome) return blockerOutcome
+  if (mode === 'policy-denied') return 'denied'
   if (mode === 'audit-unavailable') return 'audit-unavailable'
   if (mode === 'provider-unavailable') return 'provider-unavailable'
   if (mode === 'stale-plan') return 'stale-plan'
@@ -1124,6 +1128,9 @@ function recoveryForApplyOutcome(
   if (outcome === 'failed') {
     return 'retry with the same idempotency key after fixing the safe error'
   }
+  if (outcome === 'denied') {
+    return 'mutation failed closed because broker policy denied this item after final revalidation'
+  }
   if (outcome === 'audit-unavailable') {
     return 'mutation failed closed because item audit could not be persisted'
   }
@@ -1159,11 +1166,13 @@ export function buildBulkSecretCampaignApplyResult(
       auditStatus:
         outcome === 'applied'
           ? 'campaign and item audit recorded'
-          : outcome === 'audit-unavailable'
-            ? 'campaign audit unavailable; item mutation not applied'
-            : outcome === 'provider-unavailable'
-              ? 'campaign audit recorded; provider unavailable and item mutation not applied'
-              : 'campaign audit recorded; item mutation not applied',
+          : outcome === 'denied'
+            ? 'campaign audit recorded; policy denied and item mutation not applied'
+            : outcome === 'audit-unavailable'
+              ? 'campaign audit unavailable; item mutation not applied'
+              : outcome === 'provider-unavailable'
+                ? 'campaign audit recorded; provider unavailable and item mutation not applied'
+                : 'campaign audit recorded; item mutation not applied',
       recovery: recoveryForApplyOutcome(item, outcome, mode),
       nextAction: nextActionForApplyOutcome(outcome),
     }
@@ -1204,11 +1213,13 @@ export function buildBulkSecretCampaignApplyResult(
         ? 'provider_unavailable'
         : staleCount > 0
           ? 'stale_plan'
-          : appliedCount > 0 && nonAppliedCount === 0
-            ? 'applied'
-            : appliedCount > 0
-              ? 'partial_failure'
-              : 'failed'
+          : appliedCount === 0 && deniedCount > 0
+            ? 'policy_denied'
+            : appliedCount > 0 && nonAppliedCount === 0
+              ? 'applied'
+              : appliedCount > 0
+                ? 'partial_failure'
+                : 'failed'
 
   return {
     campaignId: plan.campaignId,
@@ -1231,7 +1242,9 @@ export function buildBulkSecretCampaignApplyResult(
         ? 'campaign-level audit unavailable; no item mutation applied without audit persistence'
         : providerUnavailableCount > 0
           ? 'campaign-level audit recorded; provider connector unavailable and no item mutation applied'
-          : 'campaign-level audit summary recorded',
+          : outcome === 'policy_denied'
+            ? 'campaign-level audit recorded; broker policy denied item mutation and no values were read or written'
+            : 'campaign-level audit summary recorded',
     nextAction:
       outcome === 'applied'
         ? 'monitor campaign status'
@@ -1241,7 +1254,9 @@ export function buildBulkSecretCampaignApplyResult(
             ? 'restore provider connectivity and create a fresh campaign preview'
             : outcome === 'stale_plan'
               ? 'create a fresh plan'
-              : 'review per-item outcomes and retry only by operation id',
+              : outcome === 'policy_denied'
+                ? 'request least-privilege policy approval and create a fresh campaign preview'
+                : 'review per-item outcomes and retry only by operation id',
     items,
   }
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -520,7 +520,7 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
-  test('shows bulk campaign audit and provider-unavailable apply outcomes without secret material', async ({
+  test('shows bulk campaign audit policy-denied and provider-unavailable apply outcomes without secret material', async ({
     page,
   }) => {
     await page.goto('/secrets-broker/secrets')
@@ -562,6 +562,27 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/campaign audit unavailable; item mutation not applied/i)
     ).toBeVisible()
     await expect(page.getByText(/restore audit persistence/i)).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+
+    await page.getByLabel(/Apply result mode/i).selectOption('policy-denied')
+    await page.getByRole('button', { name: /Apply bulk campaign/i }).click()
+
+    await expect(
+      page.getByText(/Campaign apply result: policy_denied/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Denied 1/i)).toBeVisible()
+    await expect(
+      page.getByText(/broker policy denied item mutation/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /campaign audit recorded; policy denied and item mutation not applied/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/request least-privilege policy approval/i)
+    ).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
 


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add an explicit metadata-only bulk campaign `policy-denied` apply result mode.
- Surface aggregate `policy_denied` status, denied item audit status, recovery guidance, and least-privilege policy next action.
- Extend unit and browser coverage to prove the denied apply path stays redaction-safe.

## Scope
- In scope: focused Service Admin Secrets page stub/fixture path for bulk campaign policy-denied apply outcome evidence.
- Out of scope: full #231 closure, live Secrets Broker mutation contract, backend policy enforcement, release/demo pin after merge.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin fixture/model state for bulk campaign policy-denied apply results.
- Not required because: this does not change a public API/schema or claim real backend enforcement; it remains a metadata-only UI workflow slice.

## Nash invariant impact
- Invariant: secret-bearing surfaces must not render raw values, provider credentials, request/response bodies, route/query payloads, local/session storage, exports, or diagnostics material.
- Preservation proof: new result text includes only refs, operation identity, audit/policy status, recovery guidance, and next action; tests assert `DEMO_REVEAL_VALUE_42` and secret material are absent.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/unit-secrets-bulk-policy-denied.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "policy-denied"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/playwright-secrets-bulk-policy-denied.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/format-check-bulk-policy-denied.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/lint-bulk-policy-denied.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/build-bulk-policy-denied.log`
- PASS canonical preflight: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: branch created from clean `master`; open org PR gate was empty before work.

## Cleanup
- Branch: `agent/issue-231-bulk-policy-denied`
- Release-to-demo gate: pending after merge/release. This PR changes Service Admin UI code consumed by the canonical demo, so #231 must not be claimed done until Service Admin is released, core `@serviceadmin` pin is updated, canonical demo is recycled on port 17883, and `npm run demo:verify-canonical` passes with matching expected/live tags.