### PR TITLE
feat(secrets): show auth challenge metadata

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -2187,6 +2187,21 @@ export function SecretsManagementPage() {
                     {singleApplyResult.nextAction}
                   </div>
                 </div>
+                {singleApplyResult.providerAuthChallengeRef ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Provider auth challenge
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.providerAuthChallengeRef}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      Broker-owned challenge metadata only; provider
+                      credentials, tokens, cookies, and recovery material stay
+                      outside Service Admin.
+                    </div>
+                  </div>
+                ) : null}
                 <div className='mt-3 grid gap-3 md:grid-cols-2'>
                   <div className='rounded-md border bg-muted/30 p-3'>
                     <div className='text-xs font-medium text-muted-foreground uppercase'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1063,6 +1063,8 @@ describe('Secrets Broker secrets management page', () => {
       recoveryStatus:
         'provider reauthentication must complete in the broker-owned auth flow',
       retryPolicy: 'fresh plan required before any retry',
+      providerAuthChallengeRef:
+        'auth-challenge-reset-serviceadmin-session-signing-metadata',
       nextAction:
         'complete broker provider reauthentication and create a fresh preview',
     })
@@ -1099,6 +1101,9 @@ describe('Secrets Broker secrets management page', () => {
         ),
       ])
     ).toBe(false)
+    expect(authRequiredResult.providerAuthChallengeRef).not.toMatch(
+      /credential|token|cookie|private key|DEMO_REVEAL_VALUE_42/i
+    )
 
     const auditUnavailableResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -111,6 +111,7 @@ export type SingleSecretOperationResult = {
   resultStatus: string
   recoveryStatus: string
   retryPolicy: string
+  providerAuthChallengeRef: string | null
   recoverySteps: string[]
   auditFeedback: SingleSecretAuditFeedback
   safetyRows: string[]
@@ -2040,6 +2041,10 @@ export function buildSingleSecretOperationResult(
           : plan.action === 'delete' || plan.action === 'policy'
             ? 'fresh plan required before any retry'
             : 'retry only by operation id when broker marks the attempt retry-safe'
+  const providerAuthChallengeRef =
+    outcome === 'auth-required'
+      ? `auth-challenge-${safeOperationSlug(plan.action, row)}-metadata`
+      : null
   const auditFeedback = buildSingleSecretAuditFeedback(
     row,
     plan,
@@ -2058,6 +2063,7 @@ export function buildSingleSecretOperationResult(
     resultStatus,
     recoveryStatus,
     retryPolicy,
+    providerAuthChallengeRef,
     recoverySteps,
     auditFeedback,
     safetyRows: [

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -459,6 +459,17 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/broker-owned provider reauthentication required/i)
     ).toBeVisible()
     await expect(
+      page.getByText('Provider auth challenge', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /auth-challenge-reset-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Broker-owned challenge metadata only/i)
+    ).toBeVisible()
+    await expect(
       page.getByText(/provider reauthentication happens outside Service Admin/i)
     ).toBeVisible()
     await expect(


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only provider auth challenge reference for single-secret `auth-required` results.
- Surface the challenge reference in the Secrets Broker > Secrets result panel with explicit credential/token/cookie/recovery-material exclusion copy.
- Extend focused unit and browser coverage for the auth-required terminal path without revealing or exporting raw values.

## Scope
- In scope: single-secret operation result metadata and UI evidence for broker-owned provider reauthentication.
- Out of scope: completing the full #231 workflow, backend mutation wiring, provider credential capture, and bulk raw reveal/export.

## Spec / contract / fixture impact
- Updated: UI model/test contract for `SingleSecretOperationResult.providerAuthChallengeRef`.
- Not required: no public API schema or backend contract changes; this is stub/metadata UI evidence only.

## Nash invariant impact
- Invariant: Service Admin must never handle raw secret values, provider credentials, tokens, cookies, private keys, recovery material, or raw env values in safe operation surfaces.
- Preservation proof: challenge refs are deterministic metadata ids only and tests assert the ref excludes credential/token/cookie/private-key/raw-value sentinels.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/unit-secrets-single-auth-required-recovery.log` (15 passed)
- FAIL then fixed `npx playwright test tests/ui/secrets-broker.spec.ts --grep "single-secret rotate preview"` — first run failed on a strict locator only; log `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/playwright-secrets-single-auth-required-recovery.log`
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "single-secret rotate preview"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/playwright-secrets-single-auth-required-recovery-rerun.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/format-check-single-auth-required-recovery-rerun.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/lint-single-auth-required-recovery.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-092514/build-single-auth-required-recovery.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: existing issue #231 worker trail uses focused Service Admin PR slices with CI and demo gate after merge.

## Cleanup
- Branch: `agent/issue-231-single-auth-required-recovery`
- Release-to-demo gate: pending after merge/release/pin/recycle because this Service Admin UI change is demo-consumed. This PR does not claim #231 done.
