### PR TITLE
feat(secrets): record single action cancellation evidence

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -13,6 +13,7 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - The Secrets Broker Secrets page also exposes a bulk campaign workflow. Operators can select multiple metadata rows, choose a campaign operation, and generate safe per-ref/aggregate capability, policy, risk, audit, operation ID, idempotency, and blocker metadata.
 - Supported rotate/reset, update/edit, policy apply/change, and provider migration/remap campaigns can apply only after audit reason, explicit confirmation, and immediate revalidation. Apply results show campaign ID, operation ID, plan token, per-item operation IDs, idempotency keys, typed outcomes, audit status, retry/recovery guidance, and skipped/denied/unsupported/auth-required rows without raw values.
 - Single-secret apply results include post-apply impact evidence: dependent service refs, audit/rollback/recovery refs, fresh-preview requirements, and omitted unsafe fields. Delete/decommission and policy assignment evidence is metadata-only and never includes current values, request/response bodies, provider credentials, cookies, tokens, private keys, recovery material, or raw environment values.
+- Single-secret cancellation is recorded as metadata-only operator intent: operation id, ref, action, audit/correlation refs, and fresh-preview recovery guidance. Cancellation evidence never submits a mutation and never stores request/response bodies or secret material.
 
 ## Not implemented in this slice
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -319,6 +319,28 @@ export function SecretsManagementPage() {
     setStubState('success')
   }
 
