### PR TITLE
feat(secrets): add bulk auth-required apply result

### DIFF
--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1842,6 +1842,33 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretBulkApplyResultHasSecretMaterial(bulkPolicyDeniedResult)
     ).toBe(false)
 
+    const bulkAuthRequiredResult = buildBulkSecretCampaignApplyResult(
+      cleanPlan,
+      'auth-required'
+    )
+    expect(bulkAuthRequiredResult.outcome).toBe('auth_required')
+    expect(bulkAuthRequiredResult.appliedCount).toBe(0)
+    expect(bulkAuthRequiredResult.authRequiredCount).toBe(1)
+    expect(bulkAuthRequiredResult.auditStatus).toMatch(
+      /provider reauthentication required/i
+    )
+    expect(bulkAuthRequiredResult.nextAction).toMatch(
+      /complete provider reauthentication/i
+    )
+    expect(bulkAuthRequiredResult.items[0]).toMatchObject({
+      outcome: 'auth-required',
+      applied: false,
+      retrySafe: false,
+      auditStatus:
+        'campaign audit recorded; provider auth required and item mutation not applied',
+      recovery:
+        'mutation failed closed because broker requires provider reauthentication',
+      nextAction: 'complete provider auth then create a fresh plan',
+    })
+    expect(
+      managedSecretBulkApplyResultHasSecretMaterial(bulkAuthRequiredResult)
+    ).toBe(false)
+
     const bulkAuditUnavailableResult = buildBulkSecretCampaignApplyResult(
       cleanPlan,
       'audit-unavailable'

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -300,6 +300,7 @@ export type BulkSecretCampaignApplyMode =
   | 'success'
   | 'partial-failure'
   | 'policy-denied'
+  | 'auth-required'
   | 'audit-unavailable'
   | 'provider-unavailable'
   | 'retryable-failure'
@@ -342,6 +343,7 @@ export type BulkSecretCampaignApplyResult = {
     | 'partial_failure'
     | 'failed'
     | 'policy_denied'
+    | 'auth_required'
     | 'audit_unavailable'
     | 'provider_unavailable'
     | 'stale_plan'
@@ -508,6 +510,7 @@ export const bulkSecretCampaignApplyModes: Array<{
   { id: 'success', label: 'Apply success' },
   { id: 'partial-failure', label: 'Partial failure' },
   { id: 'policy-denied', label: 'Policy denied after submit' },
+  { id: 'auth-required', label: 'Provider auth required after submit' },
   { id: 'audit-unavailable', label: 'Audit unavailable after submit' },
   { id: 'provider-unavailable', label: 'Provider unavailable after submit' },
   { id: 'retryable-failure', label: 'Retryable failure' },
@@ -1081,6 +1084,7 @@ function applyOutcomeForItem(
   const blockerOutcome = itemOutcomeFromBlockers(item)
   if (blockerOutcome) return blockerOutcome
   if (mode === 'policy-denied') return 'denied'
+  if (mode === 'auth-required') return 'auth-required'
   if (mode === 'audit-unavailable') return 'audit-unavailable'
   if (mode === 'provider-unavailable') return 'provider-unavailable'
   if (mode === 'stale-plan') return 'stale-plan'
@@ -1131,6 +1135,9 @@ function recoveryForApplyOutcome(
   if (outcome === 'denied') {
     return 'mutation failed closed because broker policy denied this item after final revalidation'
   }
+  if (outcome === 'auth-required') {
+    return 'mutation failed closed because broker requires provider reauthentication'
+  }
   if (outcome === 'audit-unavailable') {
     return 'mutation failed closed because item audit could not be persisted'
   }
@@ -1168,11 +1175,13 @@ export function buildBulkSecretCampaignApplyResult(
           ? 'campaign and item audit recorded'
           : outcome === 'denied'
             ? 'campaign audit recorded; policy denied and item mutation not applied'
-            : outcome === 'audit-unavailable'
-              ? 'campaign audit unavailable; item mutation not applied'
-              : outcome === 'provider-unavailable'
-                ? 'campaign audit recorded; provider unavailable and item mutation not applied'
-                : 'campaign audit recorded; item mutation not applied',
+            : outcome === 'auth-required'
+              ? 'campaign audit recorded; provider auth required and item mutation not applied'
+              : outcome === 'audit-unavailable'
+                ? 'campaign audit unavailable; item mutation not applied'
+                : outcome === 'provider-unavailable'
+                  ? 'campaign audit recorded; provider unavailable and item mutation not applied'
+                  : 'campaign audit recorded; item mutation not applied',
       recovery: recoveryForApplyOutcome(item, outcome, mode),
       nextAction: nextActionForApplyOutcome(outcome),
     }
@@ -1211,15 +1220,19 @@ export function buildBulkSecretCampaignApplyResult(
       ? 'audit_unavailable'
       : providerUnavailableCount > 0
         ? 'provider_unavailable'
-        : staleCount > 0
-          ? 'stale_plan'
-          : appliedCount === 0 && deniedCount > 0
-            ? 'policy_denied'
-            : appliedCount > 0 && nonAppliedCount === 0
-              ? 'applied'
-              : appliedCount > 0
-                ? 'partial_failure'
-                : 'failed'
+        : mode === 'auth-required' &&
+            authRequiredCount > 0 &&
+            appliedCount === 0
+          ? 'auth_required'
+          : staleCount > 0
+            ? 'stale_plan'
+            : appliedCount === 0 && deniedCount > 0
+              ? 'policy_denied'
+              : appliedCount > 0 && nonAppliedCount === 0
+                ? 'applied'
+                : appliedCount > 0
+                  ? 'partial_failure'
+                  : 'failed'
 
   return {
     campaignId: plan.campaignId,
@@ -1242,9 +1255,11 @@ export function buildBulkSecretCampaignApplyResult(
         ? 'campaign-level audit unavailable; no item mutation applied without audit persistence'
         : providerUnavailableCount > 0
           ? 'campaign-level audit recorded; provider connector unavailable and no item mutation applied'
-          : outcome === 'policy_denied'
-            ? 'campaign-level audit recorded; broker policy denied item mutation and no values were read or written'
-            : 'campaign-level audit summary recorded',
+          : outcome === 'auth_required'
+            ? 'campaign-level audit recorded; provider reauthentication required and no values were read or written'
+            : outcome === 'policy_denied'
+              ? 'campaign-level audit recorded; broker policy denied item mutation and no values were read or written'
+              : 'campaign-level audit summary recorded',
     nextAction:
       outcome === 'applied'
         ? 'monitor campaign status'
@@ -1252,11 +1267,13 @@ export function buildBulkSecretCampaignApplyResult(
           ? 'restore audit sink availability and create a fresh campaign preview'
           : outcome === 'provider_unavailable'
             ? 'restore provider connectivity and create a fresh campaign preview'
-            : outcome === 'stale_plan'
-              ? 'create a fresh plan'
-              : outcome === 'policy_denied'
-                ? 'request least-privilege policy approval and create a fresh campaign preview'
-                : 'review per-item outcomes and retry only by operation id',
+            : outcome === 'auth_required'
+              ? 'complete provider reauthentication and create a fresh campaign preview'
+              : outcome === 'stale_plan'
+                ? 'create a fresh plan'
+                : outcome === 'policy_denied'
+                  ? 'request least-privilege policy approval and create a fresh campaign preview'
+                  : 'review per-item outcomes and retry only by operation id',
     items,
   }
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -520,7 +520,7 @@ test.describe('Secrets Broker browser coverage', () => {
     expect(consoleErrors).toEqual([])
   })
 
-  test('shows bulk campaign audit policy-denied and provider-unavailable apply outcomes without secret material', async ({
+  test('shows bulk campaign audit auth policy-denied and provider-unavailable apply outcomes without secret material', async ({
     page,
   }) => {
     await page.goto('/secrets-broker/secrets')
@@ -582,6 +582,29 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(
       page.getByText(/request least-privilege policy approval/i)
+    ).toBeVisible()
+    await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
+    await expectNoSecretMaterial(page)
+
+    await page.getByLabel(/Apply result mode/i).selectOption('auth-required')
+    await page.getByRole('button', { name: /Apply bulk campaign/i }).click()
+
+    await expect(
+      page.getByText(/Campaign apply result: auth_required/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Auth 2/i)).toBeVisible()
+    await expect(
+      page.getByText(/provider reauthentication required/i)
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(
+          /campaign audit recorded; provider auth required and item mutation not applied/i
+        )
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/complete provider reauthentication/i)
     ).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Added an explicit metadata-only bulk campaign `auth-required` apply mode and `auth_required` campaign outcome.
- Bulk apply results now fail closed after submit when the broker requires provider reauthentication, with per-item audit/recovery/next-action metadata only.
- Extended unit and browser coverage for the auth-required outcome alongside policy/audit/provider fail-closed paths.

## Scope
- In scope: Service Admin Secrets Broker > Secrets stub campaign result modeling and focused test coverage.
- Out of scope: live Secrets Broker production mutation API, provider auth implementation, final #231 closure, and demo release/pin/recycle before this PR is merged.

## Spec / contract / fixture impact
- Updated: UI-facing typed stub model for `BulkSecretCampaignApplyMode` and `BulkSecretCampaignApplyResult`.
- Not required: public backend API/schema changes; this remains Service Admin stub/workflow metadata.

## Nash invariant impact
- Invariant: no raw secret values, provider credentials, tokens, request/response bodies, route/query payloads, local/session storage, exports, or diagnostics material are rendered or persisted.
- Preservation proof: tests assert no `DEMO_REVEAL_VALUE_42` and model redaction guard `managedSecretBulkApplyResultHasSecretMaterial(...) === false` for auth-required.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/unit-secrets-bulk-auth-required.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "audit auth"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/playwright-secrets-bulk-auth-required.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/format-check-bulk-auth-required.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/lint-bulk-auth-required.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/build-bulk-auth-required.log`
- NOTE initial focused Playwright attempts caught and documented a campaign outcome precedence bug and a strict locator/count adjustment before the final passing run: `playwright-secrets-bulk-auth-required-initial-fail.log`, `playwright-secrets-bulk-auth-required-count-fail.log`, and `playwright-secrets-bulk-auth-required-strict-fail.log`.

## Approval trail
- Required: no special approval requirement found in the issue trail for focused Service Admin UI/test advancement.
- Evidence: #231 recent slices used PR CI plus release/demo gate after merge.

## Cleanup
- Branch: `agent/issue-231-bulk-auth-required`
- Release-to-demo gate is pending until this PR is merged, Service Admin releases, core `@serviceadmin` pin is updated, and canonical demo consumes the exact new release.