### PR TITLE
feat(secrets): add safe broker failure evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -2218,6 +2218,25 @@ export function SecretsManagementPage() {
                     </div>
                   </div>
                 ) : null}
+                {singleApplyResult.brokerFailureRef ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Broker failure evidence
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {singleApplyResult.brokerFailureRef}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      {singleApplyResult.brokerFailureCategory}
+                    </div>
+                    <div className='mt-2 text-muted-foreground'>
+                      Metadata-only safe failure evidence; retry decisions stay
+                      scoped to the operation id and omit request bodies,
+                      response bodies, provider credentials, tokens, cookies,
+                      environment values, and raw secret material.
+                    </div>
+                  </div>
+                ) : null}
                 <div className='mt-3 grid gap-3 md:grid-cols-2'>
                   <div className='rounded-md border bg-muted/30 p-3'>
                     <div className='text-xs font-medium text-muted-foreground uppercase'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1254,6 +1254,49 @@ describe('Secrets Broker secrets management page', () => {
       ])
     ).toBe(false)
 
+    const failedResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'failed'
+    )
+    expect(failedResult).toMatchObject({
+      outcome: 'failed',
+      applied: false,
+      resultBadge: 'apply failed',
+      brokerFailureRef:
+        'broker-failure-reset-serviceadmin-session-signing-metadata',
+      brokerFailureCategory: 'provider_retryable_safe_error',
+      recoveryStatus:
+        'broker failure recovery depends on retry-safe operation metadata',
+      retryPolicy:
+        'retry only with the same operation id when broker marks retry safe',
+      nextAction:
+        'review safe broker failure metadata and retry only when marked safe',
+    })
+    expect(failedResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'preserve the broker failure reference for support evidence only',
+        'retry only when the broker marks the same operation id retry safe',
+        'create a fresh preview if the failure category changes before retry',
+      ])
+    )
+    expect(failedResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'broker failure evidence is limited to operation id, category, retry-safe status, and correlation id',
+      ])
+    )
+    expect(failedResult.auditFeedback).toMatchObject({
+      eventState: 'recorded as safe broker failure metadata',
+    })
+    expect(failedResult.auditFeedback.evidenceRows).toEqual(
+      expect.arrayContaining([
+        'broker failure evidence contains typed category metadata only and never request or response bodies',
+      ])
+    )
+    expect(failedResult.brokerFailureRef).not.toMatch(
+      /credential|token|cookie|private key|request body|response body|DEMO_REVEAL_VALUE_42/i
+    )
+
     const historyEntry = buildSingleSecretOperationHistoryEntry(
       managedSecretRows[0],
       rotatePlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -113,6 +113,8 @@ export type SingleSecretOperationResult = {
   retryPolicy: string
   providerAuthChallengeRef: string | null
   providerRecoveryRef: string | null
+  brokerFailureRef: string | null
+  brokerFailureCategory: string | null
   recoverySteps: string[]
   auditFeedback: SingleSecretAuditFeedback
   safetyRows: string[]
@@ -1937,7 +1939,13 @@ export function buildSingleSecretOperationResult(
                 'refresh policy, provider capability, audit sink, and ref metadata before retry',
                 'create a fresh audited preview before any broker submit is attempted',
               ]
-            : []
+            : outcome === 'failed'
+              ? [
+                  'preserve the broker failure reference for support evidence only',
+                  'retry only when the broker marks the same operation id retry safe',
+                  'create a fresh preview if the failure category changes before retry',
+                ]
+              : []
   const recoverySteps = [...actionRecoverySteps, ...outcomeRecoverySteps]
   const applied = outcome === 'applied'
   const resultBadge =
@@ -2050,6 +2058,22 @@ export function buildSingleSecretOperationResult(
     outcome === 'provider-unavailable'
       ? `provider-recovery-${safeOperationSlug(plan.action, row)}-metadata`
       : null
+  const brokerFailureRef =
+    outcome === 'failed'
+      ? `broker-failure-${safeOperationSlug(plan.action, row)}-metadata`
+      : null
+  const brokerFailureCategory =
+    outcome === 'failed'
+      ? plan.action === 'reset'
+        ? 'provider_retryable_safe_error'
+        : plan.action === 'edit'
+          ? 'metadata_update_retryable_safe_error'
+          : plan.action === 'delete'
+            ? 'decommission_non_retryable_safe_error'
+            : plan.action === 'policy'
+              ? 'policy_assignment_safe_error'
+              : 'reveal_safe_error'
+      : null
   const auditFeedback = buildSingleSecretAuditFeedback(
     row,
     plan,
@@ -2070,6 +2094,8 @@ export function buildSingleSecretOperationResult(
     retryPolicy,
     providerAuthChallengeRef,
     providerRecoveryRef,
+    brokerFailureRef,
+    brokerFailureCategory,
     recoverySteps,
     auditFeedback,
     safetyRows: [
@@ -2088,7 +2114,9 @@ export function buildSingleSecretOperationResult(
           ? 'provider outage details are limited to connector state, capability metadata, and correlation id'
           : outcome === 'stale-plan'
             ? 'stale-plan evidence is limited to operation id, ref, action, and expired preview metadata'
-            : 'broker result metadata excludes provider auth challenge secrets',
+            : outcome === 'failed'
+              ? 'broker failure evidence is limited to operation id, category, retry-safe status, and correlation id'
+              : 'broker result metadata excludes provider auth challenge secrets',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction,
@@ -2149,7 +2177,9 @@ export function buildSingleSecretAuditFeedback(
           ? 'provider outage evidence contains connector status metadata only and never provider credentials'
           : outcome === 'stale-plan'
             ? 'stale-plan evidence contains expired preview metadata only and never request or response bodies'
-            : 'provider auth material is omitted from audit evidence',
+            : outcome === 'failed'
+              ? 'broker failure evidence contains typed category metadata only and never request or response bodies'
+              : 'provider auth material is omitted from audit evidence',
       'route, query string, local storage, and diagnostics receive no secret material',
     ],
   }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -554,6 +554,35 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/stale-plan recovery creates a new dry-run/i)
     ).toBeVisible()
     await expect(page.getByText(/7 submitted/i)).toBeVisible()
+    await page.getByLabel(/Result status/i).selectOption('failed')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: failed/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/failed with broker-owned safe error metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText('Broker failure evidence', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /broker-failure-reset-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    await expect(page.getByText(/provider_retryable_safe_error/i)).toBeVisible()
+    await expect(
+      page.getByText(/Metadata-only safe failure evidence/i)
+    ).toBeVisible()
+    await expect(page.getByText(/terminal safe failure/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/retry-reset-serviceadmin-session-signing/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/retry only with the same operation id/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/8 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add metadata-only broker failure evidence for single-secret terminal `failed` operation results.
- Render a dedicated Broker failure evidence panel on the Secrets page with the failure ref/category and retry guidance.
- Extend unit and Playwright coverage for retry-safe failure metadata without raw value or credential leakage.

## Scope
- In scope: single-secret stub/result metadata and UI coverage for safe broker failures.
- Out of scope: completing all remaining #231 reveal/edit/delete/policy production wiring or changing the Secrets Broker API contract.

## Spec / contract / fixture impact
- No public API/contract change. This is Service Admin metadata-display behavior over the existing stub/result model.

## Service Lasso invariant impact
- Raw secret values, provider credentials, tokens, cookies, request/response bodies, environment values, and recovery material remain omitted from the UI and tests.
- Retry guidance stays operation-id scoped and metadata-only.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\unit-secrets-safe-failure.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "single-secret rotate preview"` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\playwright-secrets-safe-failure.log` (1 passed)
- PASS `npm run format:check` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\format-check-safe-failure.log`
- PASS `npm run lint` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\lint-safe-failure.log`
- PASS `npm run build` — `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-231-20260622-112816\build-safe-failure.log`

## Demo / release gate
- Code changes are demo-consumed. Release-to-demo is not complete until this PR is merged, released, pinned in core, canonical demo is recycled on port 17883, and `npm run demo:verify-canonical` passes.
- Current canonical preflight before work was healthy: Service Admin HTTP 200 and runtime `/api/health` HTTP 200/status `ok`.

## Cleanup
- Branch: `agent/issue-231-single-safe-failure-metadata`
- Local cleanup pending PR merge/release/demo gate.