+  function cancelSingleSecretOperation() {
+    const result = buildSingleSecretOperationResult(
+      selectedRow,
+      singleOperationPlan,
+      'cancelled'
+    )
+    setSingleApplyResult(result)
+    setSingleOperationHistory((current) => [
+      buildSingleSecretOperationHistoryEntry(
+        selectedRow,
+        singleOperationPlan,
+        current.length + 1,
+        'cancelled'
+      ),
+      ...current,
+    ])
+    setAuditReason('')
+    setConfirmed(false)
+    setStubState('cancelled')
+    setSingleOperationOutcome('submitted')
+  }
+
   const columns = useMemo<ColumnDef<ManagedSecretRow>[]>(
     () => [
       {
@@ -2635,12 +2657,7 @@ export function SecretsManagementPage() {
               <Button
                 type='button'
                 variant='outline'
-                onClick={() => {
-                  setAuditReason('')
-                  setConfirmed(false)
-                  setStubState('cancelled')
-                  setSingleApplyResult(null)
-                }}
+                onClick={cancelSingleSecretOperation}
               >
                 Cancel stub preview
               </Button>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -878,7 +878,20 @@ describe('Secrets Broker secrets management page', () => {
       screen.getByRole('button', { name: /Cancel stub preview/i })
     )
     expect(screen.getAllByText(/Cancelled/i)[0]).toBeVisible()
-    expect(screen.getByText(/cancelled by operator/i)).toBeVisible()
+    expect(screen.getAllByText(/cancelled by operator/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/Single-secret operation result: cancelled/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/cancelled by operator before broker mutation/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/terminal operator cancellation/i)[0]
+    ).toBeVisible()
+    expect(
+      screen.getByText(/cancelled preview recovery creates a fresh dry-run/i)
+    ).toBeVisible()
+    expect(screen.getByText(/4 submitted/i)).toBeVisible()
   })
 
   it('keeps fixtures and modeled safe surfaces free of secret material', () => {
@@ -1319,6 +1332,79 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretSingleHistoryHasSecretMaterial([historyEntry])).toBe(
       false
     )
+
+    const cancelledResult = buildSingleSecretOperationResult(
+      managedSecretRows[0],
+      rotatePlan,
+      'cancelled'
+    )
+    expect(cancelledResult).toMatchObject({
+      outcome: 'cancelled',
+      applied: false,
+      resultBadge: 'cancelled by operator',
+      auditStatus:
+        'stub cancellation metadata recorded; mutation not submitted',
+      recoveryStatus:
+        'cancelled preview was not submitted and can only resume with a fresh dry-run',
+      retryPolicy: 'fresh plan required before any retry',
+      nextAction:
+        'create a fresh dry-run preview if the operator resumes this action',
+    })
+    expect(cancelledResult.recoverySteps).toEqual(
+      expect.arrayContaining([
+        'record the cancelled operation id as audit metadata only',
+        'discard the cancelled submit envelope before any broker mutation',
+        'create a fresh audited preview if the operator resumes',
+      ])
+    )
+    expect(cancelledResult.safetyRows).toEqual(
+      expect.arrayContaining([
+        'cancellation evidence is limited to operation id, ref, action, audit reason metadata, and correlation id',
+      ])
+    )
+    expect(cancelledResult.auditFeedback).toMatchObject({
+      eventState: 'recorded as operator cancellation with no broker mutation',
+    })
+    expect(cancelledResult.auditFeedback.evidenceRows).toEqual(
+      expect.arrayContaining([
+        'cancellation evidence contains typed operator intent metadata only and never request or response bodies',
+      ])
+    )
+    const cancelledTrail = buildSingleSecretOperationAuditTrail(
+      managedSecretRows[0],
+      rotatePlan,
+      'cancelled'
+    )
+    expect(cancelledTrail[2]).toMatchObject({
+      status: 'terminal operator cancellation',
+      terminal: true,
+    })
+    const cancelledMonitor = buildSingleSecretStatusMonitor(
+      managedSecretRows[0],
+      rotatePlan,
+      cancelledResult
+    )
+    expect(cancelledMonitor).toMatchObject({
+      terminalState: 'terminal operator cancellation',
+      stateBadge: 'cancelled',
+      retryAllowed: false,
+      stalePlanGuard:
+        'status updates are accepted only when operation id, ref, action, and correlation id match the latest preview',
+    })
+    expect(cancelledMonitor.statusRows).toEqual(
+      expect.arrayContaining([
+        'cancelled preview: operator stopped before broker mutation',
+      ])
+    )
+    expect(cancelledMonitor.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'cancelled preview recovery creates a fresh dry-run and omits request and response body echoes',
+      ])
+    )
+    expect(managedSecretStatusMonitorHasSecretMaterial(cancelledMonitor)).toBe(
+      false
+    )
+
     const auditTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],
       rotatePlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -89,6 +89,7 @@ export type SingleSecretOperationOutcome =
   | 'provider-unavailable'
   | 'failed'
   | 'stale-plan'
+  | 'cancelled'
 
 export type SingleSecretAuditFeedback = {
   auditEventId: string
@@ -491,6 +492,7 @@ export const singleSecretOperationOutcomes: Array<{
   },
   { id: 'failed', label: 'Broker apply failed' },
   { id: 'stale-plan', label: 'Stale plan rejected' },
+  { id: 'cancelled', label: 'Operator cancelled before submit' },
 ]
 
 export const bulkSecretCampaignOperations: Array<{
@@ -1962,7 +1964,13 @@ export function buildSingleSecretOperationResult(
                   'retry only when the broker marks the same operation id retry safe',
                   'create a fresh preview if the failure category changes before retry',
                 ]
-              : []
+              : outcome === 'cancelled'
+                ? [
+                    'record the cancelled operation id as audit metadata only',
+                    'discard the cancelled submit envelope before any broker mutation',
+                    'create a fresh audited preview if the operator resumes',
+                  ]
+                : []
   const recoverySteps = [...actionRecoverySteps, ...outcomeRecoverySteps]
   const applied = outcome === 'applied'
   const resultBadge =
@@ -1980,7 +1988,9 @@ export function buildSingleSecretOperationResult(
                 ? 'apply failed'
                 : outcome === 'stale-plan'
                   ? 'stale plan'
-                  : 'submitted to broker'
+                  : outcome === 'cancelled'
+                    ? 'cancelled by operator'
+                    : 'submitted to broker'
   const auditStatus =
     outcome === 'submitted'
       ? 'stub audit event recorded with metadata only'
@@ -1992,7 +2002,9 @@ export function buildSingleSecretOperationResult(
             ? 'stub provider outage metadata recorded; mutation failed closed'
             : outcome === 'stale-plan'
               ? 'stub stale-plan rejection recorded; mutation failed closed'
-              : 'stub audit event recorded with typed failure metadata only'
+              : outcome === 'cancelled'
+                ? 'stub cancellation metadata recorded; mutation not submitted'
+                : 'stub audit event recorded with typed failure metadata only'
   const resultStatus =
     outcome === 'submitted'
       ? `${actionLabel} dry-run accepted for broker submission; production mutation remains external to this stub`
@@ -2008,7 +2020,9 @@ export function buildSingleSecretOperationResult(
                 ? `${actionLabel} blocked because the provider connector is unavailable or unsupported; no value was read or written`
                 : outcome === 'stale-plan'
                   ? `${actionLabel} rejected because the dry-run plan token expired before final broker revalidation; no value was read or written`
-                  : `${actionLabel} failed with broker-owned safe error metadata`
+                  : outcome === 'cancelled'
+                    ? `${actionLabel} cancelled by operator before broker mutation; the cancelled operation id is retained as metadata only`
+                    : `${actionLabel} failed with broker-owned safe error metadata`
   const nextAction =
     outcome === 'applied'
       ? plan.action === 'reset'
@@ -2026,9 +2040,11 @@ export function buildSingleSecretOperationResult(
                 ? 'create a fresh dry-run plan before retry'
                 : outcome === 'failed'
                   ? 'review safe broker failure metadata and retry only when marked safe'
-                  : plan.action === 'reset'
-                    ? 'monitor broker rotation outcome and dependent service restart notes'
-                    : 'monitor broker operation status and typed policy/audit result'
+                  : outcome === 'cancelled'
+                    ? 'create a fresh dry-run preview if the operator resumes this action'
+                    : plan.action === 'reset'
+                      ? 'monitor broker rotation outcome and dependent service restart notes'
+                      : 'monitor broker operation status and typed policy/audit result'
   const recoveryStatus =
     outcome === 'applied'
       ? 'operation settled with broker success metadata'
@@ -2044,15 +2060,17 @@ export function buildSingleSecretOperationResult(
                 ? 'stale plan recovery requires a fresh audited preview'
                 : outcome === 'failed'
                   ? 'broker failure recovery depends on retry-safe operation metadata'
-                  : plan.action === 'delete'
-                    ? 'delete/decommission requires recovery-guided broker ownership'
-                    : plan.action === 'policy'
-                      ? 'policy rollback requires a fresh audited preview'
-                      : plan.action === 'reset'
-                        ? 'rotation retry is operation-id scoped and provider-owned'
-                        : plan.action === 'edit'
-                          ? 'edit retry waits for broker retry-safe metadata'
-                          : 'reveal recovery is fresh-challenge only'
+                  : outcome === 'cancelled'
+                    ? 'cancelled preview was not submitted and can only resume with a fresh dry-run'
+                    : plan.action === 'delete'
+                      ? 'delete/decommission requires recovery-guided broker ownership'
+                      : plan.action === 'policy'
+                        ? 'policy rollback requires a fresh audited preview'
+                        : plan.action === 'reset'
+                          ? 'rotation retry is operation-id scoped and provider-owned'
+                          : plan.action === 'edit'
+                            ? 'edit retry waits for broker retry-safe metadata'
+                            : 'reveal recovery is fresh-challenge only'
   const retryPolicy =
     outcome === 'applied'
       ? 'no retry needed after broker success'
@@ -2060,7 +2078,8 @@ export function buildSingleSecretOperationResult(
           outcome === 'auth-required' ||
           outcome === 'audit-unavailable' ||
           outcome === 'provider-unavailable' ||
-          outcome === 'stale-plan'
+          outcome === 'stale-plan' ||
+          outcome === 'cancelled'
         ? 'fresh plan required before any retry'
         : outcome === 'failed'
           ? 'retry only with the same operation id when broker marks retry safe'
@@ -2140,7 +2159,9 @@ export function buildSingleSecretOperationResult(
             ? 'stale-plan evidence is limited to operation id, ref, action, and expired preview metadata'
             : outcome === 'failed'
               ? 'broker failure evidence is limited to operation id, category, retry-safe status, and correlation id'
-              : 'broker result metadata excludes provider auth challenge secrets',
+              : outcome === 'cancelled'
+                ? 'cancellation evidence is limited to operation id, ref, action, audit reason metadata, and correlation id'
+                : 'broker result metadata excludes provider auth challenge secrets',
       'no copy, export, route, query string, local storage, or diagnostic payload contains secret material',
     ],
     nextAction,
@@ -2245,7 +2266,9 @@ export function buildSingleSecretAuditFeedback(
                 ? 'recorded as provider unavailable with no source access'
                 : outcome === 'stale-plan'
                   ? 'recorded as stale-plan rejection'
-                  : 'recorded as safe broker failure metadata'
+                  : outcome === 'cancelled'
+                    ? 'recorded as operator cancellation with no broker mutation'
+                    : 'recorded as safe broker failure metadata'
   const dependentServiceStatus =
     plan.action === 'reset'
       ? outcome === 'applied'
@@ -2280,7 +2303,9 @@ export function buildSingleSecretAuditFeedback(
             ? 'stale-plan evidence contains expired preview metadata only and never request or response bodies'
             : outcome === 'failed'
               ? 'broker failure evidence contains typed category metadata only and never request or response bodies'
-              : 'provider auth material is omitted from audit evidence',
+              : outcome === 'cancelled'
+                ? 'cancellation evidence contains typed operator intent metadata only and never request or response bodies'
+                : 'provider auth material is omitted from audit evidence',
       'route, query string, local storage, and diagnostics receive no secret material',
     ],
   }
@@ -2340,7 +2365,9 @@ export function buildSingleSecretOperationAuditTrail(
                 ? 'terminal provider unavailable'
                 : outcome === 'stale-plan'
                   ? 'terminal stale-plan rejection'
-                  : 'terminal safe failure'
+                  : outcome === 'cancelled'
+                    ? 'terminal operator cancellation'
+                    : 'terminal safe failure'
 
   return [
     {
@@ -2416,7 +2443,9 @@ export function buildSingleSecretStatusMonitor(
                 ? 'terminal provider unavailable'
                 : result.outcome === 'stale-plan'
                   ? 'terminal stale-plan rejection'
-                  : 'terminal safe failure'
+                  : result.outcome === 'cancelled'
+                    ? 'terminal operator cancellation'
+                    : 'terminal safe failure'
 
   return {
     operationId: result.operationId,
@@ -2439,7 +2468,9 @@ export function buildSingleSecretStatusMonitor(
                 ? 'auth challenge'
                 : result.outcome === 'provider-unavailable'
                   ? 'provider outage'
-                  : result.outcome,
+                  : result.outcome === 'cancelled'
+                    ? 'cancelled'
+                    : result.outcome,
     retryAllowed,
     retryToken: retryAllowed
       ? `retry-${safeOperationSlug(plan.action, row)}-operation-id-only`
@@ -2479,7 +2510,9 @@ export function buildSingleSecretStatusMonitor(
           ? 'provider status: connector unavailable or unsupported'
           : result.outcome === 'stale-plan'
             ? 'stale preview: broker rejected the expired dry-run token'
-            : 'auth challenge: not requested by broker status',
+            : result.outcome === 'cancelled'
+              ? 'cancelled preview: operator stopped before broker mutation'
+              : 'auth challenge: not requested by broker status',
     ],
     operatorNextAction: result.nextAction,
     safeEvidenceRows: [
@@ -2491,7 +2524,9 @@ export function buildSingleSecretStatusMonitor(
           ? 'provider recovery happens in broker/provider configuration and omits provider credentials'
           : result.outcome === 'stale-plan'
             ? 'stale-plan recovery creates a new dry-run and omits request and response body echoes'
-            : 'provider credentials remain omitted from status polling',
+            : result.outcome === 'cancelled'
+              ? 'cancelled preview recovery creates a fresh dry-run and omits request and response body echoes'
+              : 'provider credentials remain omitted from status polling',
       'retry guidance never reuses stale previews or blocked policy decisions',
       'support evidence may include ids, timestamps, and typed outcomes only',
     ],

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -347,7 +347,7 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/no local storage or session storage/i)
     ).toBeVisible()
-    await expect(page.getByText(/2 submitted/i)).toBeVisible()
+    await expect(page.getByText(/3 submitted/i)).toBeVisible()
     await expect(page.getByText(/audit reason required/i).first()).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Simulate stub apply/i })
@@ -366,7 +366,19 @@ test.describe('Secrets Broker browser coverage', () => {
     await page.getByLabel(/Stub API state/i).selectOption('failure')
     await expect(page.getByText(/Stub apply failure/i).last()).toBeVisible()
     await page.getByRole('button', { name: /Cancel stub preview/i }).click()
-    await expect(page.getByText(/cancelled by operator/i)).toBeVisible()
+    await expect(page.getByText(/cancelled by operator/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/Single-secret operation result: cancelled/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/cancelled by operator before broker mutation/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/terminal operator cancellation/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/cancelled preview recovery creates a fresh dry-run/i)
+    ).toBeVisible()
 
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
@@ -645,6 +657,22 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/retry only with the same operation id/i).first()
     ).toBeVisible()
     await expect(page.getByText(/8 submitted/i)).toBeVisible()
+    await page.getByRole('button', { name: /Cancel stub preview/i }).click()
+    await expect(
+      page.getByText(/Single-secret operation result: cancelled/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /cancelled preview: operator stopped before broker mutation/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/terminal operator cancellation/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/cancellation evidence contains typed operator intent/i)
+    ).toBeVisible()
+    await expect(page.getByText(/9 submitted/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds `cancelled` as a first-class single-secret operation result.
- Records cancellation in the same metadata-only result, history, audit trail, and status monitor surfaces as other terminal outcomes.
- Documents that cancellation evidence is operation/ref/action/audit metadata only and never submits a mutation.

## Scope
- In scope: single-secret cancellation evidence for the Secrets Broker > Secrets stub workflow.
- Out of scope: completing all remaining #231 reveal/edit/delete/policy/backend contract work.

## Spec / contract / fixture impact
- Updated: `docs/secret-inventory.md` for metadata-only single-secret cancellation behavior.
- Contract impact: none; this is UI/model stub evidence only and does not claim backend enforcement.

## Service Lasso invariant impact
- Invariant: no raw secret values or credential material in the Secrets management table, routes, diagnostics, storage, tests, or support evidence.
- Preservation proof: cancellation evidence uses operation id, ref, action, audit/correlation refs, typed outcome, and fresh-preview guidance only.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/unit-secrets-cancel-final.log` (15 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/format-check-cancel-final.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/lint-cancel-final.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/build-cancel.log`
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "safe action previews|single-secret rotate preview"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-cancel/playwright-secrets-cancel-rerun.log` (2 passed)

## Approval trail
- Required: no special approval requirement found for this focused UI/test/doc advancement.
- Evidence: Project #1 item is Ready / Ready for Agent; issue #231 remains open for broader scope.

## Cleanup
- Branch: `agent/issue-231-single-action-cancel-evidence`
- Post-merge: release Service Admin, update core demo pin, recycle canonical demo on port 17883, run `npm run demo:verify-canonical`, then revalidate before claiming demo-gated advancement.