### PR TITLE
feat(secrets): show single action impact evidence

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -12,6 +12,7 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - Shows unavailable privileged operations as explanatory text, not controls.
 - The Secrets Broker Secrets page also exposes a bulk campaign workflow. Operators can select multiple metadata rows, choose a campaign operation, and generate safe per-ref/aggregate capability, policy, risk, audit, operation ID, idempotency, and blocker metadata.
 - Supported rotate/reset, update/edit, policy apply/change, and provider migration/remap campaigns can apply only after audit reason, explicit confirmation, and immediate revalidation. Apply results show campaign ID, operation ID, plan token, per-item operation IDs, idempotency keys, typed outcomes, audit status, retry/recovery guidance, and skipped/denied/unsupported/auth-required rows without raw values.
+- Single-secret apply results include post-apply impact evidence: dependent service refs, audit/rollback/recovery refs, fresh-preview requirements, and omitted unsafe fields. Delete/decommission and policy assignment evidence is metadata-only and never includes current values, request/response bodies, provider credentials, cookies, tokens, private keys, recovery material, or raw environment values.
 
 ## Not implemented in this slice
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -2187,6 +2187,101 @@ export function SecretsManagementPage() {
                     {singleApplyResult.nextAction}
                   </div>
                 </div>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='mb-3 flex flex-wrap items-center gap-2'>
+                    <div className='font-medium'>
+                      {singleApplyResult.impactEvidence.title}
+                    </div>
+                    <Badge variant='secondary'>Metadata only</Badge>
+                  </div>
+                  <div className='grid gap-3 md:grid-cols-3'>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Impact ref
+                      </div>
+                      <div className='mt-1 break-all'>
+                        {singleApplyResult.impactEvidence.impactRef}
+                      </div>
+                    </div>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Rollback / recovery ref
+                      </div>
+                      <div className='mt-1 break-all'>
+                        {singleApplyResult.impactEvidence.rollbackRef}
+                      </div>
+                    </div>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Fresh preview
+                      </div>
+                      <div className='mt-1'>
+                        {
+                          singleApplyResult.impactEvidence
+                            .freshPreviewRequirement
+                        }
+                      </div>
+                    </div>
+                  </div>
+                  <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Dependent service refs
+                      </div>
+                      <div className='mt-2 flex flex-wrap gap-1'>
+                        {singleApplyResult.impactEvidence.dependentServiceRefs.map(
+                          (ref) => (
+                            <Badge key={ref} variant='outline'>
+                              {ref}
+                            </Badge>
+                          )
+                        )}
+                      </div>
+                    </div>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Audit refs
+                      </div>
+                      <div className='mt-2 flex flex-wrap gap-1'>
+                        {singleApplyResult.impactEvidence.auditRefs.map(
+                          (ref) => (
+                            <Badge key={ref} variant='outline'>
+                              {ref}
+                            </Badge>
+                          )
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Omitted unsafe fields
+                      </div>
+                      <div className='mt-2 flex flex-wrap gap-1'>
+                        {singleApplyResult.impactEvidence.omittedUnsafeFields.map(
+                          (field) => (
+                            <Badge key={field} variant='secondary'>
+                              {field}
+                            </Badge>
+                          )
+                        )}
+                      </div>
+                    </div>
+                    <div className='rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Safe impact rows
+                      </div>
+                      <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                        {singleApplyResult.impactEvidence.safeEvidenceRows.map(
+                          (row) => (
+                            <li key={row}>{row}</li>
+                          )
+                        )}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
                 {singleApplyResult.providerAuthChallengeRef ? (
                   <div className='mt-3 rounded-md border bg-muted/30 p-3'>
                     <div className='text-xs font-medium text-muted-foreground uppercase'>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -1671,6 +1671,35 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretRows[0],
       singlePolicyPlan
     )
+    expect(policyResult.impactEvidence).toMatchObject({
+      title: 'Policy assignment impact evidence',
+      impactRef:
+        'impact-policy-serviceadmin-session-signing-submitted-metadata',
+      rollbackRef: 'rollback-policy-serviceadmin-session-signing-metadata',
+      freshPreviewRequirement:
+        'wait for broker terminal metadata before any follow-up preview',
+    })
+    expect(policyResult.impactEvidence.dependentServiceRefs).toEqual(
+      expect.arrayContaining(['@serviceadmin operator API'])
+    )
+    expect(policyResult.impactEvidence.omittedUnsafeFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'providerTokens',
+        'cookies',
+        'privateKeys',
+        'recoveryMaterial',
+        'environmentValues',
+      ])
+    )
+    expect(policyResult.impactEvidence.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'policy impact keeps previous and target policy refs as metadata-only rollback context',
+      ])
+    )
     expect(policyResult.safetyRows).toEqual(
       expect.arrayContaining([
         'policy change carries target policy metadata only',
@@ -1804,6 +1833,20 @@ describe('Secrets Broker secrets management page', () => {
     const deleteResult = buildSingleSecretOperationResult(
       managedSecretRows[0],
       deletePlan
+    )
+    expect(deleteResult.impactEvidence).toMatchObject({
+      title: 'Delete/decommission impact evidence',
+      impactRef:
+        'impact-delete-serviceadmin-session-signing-submitted-metadata',
+      rollbackRef: 'recovery-delete-serviceadmin-session-signing-metadata',
+    })
+    expect(deleteResult.impactEvidence.dependentServiceRefs).toEqual(
+      expect.arrayContaining(['@serviceadmin runtime session loader'])
+    )
+    expect(deleteResult.impactEvidence.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'decommission impact keeps tombstone and recovery references separate from secret material',
+      ])
     )
     expect(deleteResult).toMatchObject({
       recoveryStatus:

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -100,6 +100,17 @@ export type SingleSecretAuditFeedback = {
   evidenceRows: string[]
 }
 
+export type SingleSecretImpactEvidence = {
+  title: string
+  impactRef: string
+  dependentServiceRefs: string[]
+  auditRefs: string[]
+  rollbackRef: string
+  freshPreviewRequirement: string
+  omittedUnsafeFields: string[]
+  safeEvidenceRows: string[]
+}
+
 export type SingleSecretOperationResult = {
   operationId: string
   ref: string
@@ -117,6 +128,7 @@ export type SingleSecretOperationResult = {
   brokerFailureCategory: string | null
   recoverySteps: string[]
   auditFeedback: SingleSecretAuditFeedback
+  impactEvidence: SingleSecretImpactEvidence
   safetyRows: string[]
   nextAction: string
 }
@@ -1741,6 +1753,17 @@ export function buildSingleSecretRevealPreview(
   }
 }
 
+function decommissionDependentServiceRefsForRow(row: ManagedSecretRow) {
+  if (row.owningService === '@serviceadmin') {
+    return ['@serviceadmin runtime session loader', '@secretsbroker audit sink']
+  }
+
+  return [
+    `${row.owningService} runtime binding`,
+    `${row.workspace} workspace policy reference`,
+  ]
+}
+
 export function buildSingleSecretDecommissionPreview(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan
@@ -1752,13 +1775,7 @@ export function buildSingleSecretDecommissionPreview(
   }
 
   const providerBacked = row.provider === 'provider connection'
-  const dependentServiceRefs =
-    row.owningService === '@serviceadmin'
-      ? ['@serviceadmin runtime session loader', '@secretsbroker audit sink']
-      : [
-          `${row.owningService} runtime binding`,
-          `${row.workspace} workspace policy reference`,
-        ]
+  const dependentServiceRefs = decommissionDependentServiceRefsForRow(row)
   const mode = providerBacked ? 'disable' : 'decommission'
   const eligible = blockers.length === 0
   const actionLabel = mode === 'disable' ? 'disable' : 'decommission'
@@ -2080,6 +2097,12 @@ export function buildSingleSecretOperationResult(
     outcome,
     auditEventIdForSingleSecretAction(plan.action, row)
   )
+  const impactEvidence = buildSingleSecretImpactEvidence(
+    row,
+    plan,
+    outcome,
+    auditFeedback
+  )
 
   return {
     operationId: plan.operationId,
@@ -2098,6 +2121,7 @@ export function buildSingleSecretOperationResult(
     brokerFailureCategory,
     recoverySteps,
     auditFeedback,
+    impactEvidence,
     safetyRows: [
       'raw value was not revealed',
       'request body is limited to ref, operation id, action, owner, provider, policy, and audit reason metadata',
@@ -2120,6 +2144,83 @@ export function buildSingleSecretOperationResult(
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction,
+  }
+}
+
+export function buildSingleSecretImpactEvidence(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  outcome: SingleSecretOperationOutcome,
+  auditFeedback: SingleSecretAuditFeedback
+): SingleSecretImpactEvidence {
+  const slug = safeOperationSlug(plan.action, row)
+  const dependentServiceRefs =
+    plan.action === 'delete'
+      ? decommissionDependentServiceRefsForRow(row)
+      : plan.action === 'policy'
+        ? policyConsumerRefsForRow(row)
+        : plan.action === 'reset'
+          ? ['@serviceadmin runtime session loader']
+          : plan.action === 'edit'
+            ? [row.owningService]
+            : ['@serviceadmin operator session']
+  const rollbackRef =
+    plan.action === 'delete'
+      ? `recovery-${slug}-metadata`
+      : plan.action === 'policy'
+        ? `rollback-${slug}-metadata`
+        : plan.action === 'reset'
+          ? `rotation-monitor-${slug}-metadata`
+          : plan.action === 'edit'
+            ? `update-rollback-${slug}-metadata`
+            : `reveal-window-${slug}-metadata`
+  const freshPreviewRequirement =
+    outcome === 'applied'
+      ? plan.action === 'delete'
+        ? 'restore or recreate only through a fresh audited broker recovery plan'
+        : plan.action === 'policy'
+          ? 'rollback requires a fresh audited policy assignment preview'
+          : 'future changes require a fresh audited dry-run preview'
+      : outcome === 'submitted'
+        ? 'wait for broker terminal metadata before any follow-up preview'
+        : 'discard this result before retry and create a fresh audited dry-run preview'
+
+  return {
+    title:
+      plan.action === 'delete'
+        ? 'Delete/decommission impact evidence'
+        : plan.action === 'policy'
+          ? 'Policy assignment impact evidence'
+          : plan.action === 'reset'
+            ? 'Rotation impact evidence'
+            : plan.action === 'edit'
+              ? 'Edit impact evidence'
+              : 'Reveal impact evidence',
+    impactRef: `impact-${slug}-${outcome}-metadata`,
+    dependentServiceRefs,
+    auditRefs: [auditFeedback.auditEventId, auditFeedback.correlationId],
+    rollbackRef,
+    freshPreviewRequirement,
+    omittedUnsafeFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    safeEvidenceRows: [
+      'impact evidence stores refs, operation ids, typed outcome, audit refs, and dependent service metadata only',
+      plan.action === 'delete'
+        ? 'decommission impact keeps tombstone and recovery references separate from secret material'
+        : plan.action === 'policy'
+          ? 'policy impact keeps previous and target policy refs as metadata-only rollback context'
+          : 'impact evidence keeps follow-up guidance metadata-only',
+      'support bundles and diagnostics may include this impact reference but never secret payloads',
+    ],
   }
 }
 

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -219,7 +219,9 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/decommission preview blocked/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
     await expect(
-      page.getByText(/recovery-delete-serviceadmin-session-signing-metadata/i)
+      page
+        .getByText(/recovery-delete-serviceadmin-session-signing-metadata/i)
+        .first()
     ).toBeVisible()
     await expect(
       page.getByText(/tombstone-delete-serviceadmin-session-signing-metadata/i)
@@ -230,6 +232,36 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/current secret value is not read/i)
     ).toBeVisible()
+    await page
+      .getByLabel(/Audit reason for stub preview/i)
+      .fill('operator requested decommission preview')
+    await page.getByLabel(/I confirm this is a stub preview/i).check()
+    await page.getByLabel(/Result status/i).selectOption('applied')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: applied/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Delete\/decommission impact evidence/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /impact-delete-serviceadmin-session-signing-applied-metadata/i
+      )
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(/recovery-delete-serviceadmin-session-signing-metadata/i)
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /restore or recreate only through a fresh audited broker recovery plan/i
+      )
+    ).toBeVisible()
+    await expect(page.getByText(/requestBody/i).first()).toBeVisible()
+    await expect(page.getByText(/responseBody/i).first()).toBeVisible()
+    await expect(page.getByText(/recoveryMaterial/i).first()).toBeVisible()
     await page
       .getByRole('button', { name: /Apply policy preview/i })
       .first()
@@ -243,7 +275,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/Policy assignment safety preview/i)
     ).toBeVisible()
-    await expect(page.getByText(/policy preview blocked/i)).toBeVisible()
+    await expect(page.getByText(/policy preview ready/i)).toBeVisible()
     await expect(
       page.getByText(
         'policy/openclaw/service-lasso/serviceadmin/least-privilege-single-ref',
@@ -251,7 +283,9 @@ test.describe('Secrets Broker browser coverage', () => {
       )
     ).toBeVisible()
     await expect(
-      page.getByText(/rollback-policy-serviceadmin-session-signing-metadata/i)
+      page
+        .getByText(/rollback-policy-serviceadmin-session-signing-metadata/i)
+        .first()
     ).toBeVisible()
     await expect(page.getByText(/@serviceadmin operator API/i)).toBeVisible()
     await expect(
@@ -259,6 +293,33 @@ test.describe('Secrets Broker browser coverage', () => {
         /policy preview never reads or writes the current secret value/i
       )
     ).toBeVisible()
+    await page
+      .getByLabel(/Audit reason for stub preview/i)
+      .fill('operator requested least privilege policy assignment')
+    await page.getByLabel(/I confirm this is a stub preview/i).check()
+    await page.getByLabel(/Result status/i).selectOption('applied')
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
+    await page.getByRole('button', { name: /Simulate stub apply/i }).click()
+    await expect(
+      page.getByText(/Policy assignment impact evidence/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /impact-policy-serviceadmin-session-signing-applied-metadata/i
+      )
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(/rollback-policy-serviceadmin-session-signing-metadata/i)
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/rollback requires a fresh audited policy assignment/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/policy impact keeps previous and target policy refs/i)
+    ).toBeVisible()
+    await page.getByRole('button', { name: /Cancel stub preview/i }).click()
 
     await page.getByPlaceholder(/Search secret metadata/i).fill('payments')
     await page.getByRole('button', { name: /Delete dry-run/ }).click()
@@ -286,11 +347,12 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/no local storage or session storage/i)
     ).toBeVisible()
-    await expect(page.getByText(/0 submitted/i)).toBeVisible()
+    await expect(page.getByText(/2 submitted/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeDisabled()
+    await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page
       .getByLabel(/Audit reason for stub preview/i)
       .fill('operator requested preview')


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add metadata-only single-secret impact evidence to post-apply results.
- Surface dependent service refs, audit refs, rollback/recovery refs, fresh-preview requirements, omitted unsafe fields, and safe impact rows in the Secrets page result panel.
- Cover delete/decommission and policy assignment impact evidence without raw values, provider credentials, request/response bodies, cookies, tokens, keys, recovery material, or environment values.

## Scope
- In scope: focused Service Admin UI/model/test/docs advancement for #231 single-secret action evidence.
- Out of scope: full #231 completion, production Secrets Broker mutation contract changes, plaintext editing, raw reveal/export/copy, and backend enforcement claims.

## Spec / contract / fixture impact
- Updated: `docs/secret-inventory.md` documents single-secret post-apply impact evidence boundaries.
- Not required: no production API/schema change; this remains deterministic metadata-only UI/model fixture behavior.

## Nash invariant impact
- Invariant: Service Admin must not render or persist raw secret values or provider credentials while advancing secret management workflows.
- Preservation proof: new impact evidence uses refs, operation ids, typed outcomes, audit refs, dependent service metadata, and explicit omitted unsafe fields only; tests assert no raw-value leakage.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/unit-secrets-impact-evidence-rerun.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "safe action previews"` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/playwright-secrets-impact-evidence-rerun7.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/format-check-impact-evidence-final.log`
- PASS `npm run lint` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/lint-impact-evidence.log`
- PASS `npm run build` - `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-20260622-123029/build-impact-evidence.log`
- NOTE earlier focused unit/browser attempts failed during implementation and are saved in the same evidence directory; both were fixed and rerun successfully.
- PASS preflight canonical demo before work: Service Admin HTTP 200; runtime `/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval requirement found for this focused UI/test/doc advancement.
- Evidence: no open org PRs before selection; #231 remains open and agent-ready.

## Cleanup
- Branch: `agent/issue-231-single-action-impact-evidence`
- Release-to-demo gate: pending until this PR is merged, Service Admin release publishes, core demo pin is updated, canonical demo recycles on port 17883, and `npm run demo:verify-canonical` passes. This PR does not claim #231 done.
