### PR TITLE
feat(secrets): add edit update preview evidence

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -15,6 +15,7 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - Single-secret apply results include post-apply impact evidence: dependent service refs, audit/rollback/recovery refs, fresh-preview requirements, and omitted unsafe fields. Delete/decommission and policy assignment evidence is metadata-only and never includes current values, request/response bodies, provider credentials, cookies, tokens, private keys, recovery material, or raw environment values.
 - Single-secret cancellation is recorded as metadata-only operator intent: operation id, ref, action, audit/correlation refs, and fresh-preview recovery guidance. Cancellation evidence never submits a mutation and never stores request/response bodies or secret material.
 - Controlled reveal previews include a challenge lifecycle model for pending, authorized, expired, revoked, denied, and audit-unavailable states. Lifecycle evidence records challenge/session refs, expiry, revocation, actor/audit/correlation refs, omitted unsafe fields, and next action guidance only; revealed values stay broker-controlled and hidden from the management table.
+- Edit/update previews now show metadata-only change evidence before any submit: operation id, patch plan hash, schema validation status, conflict check ref, rollback ref, dependent consumers, immutable fields, omitted unsafe fields, and safe diff rows. The preview never accepts spreadsheet-style plaintext values and never renders request/response bodies or provider credential material.
 
 ## Not implemented in this slice
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -63,6 +63,7 @@ import {
   buildManagedSecretActionPreview,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
+  buildSingleSecretEditPreview,
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
@@ -218,6 +219,10 @@ export function SecretsManagementPage() {
     selectedRow,
     singleOperationPlan
   )
+  const editPreview =
+    selectedAction === 'edit'
+      ? buildSingleSecretEditPreview(selectedRow, singleOperationPlan)
+      : null
   const revealPreview =
     selectedAction === 'reveal'
       ? buildSingleSecretRevealPreview(selectedRow, singleOperationPlan)
@@ -1896,6 +1901,125 @@ export function SecretsManagementPage() {
                 {revealPreview.blockers.length > 0 ? (
                   <div className='mt-3 flex flex-wrap gap-1'>
                     {revealPreview.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            {editPreview ? (
+              <div className='rounded-md border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <SlidersHorizontal className='size-4 text-primary' />
+                  <div className='font-medium'>Edit/update safety preview</div>
+                  <Badge
+                    variant={editPreview.eligible ? 'default' : 'secondary'}
+                  >
+                    {editPreview.badge}
+                  </Badge>
+                  <Badge variant='outline'>Metadata diff only</Badge>
+                </div>
+                <div className='grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Patch plan
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {editPreview.patchPlanHash}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Conflict check
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {editPreview.conflictCheckRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Rollback plan
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {editPreview.rollbackPlanRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Apply gate
+                    </div>
+                    <div className='mt-1'>{editPreview.applyGate}</div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Metadata fields
+                    </div>
+                    <div className='mt-2 flex flex-wrap gap-1'>
+                      {editPreview.targetMetadataFields.map((field) => (
+                        <Badge key={field} variant='outline'>
+                          {field}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Immutable fields
+                    </div>
+                    <div className='mt-2 flex flex-wrap gap-1'>
+                      {editPreview.immutableFields.map((field) => (
+                        <Badge key={field} variant='secondary'>
+                          {field}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Affected consumers
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {editPreview.affectedConsumerRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Safe metadata proof
+                    </div>
+                    <div className='mt-2'>{editPreview.validationStatus}</div>
+                    <div className='mt-2 text-muted-foreground'>
+                      {editPreview.auditTrail}
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {editPreview.safeDiffRows.map((row) => (
+                        <li key={row}>{row}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted unsafe fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {editPreview.omittedUnsafeFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                {editPreview.blockers.length > 0 ? (
+                  <div className='mt-3 flex flex-wrap gap-1'>
+                    {editPreview.blockers.map((blocker) => (
                       <Badge key={blocker} variant='outline'>
                         {blocker}
                       </Badge>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -8,6 +8,7 @@ import {
   buildBulkSecretCampaignApplyResult,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
+  buildSingleSecretEditPreview,
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
@@ -23,6 +24,7 @@ import {
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
   managedSecretDecommissionPreviewHasSecretMaterial,
+  managedSecretEditPreviewHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
@@ -614,6 +616,27 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(
       screen.getAllByText(/dry-run required before apply/i)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Edit\/update safety preview/i)).toBeVisible()
+    expect(screen.getByText(/edit preview blocked/i)).toBeVisible()
+    expect(
+      screen.getByText(/patch-edit-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/conflict-edit-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /update-rollback-edit-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    expect(screen.getAllByText('rotationPolicyRef')[0]).toBeVisible()
+    expect(screen.getAllByText('providerCredential')[0]).toBeVisible()
+    expect(
+      screen.getByText(/metadata diff contains field names/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/clear-value table editing is unavailable/i)
     ).toBeVisible()
 
     await user.click(
@@ -1926,6 +1949,75 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretPolicyPreviewHasSecretMaterial(policyPreview)).toBe(
       false
     )
+
+    const editPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[0],
+      'edit',
+      'operator requested metadata update preview',
+      true,
+      'ready'
+    )
+    expect(editPlan.safePayloadFields).toEqual(
+      expect.arrayContaining([
+        'metadataDiff',
+        'patchPlanHash',
+        'rollbackPlanRef',
+      ])
+    )
+    expect(editPlan.revalidationChecks).toEqual(
+      expect.arrayContaining([
+        'metadata diff, schema guard, and conflict check reviewed',
+      ])
+    )
+    const editPreview = buildSingleSecretEditPreview(
+      managedSecretRows[0],
+      editPlan
+    )
+    expect(editPreview).toMatchObject({
+      eligible: true,
+      badge: 'edit preview ready',
+      patchPlanHash: 'patch-edit-serviceadmin-session-signing-metadata-sha256',
+      conflictCheckRef: 'conflict-edit-serviceadmin-session-signing-metadata',
+      rollbackPlanRef:
+        'update-rollback-edit-serviceadmin-session-signing-metadata',
+      applyGate:
+        'ready for broker-owned edit/update submit after final conflict and policy revalidation',
+    })
+    expect(editPreview.targetMetadataFields).toEqual(
+      expect.arrayContaining(['rotationPolicyRef', 'ownerServiceRef'])
+    )
+    expect(editPreview.immutableFields).toEqual(
+      expect.arrayContaining([
+        'ref',
+        'providerCredential',
+        'rawValue',
+        'providerToken',
+        'environmentValue',
+      ])
+    )
+    expect(editPreview.affectedConsumerRefs).toEqual(
+      expect.arrayContaining(['@serviceadmin runtime config loader'])
+    )
+    expect(editPreview.omittedUnsafeFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'providerTokens',
+        'cookies',
+        'privateKeys',
+        'recoveryMaterial',
+        'environmentValues',
+      ])
+    )
+    expect(editPreview.safeDiffRows).toEqual(
+      expect.arrayContaining([
+        'metadata diff contains field names, old/new metadata refs, and validation status only',
+        'clear-value table editing is unavailable and cannot be represented in the patch plan',
+      ])
+    )
+    expect(managedSecretEditPreviewHasSecretMaterial(editPreview)).toBe(false)
 
     const missingPolicyPlan = buildSingleSecretOperationPlan(
       managedSecretRows[3],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -80,6 +80,25 @@ export type SingleSecretSubmitEnvelope = {
   blockedReason: string
 }
 
+export type SingleSecretEditPreview = {
+  ref: string
+  operationId: string
+  eligible: boolean
+  badge: string
+  patchPlanHash: string
+  validationStatus: string
+  conflictCheckRef: string
+  rollbackPlanRef: string
+  targetMetadataFields: string[]
+  immutableFields: string[]
+  affectedConsumerRefs: string[]
+  auditTrail: string
+  applyGate: string
+  blockers: string[]
+  omittedUnsafeFields: string[]
+  safeDiffRows: string[]
+}
+
 export type SingleSecretOperationOutcome =
   | 'submitted'
   | 'applied'
@@ -1568,7 +1587,7 @@ function safePayloadFieldsForSingleSecretAction(action: ManagedSecretAction) {
     case 'reveal':
       return [...baseFields, 'revealChallengeId']
     case 'edit':
-      return [...baseFields, 'metadataDiff']
+      return [...baseFields, 'metadataDiff', 'patchPlanHash', 'rollbackPlanRef']
     case 'reset':
       return [...baseFields, 'rotationReason']
     case 'delete':
@@ -1597,6 +1616,9 @@ function revalidationChecksForSingleSecretAction(
 
   if (action === 'delete') {
     checks.push('dependent service references and recovery guidance checked')
+  }
+  if (action === 'edit') {
+    checks.push('metadata diff, schema guard, and conflict check reviewed')
   }
   if (action === 'policy') {
     checks.push('target policy assignment diff checked as metadata only')
@@ -1729,6 +1751,85 @@ export function buildSingleSecretSubmitEnvelope(
     blockedReason: plan.canSubmit
       ? 'ready after final broker revalidation'
       : (plan.blockers[0] ?? plan.applyGate),
+  }
+}
+
+function editConsumerRefsForRow(row: ManagedSecretRow) {
+  if (row.owningService === '@serviceadmin') {
+    return ['@serviceadmin operator API', '@serviceadmin runtime config loader']
+  }
+
+  return [
+    `${row.owningService} runtime config consumer`,
+    `${row.workspace} workspace dependency map`,
+  ]
+}
+
+export function buildSingleSecretEditPreview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretEditPreview {
+  const blockers = [...plan.blockers]
+
+  if (plan.action !== 'edit') {
+    blockers.push('select edit action')
+  }
+
+  const eligible = blockers.length === 0
+  const slug = safeOperationSlug('edit', row)
+  const affectedConsumerRefs = editConsumerRefsForRow(row)
+
+  return {
+    ref: row.ref,
+    operationId: plan.operationId,
+    eligible,
+    badge: eligible ? 'edit preview ready' : 'edit preview blocked',
+    patchPlanHash: `patch-${slug}-metadata-sha256`,
+    validationStatus: eligible
+      ? 'schema and policy validation ready for final broker revalidation'
+      : 'schema validation deferred while preview is blocked',
+    conflictCheckRef: `conflict-${slug}-metadata`,
+    rollbackPlanRef: `update-rollback-${slug}-metadata`,
+    targetMetadataFields: [
+      'label',
+      'description',
+      'rotationPolicyRef',
+      'ownerServiceRef',
+      'safeTagSet',
+    ],
+    immutableFields: [
+      'ref',
+      'providerCredential',
+      'rawValue',
+      'providerToken',
+      'environmentValue',
+    ],
+    affectedConsumerRefs,
+    auditTrail: eligible
+      ? 'audit reason, operation id, metadata patch hash, rollback ref, and consumer refs are ready for broker submit'
+      : 'audit trail records blocker metadata only; no update patch will be submitted while blocked',
+    applyGate: eligible
+      ? 'ready for broker-owned edit/update submit after final conflict and policy revalidation'
+      : blockers[0],
+    blockers,
+    omittedUnsafeFields: [
+      'rawValue',
+      'clearValueBody',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    safeDiffRows: [
+      'metadata diff contains field names, old/new metadata refs, and validation status only',
+      'clear-value table editing is unavailable and cannot be represented in the patch plan',
+      'conflict checks compare operation id, ref, patch hash, policy, and latest metadata version',
+      'rollback reference stores previous metadata refs only and never stores secret material',
+    ],
   }
 }
 
@@ -2733,6 +2834,12 @@ export function managedSecretSubmitEnvelopeHasSecretMaterial(
   envelope: SingleSecretSubmitEnvelope
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(envelope))
+}
+
+export function managedSecretEditPreviewHasSecretMaterial(
+  preview: SingleSecretEditPreview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(preview))
 }
 
 export function managedSecretDecommissionPreviewHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -226,6 +226,27 @@ test.describe('Secrets Broker browser coverage', () => {
         name: /Apply disabled until dry-run preview is accepted/i,
       })
     ).toBeDisabled()
+    await expect(page.getByText(/Edit\/update safety preview/i)).toBeVisible()
+    await expect(page.getByText(/edit preview blocked/i)).toBeVisible()
+    await expect(
+      page.getByText(/patch-edit-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/conflict-edit-serviceadmin-session-signing-metadata/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /update-rollback-edit-serviceadmin-session-signing-metadata/i
+      )
+    ).toBeVisible()
+    await expect(page.getByText('rotationPolicyRef').first()).toBeVisible()
+    await expect(page.getByText('providerCredential').first()).toBeVisible()
+    await expect(
+      page.getByText(/metadata diff contains field names/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/clear-value table editing is unavailable/i)
+    ).toBeVisible()
     await page
       .getByRole('button', { name: /Delete dry-run/i })
       .first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Added a metadata-only edit/update safety preview for the Secrets Broker Secrets page.
- Shows patch plan hash, conflict check ref, rollback ref, target metadata fields, immutable fields, affected consumers, omitted unsafe fields, blockers, and safe diff evidence.
- Extended unit and browser coverage for edit preview redaction and no raw-value/credential rendering.

## Scope
- In scope: Service Admin Secrets page edit/update preview evidence and safe model helpers.
- Out of scope: live Secrets Broker mutation API wiring, raw reveal/value editing, backend enforcement claims, full #231 closure.

## Spec / contract / fixture impact
- Updated: `docs/secret-inventory.md` documents the edit/update preview boundary.
- Fixture/model update is metadata-only; no API/schema contract is claimed as live enforcement.

## Nash invariant impact
- Invariant: Secrets page must not render raw secret values, provider credentials, tokens, cookies, private keys, recovery material, request/response bodies, or environment values.
- Preservation proof: redaction helper `managedSecretEditPreviewHasSecretMaterial` is covered by unit tests; focused browser test confirms the preview renders metadata-only evidence and no reveal sentinel.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/unit-secrets-edit-preview-after-prettier.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "safe action previews"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/playwright-secrets-edit-preview-after-prettier.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/format-check-after-prettier.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/lint-edit-preview.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622T154206/issue-231-edit-update-preview/build-edit-preview.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: no open org PRs before selection; #231 remains open and Ready/Ready for Agent.

## Cleanup
- Branch: `agent/issue-231-edit-update-preview`
- Post-merge release-to-demo gate is required because this Service Admin UI change is demo-consumed: merge, release lasso-serviceadmin, update core `@serviceadmin` pin, recycle canonical demo on port 17883, and run `npm run demo:verify-canonical` before claiming done.