### PR TITLE
feat(secrets): add single-secret policy denial recovery

### DIFF
--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1043,6 +1043,13 @@ describe('Secrets Broker secrets management page', () => {
       nextAction:
         'update policy assignment or request least-privilege approval',
     })
+    expect(deniedResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'preserve the denied operation id for audit review only',
+        'request least-privilege policy approval before any new submit',
+        'create a fresh audited preview after policy assignment changes',
+      ])
+    )
 
     const authRequiredResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -1911,25 +1911,31 @@ export function buildSingleSecretOperationResult(
                 'request a fresh reveal instead of reusing stale metadata',
               ]
   const outcomeRecoverySteps =
-    outcome === 'auth-required'
+    outcome === 'policy-denied'
       ? [
-          'complete provider reauthentication in the broker-owned auth flow',
-          'discard this dry-run token after auth challenge starts',
-          'create a fresh audited preview after provider session is refreshed',
+          'preserve the denied operation id for audit review only',
+          'request least-privilege policy approval before any new submit',
+          'create a fresh audited preview after policy assignment changes',
         ]
-      : outcome === 'provider-unavailable'
+      : outcome === 'auth-required'
         ? [
-            'wait for broker health to confirm the provider connector is reachable',
-            'keep the current operation id for support evidence only',
-            'create a fresh audited preview after provider capability metadata refreshes',
+            'complete provider reauthentication in the broker-owned auth flow',
+            'discard this dry-run token after auth challenge starts',
+            'create a fresh audited preview after provider session is refreshed',
           ]
-        : outcome === 'stale-plan'
+        : outcome === 'provider-unavailable'
           ? [
-              'discard the expired dry-run token and operation submit envelope',
-              'refresh policy, provider capability, audit sink, and ref metadata before retry',
-              'create a fresh audited preview before any broker submit is attempted',
+              'wait for broker health to confirm the provider connector is reachable',
+              'keep the current operation id for support evidence only',
+              'create a fresh audited preview after provider capability metadata refreshes',
             ]
-          : []
+          : outcome === 'stale-plan'
+            ? [
+                'discard the expired dry-run token and operation submit envelope',
+                'refresh policy, provider capability, audit sink, and ref metadata before retry',
+                'create a fresh audited preview before any broker submit is attempted',
+              ]
+            : []
   const recoverySteps = [...actionRecoverySteps, ...outcomeRecoverySteps]
   const applied = outcome === 'applied'
   const resultBadge =

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -423,6 +423,23 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/no retry needed after broker success/i).first()
     ).toBeVisible()
     await expect(page.getByText(/2 submitted/i)).toBeVisible()
+    await page.getByLabel(/Result status/i).selectOption('policy-denied')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: policy-denied/i)
+    ).toBeVisible()
+    await expect(page.getByText(/no value was read or written/i)).toBeVisible()
+    await expect(
+      page.getByText(/policy denial is fail-closed/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/request least-privilege policy approval/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/fresh plan required before any retry/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/3 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('auth-required')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -447,7 +464,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/paused for broker reauthentication/i)
     ).toBeVisible()
-    await expect(page.getByText(/3 submitted/i)).toBeVisible()
+    await expect(page.getByText(/4 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('audit-unavailable')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -468,7 +485,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/restore audit sink availability/i).first()
     ).toBeVisible()
-    await expect(page.getByText(/4 submitted/i)).toBeVisible()
+    await expect(page.getByText(/5 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('provider-unavailable')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -490,7 +507,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/provider recovery happens in broker/i)
     ).toBeVisible()
-    await expect(page.getByText(/5 submitted/i)).toBeVisible()
+    await expect(page.getByText(/6 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('stale-plan')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -514,7 +531,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/stale-plan recovery creates a new dry-run/i)
     ).toBeVisible()
-    await expect(page.getByText(/6 submitted/i)).toBeVisible()
+    await expect(page.getByText(/7 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Added explicit metadata-only recovery steps for single-secret `policy-denied` operation results.
- Extended browser coverage to drive the single-secret policy-denied terminal path after dry-run/apply simulation.
- Kept the path fail-closed: no raw values, copy/export payloads, route/query payloads, storage writes, or diagnostic secret material.

## Scope
- In scope: single-secret policy-denied recovery guidance and matching unit/browser coverage.
- Out of scope: closing the full #231 workflow, backend mutation wiring, release/demo pinning before merge.

## Spec / contract / fixture impact
- Updated: modeled Service Admin operation-result metadata only.
- Not required because: no public API/schema/lifecycle/release contract changes.

## Nash invariant impact
- Invariant: raw secret values and provider credentials must not appear in UI, routes, storage, logs, diagnostics, screenshots, or tests.
- Preservation proof: test coverage asserts the policy-denied path renders no `DEMO_REVEAL_VALUE_42` and the shared no-secret-material browser guard stays green.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/unit-secrets-single-policy-denied-rerun.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "single-secret rotate preview"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/playwright-secrets-single-policy-denied-final.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/format-check-single-policy-denied-rerun.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/lint-single-policy-denied.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/build-single-policy-denied.log`
- NOTE first focused Playwright attempt failed on a hidden select-option assertion; fixed and reran successfully. Failure log: `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-0825/playwright-secrets-single-policy-denied.log`.

## Approval trail
- Required: no special approval documented for this focused UI/test advancement.
- Evidence: issue #231 is Ready / Ready for Agent; this PR uses `Refs #231` because the full issue remains open.

## Cleanup
- Branch: `agent/issue-231-single-policy-denied`
- After merge: release Service Admin, update core `@serviceadmin` pin, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, verify LAN Service Admin/runtime, then delete branch when safe.