### PR TITLE
feat(secrets): add provider recovery metadata evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -2202,6 +2202,22 @@ export function SecretsManagementPage() {
                     </div>
                   </div>
                 ) : null}
+                {singleApplyResult.providerRecoveryRef ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Provider recovery evidence
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.providerRecoveryRef}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      Broker-owned recovery metadata only; connector health,
+                      capability refresh, and correlation refs are tracked
+                      without provider credentials, tokens, cookies, request
+                      bodies, response bodies, or raw secret material.
+                    </div>
+                  </div>
+                ) : null}
                 <div className='mt-3 grid gap-3 md:grid-cols-2'>
                   <div className='rounded-md border bg-muted/30 p-3'>
                     <div className='text-xs font-medium text-muted-foreground uppercase'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -843,6 +843,15 @@ describe('Secrets Broker secrets management page', () => {
       screen.getAllByText(/terminal provider unavailable/i)[0]
     ).toBeVisible()
     expect(screen.getAllByText(/provider outage/i)[0]).toBeVisible()
+    expect(screen.getByText(/Provider recovery evidence/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        /provider-recovery-[a-z-]+-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Broker-owned recovery metadata only/i)
+    ).toBeVisible()
     expect(screen.getByText(/connector status metadata only/i)).toBeVisible()
 
     await user.selectOptions(
@@ -1154,6 +1163,9 @@ describe('Secrets Broker secrets management page', () => {
       recoveryStatus:
         'provider outage is fail-closed and requires a fresh audited preview',
       retryPolicy: 'fresh plan required before any retry',
+      providerAuthChallengeRef: null,
+      providerRecoveryRef:
+        'provider-recovery-reset-serviceadmin-session-signing-metadata',
       nextAction:
         'restore provider connectivity or capability support and create a fresh preview',
     })
@@ -1190,6 +1202,9 @@ describe('Secrets Broker secrets management page', () => {
         ),
       ])
     ).toBe(false)
+    expect(providerUnavailableResult.providerRecoveryRef).not.toMatch(
+      /credential|token|cookie|private key|request body|response body|DEMO_REVEAL_VALUE_42/i
+    )
 
     const staleResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -112,6 +112,7 @@ export type SingleSecretOperationResult = {
   recoveryStatus: string
   retryPolicy: string
   providerAuthChallengeRef: string | null
+  providerRecoveryRef: string | null
   recoverySteps: string[]
   auditFeedback: SingleSecretAuditFeedback
   safetyRows: string[]
@@ -2045,6 +2046,10 @@ export function buildSingleSecretOperationResult(
     outcome === 'auth-required'
       ? `auth-challenge-${safeOperationSlug(plan.action, row)}-metadata`
       : null
+  const providerRecoveryRef =
+    outcome === 'provider-unavailable'
+      ? `provider-recovery-${safeOperationSlug(plan.action, row)}-metadata`
+      : null
   const auditFeedback = buildSingleSecretAuditFeedback(
     row,
     plan,
@@ -2064,6 +2069,7 @@ export function buildSingleSecretOperationResult(
     recoveryStatus,
     retryPolicy,
     providerAuthChallengeRef,
+    providerRecoveryRef,
     recoverySteps,
     auditFeedback,
     safetyRows: [

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -513,6 +513,17 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/provider status: connector unavailable or unsupported/i)
     ).toBeVisible()
     await expect(
+      page.getByText('Provider recovery evidence', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /provider-recovery-reset-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Broker-owned recovery metadata only/i)
+    ).toBeVisible()
+    await expect(
       page.getByText(/terminal provider unavailable/i).first()
     ).toBeVisible()
     await expect(


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only `providerRecoveryRef` for single-secret terminal `provider-unavailable` results.
- Render provider recovery evidence on the Secrets page so operators can track connector/capability recovery without leaking credentials or raw values.
- Extend unit and browser coverage for the provider-unavailable path.

## Scope
- In scope: focused provider-unavailable recovery evidence for the existing single-secret stub apply/status workflow.
- Out of scope: full #231 completion, production Secrets Broker mutation API wiring, bulk raw reveal/export, provider credential entry.

## Spec / contract / fixture impact
- Not required because this extends existing Service Admin stub/status metadata for an already modeled terminal outcome; no public API/schema is changed.

## Service Lasso invariant impact
- Secrets remain hidden by default.
- Provider credentials, tokens, cookies, private keys, recovery material, request bodies, response bodies, and raw secret material remain outside Service Admin.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/unit-secrets-provider-recovery-rerun.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "single-secret rotate preview"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/playwright-secrets-provider-recovery.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/format-check-provider-recovery.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/lint-provider-recovery.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/build-provider-recovery.log`
- NOTE first focused unit attempt failed only because the new assertion expected the reset action slug while that component path used the default metadata action; fixed and reran successfully. Failure log: `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/unit-secrets-provider-recovery.log`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.

## Cleanup
- Branch will be deleted after merge.
- Release-to-demo gate applies after merge/release/pin/recycle because this repo is demo-consumed. This PR is not claiming #231 done.