### PR TITLE
feat(secrets): add rotation safety preview

### DIFF
--- a/docs/secret-inventory.md
+++ b/docs/secret-inventory.md
@@ -16,6 +16,7 @@ The secret inventory surface is an advanced Secrets Broker planning view for met
 - Single-secret cancellation is recorded as metadata-only operator intent: operation id, ref, action, audit/correlation refs, and fresh-preview recovery guidance. Cancellation evidence never submits a mutation and never stores request/response bodies or secret material.
 - Controlled reveal previews include a challenge lifecycle model for pending, authorized, expired, revoked, denied, and audit-unavailable states. Lifecycle evidence records challenge/session refs, expiry, revocation, actor/audit/correlation refs, omitted unsafe fields, and next action guidance only; revealed values stay broker-controlled and hidden from the management table.
 - Edit/update previews now show metadata-only change evidence before any submit: operation id, patch plan hash, schema validation status, conflict check ref, rollback ref, dependent consumers, immutable fields, omitted unsafe fields, and safe diff rows. The preview never accepts spreadsheet-style plaintext values and never renders request/response bodies or provider credential material.
+- Reset/rotate previews now show metadata-only rotation safety evidence before any submit: operation id, rotation plan ref, idempotency/retry refs, dependent service restart/reload refs, provider capability checks, audit event refs, omitted unsafe fields, and fail-closed blockers. Rotation does not require controlled reveal and never renders generated replacement values.
 
 ## Not implemented in this slice
 

--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -69,6 +69,7 @@ import {
   buildSingleSecretPolicyPreview,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
+  buildSingleSecretRotationPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildSingleSecretStatusMonitor,
@@ -234,6 +235,10 @@ export function SecretsManagementPage() {
         singleRevealLifecycleState
       )
     : null
+  const rotationPreview =
+    selectedAction === 'reset'
+      ? buildSingleSecretRotationPreview(selectedRow, singleOperationPlan)
+      : null
   const decommissionPreview =
     selectedAction === 'delete'
       ? buildSingleSecretDecommissionPreview(selectedRow, singleOperationPlan)
@@ -1901,6 +1906,111 @@ export function SecretsManagementPage() {
                 {revealPreview.blockers.length > 0 ? (
                   <div className='mt-3 flex flex-wrap gap-1'>
                     {revealPreview.blockers.map((blocker) => (
+                      <Badge key={blocker} variant='outline'>
+                        {blocker}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            {rotationPreview ? (
+              <div className='rounded-md border p-3'>
+                <div className='mb-3 flex flex-wrap items-center gap-2'>
+                  <RotateCcw className='size-4 text-primary' />
+                  <div className='font-medium'>Rotation safety preview</div>
+                  <Badge
+                    variant={rotationPreview.eligible ? 'default' : 'secondary'}
+                  >
+                    {rotationPreview.badge}
+                  </Badge>
+                  <Badge variant='outline'>No reveal required</Badge>
+                </div>
+                <div className='grid gap-3 lg:grid-cols-4'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Rotation plan
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {rotationPreview.rotationPlanRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Idempotency
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {rotationPreview.idempotencyRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Retry window
+                    </div>
+                    <div className='mt-1 break-all'>
+                      {rotationPreview.retryWindowRef}
+                    </div>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Apply gate
+                    </div>
+                    <div className='mt-1'>{rotationPreview.applyGate}</div>
+                  </div>
+                </div>
+                <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Dependent services
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {rotationPreview.dependentServiceRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className='rounded-md border bg-muted/30 p-3'>
+                    <div className='text-xs font-medium text-muted-foreground uppercase'>
+                      Restart/reload refs
+                    </div>
+                    <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                      {rotationPreview.restartPlanRefs.map((ref) => (
+                        <li key={ref}>{ref}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Safe rotation proof
+                  </div>
+                  <div className='mt-2'>
+                    {rotationPreview.providerCapabilityCheck}
+                  </div>
+                  <div className='mt-2 break-all text-muted-foreground'>
+                    {rotationPreview.auditEventId}
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {rotationPreview.safeMetadataRows.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted unsafe fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {rotationPreview.omittedUnsafeFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                {rotationPreview.blockers.length > 0 ? (
+                  <div className='mt-3 flex flex-wrap gap-1'>
+                    {rotationPreview.blockers.map((blocker) => (
                       <Badge key={blocker} variant='outline'>
                         {blocker}
                       </Badge>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -14,6 +14,7 @@ import {
   buildSingleSecretPolicyPreview,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
+  buildSingleSecretRotationPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
   buildSingleSecretStatusMonitor,
@@ -28,6 +29,7 @@ import {
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
+  managedSecretRotationPreviewHasSecretMaterial,
   managedSecretSingleAuditTrailHasSecretMaterial,
   managedSecretStatusMonitorHasSecretMaterial,
   managedSecretSubmitEnvelopeHasSecretMaterial,
@@ -654,6 +656,25 @@ describe('Secrets Broker secrets management page', () => {
       )[0]
     ).toBeVisible()
     expect(screen.getByText(/reset dry-run capability checked/i)).toBeVisible()
+    expect(screen.getByText(/Rotation safety preview/i)).toBeVisible()
+    expect(screen.getByText(/rotation preview blocked/i)).toBeVisible()
+    expect(screen.getByText(/No reveal required/i)).toBeVisible()
+    expect(
+      screen.getByText(/rotation-plan-reset-serviceadmin-session-signing/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/retry-window-reset-serviceadmin-session-signing/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(/restart-serviceadmin-runtime-session-loader/i)
+    ).toBeVisible()
+    expect(
+      screen.getByText(
+        /operator can rotate without opening a controlled reveal/i
+      )
+    ).toBeVisible()
+    expect(screen.getByText(/generatedValue/i)).toBeVisible()
+    expect(screen.getByText(/replacementValue/i)).toBeVisible()
     await user.type(
       screen.getByLabelText(/Audit reason for stub preview/i),
       'operator requested rotation preview'
@@ -994,7 +1015,101 @@ describe('Secrets Broker secrets management page', () => {
       canSubmit: true,
     })
     expect(rotatePlan.safePayloadFields).toEqual(
-      expect.arrayContaining(['ref', 'operationId', 'auditReasonMetadata'])
+      expect.arrayContaining([
+        'ref',
+        'operationId',
+        'auditReasonMetadata',
+        'rotationPlanRef',
+        'dependentServiceRefs',
+        'restartPlanRefs',
+        'idempotencyRef',
+      ])
+    )
+    expect(rotatePlan.revalidationChecks).toEqual(
+      expect.arrayContaining([
+        'rotation can submit without controlled reveal',
+        'dependent service restart and reload plan checked',
+      ])
+    )
+    const rotationPreview = buildSingleSecretRotationPreview(
+      managedSecretRows[0],
+      rotatePlan
+    )
+    expect(rotationPreview).toMatchObject({
+      eligible: true,
+      badge: 'rotation preview ready',
+      rotationPlanRef:
+        'rotation-plan-reset-serviceadmin-session-signing-metadata',
+      idempotencyRef: 'idem-reset-serviceadmin-session-signing-metadata-submit',
+      retryWindowRef:
+        'retry-window-reset-serviceadmin-session-signing-operation-id-only',
+      applyGate:
+        'ready for broker-owned rotate/reset submit after final service impact revalidation',
+      auditEventId: 'audit-reset-serviceadmin-session-signing-preview',
+    })
+    expect(rotationPreview.dependentServiceRefs).toEqual(
+      expect.arrayContaining([
+        '@serviceadmin runtime session loader',
+        '@serviceadmin operator API',
+      ])
+    )
+    expect(rotationPreview.restartPlanRefs).toEqual(
+      expect.arrayContaining([
+        'restart-serviceadmin-runtime-session-loader-after-rotation-metadata',
+      ])
+    )
+    expect(rotationPreview.omittedUnsafeFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'generatedValue',
+        'replacementValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'providerTokens',
+        'cookies',
+        'privateKeys',
+        'recoveryMaterial',
+        'environmentValues',
+      ])
+    )
+    expect(rotationPreview.safeMetadataRows).toEqual(
+      expect.arrayContaining([
+        'rotation preview never reveals the current value or generated replacement value',
+        'operator can rotate without opening a controlled reveal session',
+      ])
+    )
+    expect(managedSecretRotationPreviewHasSecretMaterial(rotationPreview)).toBe(
+      false
+    )
+    const blockedRotationPreview = buildSingleSecretRotationPreview(
+      managedSecretRows[3],
+      buildSingleSecretOperationPlan(
+        managedSecretRows[3],
+        'reset',
+        'operator requested rotation preview',
+        true,
+        'ready'
+      )
+    )
+    expect(blockedRotationPreview).toMatchObject({
+      eligible: false,
+      badge: 'rotation preview blocked',
+      applyGate: 'ref unavailable',
+    })
+    expect(blockedRotationPreview.blockers).toEqual(
+      expect.arrayContaining(['ref unavailable', 'reset dry-run unsupported'])
+    )
+    expect(
+      managedSecretRotationPreviewHasSecretMaterial(blockedRotationPreview)
+    ).toBe(false)
+    expect(rotatePlan.safePayloadFields).toEqual(
+      expect.arrayContaining([
+        'rotationReason',
+        'rotationPlanRef',
+        'dependentServiceRefs',
+        'restartPlanRefs',
+      ])
     )
     const rotateResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -99,6 +99,24 @@ export type SingleSecretEditPreview = {
   safeDiffRows: string[]
 }
 
+export type SingleSecretRotationPreview = {
+  ref: string
+  operationId: string
+  eligible: boolean
+  badge: string
+  rotationPlanRef: string
+  idempotencyRef: string
+  retryWindowRef: string
+  providerCapabilityCheck: string
+  dependentServiceRefs: string[]
+  restartPlanRefs: string[]
+  auditEventId: string
+  applyGate: string
+  blockers: string[]
+  omittedUnsafeFields: string[]
+  safeMetadataRows: string[]
+}
+
 export type SingleSecretOperationOutcome =
   | 'submitted'
   | 'applied'
@@ -1589,7 +1607,14 @@ function safePayloadFieldsForSingleSecretAction(action: ManagedSecretAction) {
     case 'edit':
       return [...baseFields, 'metadataDiff', 'patchPlanHash', 'rollbackPlanRef']
     case 'reset':
-      return [...baseFields, 'rotationReason']
+      return [
+        ...baseFields,
+        'rotationReason',
+        'rotationPlanRef',
+        'dependentServiceRefs',
+        'restartPlanRefs',
+        'idempotencyRef',
+      ]
     case 'delete':
       return [...baseFields, 'recoveryPlanRef', 'dependentServiceRefs']
     case 'policy':
@@ -1625,6 +1650,7 @@ function revalidationChecksForSingleSecretAction(
   }
   if (action === 'reset') {
     checks.push('rotation can submit without controlled reveal')
+    checks.push('dependent service restart and reload plan checked')
   }
 
   return checks
@@ -1763,6 +1789,76 @@ function editConsumerRefsForRow(row: ManagedSecretRow) {
     `${row.owningService} runtime config consumer`,
     `${row.workspace} workspace dependency map`,
   ]
+}
+
+function rotationDependentServiceRefsForRow(row: ManagedSecretRow) {
+  if (row.owningService === '@serviceadmin') {
+    return [
+      '@serviceadmin runtime session loader',
+      '@serviceadmin operator API',
+    ]
+  }
+
+  return [
+    `${row.owningService} runtime secret consumer`,
+    `${row.workspace} restart coordination ref`,
+  ]
+}
+
+export function buildSingleSecretRotationPreview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan
+): SingleSecretRotationPreview {
+  const blockers = [...plan.blockers]
+
+  if (plan.action !== 'reset') {
+    blockers.push('select reset action')
+  }
+
+  const eligible = blockers.length === 0
+  const slug = safeOperationSlug('reset', row)
+  const dependentServiceRefs = rotationDependentServiceRefsForRow(row)
+
+  return {
+    ref: row.ref,
+    operationId: plan.operationId,
+    eligible,
+    badge: eligible ? 'rotation preview ready' : 'rotation preview blocked',
+    rotationPlanRef: `rotation-plan-${slug}-metadata`,
+    idempotencyRef: `idem-${slug}-metadata-submit`,
+    retryWindowRef: `retry-window-${slug}-operation-id-only`,
+    providerCapabilityCheck: eligible
+      ? 'rotate/reset capability, provider state, policy, and audit metadata ready for final broker revalidation'
+      : 'rotation capability and provider state deferred while preview is blocked',
+    dependentServiceRefs,
+    restartPlanRefs: dependentServiceRefs.map(
+      (ref) => `restart-${safeCampaignSlug(ref)}-after-rotation-metadata`
+    ),
+    auditEventId: auditEventIdForSingleSecretAction('reset', row),
+    applyGate: eligible
+      ? 'ready for broker-owned rotate/reset submit after final service impact revalidation'
+      : blockers[0],
+    blockers,
+    omittedUnsafeFields: [
+      'rawValue',
+      'generatedValue',
+      'replacementValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    safeMetadataRows: [
+      'rotation preview never reveals the current value or generated replacement value',
+      'dependent service restart refs are names only and contain no environment values',
+      'idempotency and retry refs are scoped to the broker operation id',
+      'operator can rotate without opening a controlled reveal session',
+    ],
+  }
 }
 
 export function buildSingleSecretEditPreview(
@@ -2838,6 +2934,12 @@ export function managedSecretSubmitEnvelopeHasSecretMaterial(
 
 export function managedSecretEditPreviewHasSecretMaterial(
   preview: SingleSecretEditPreview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(preview))
+}
+
+export function managedSecretRotationPreviewHasSecretMaterial(
+  preview: SingleSecretRotationPreview
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(preview))
 }

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -384,12 +384,32 @@ test.describe('Secrets Broker browser coverage', () => {
       .first()
       .click()
     await expect(page.getByText(/Single-secret preview gate/i)).toBeVisible()
+    await expect(page.getByText(/Rotation safety preview/i)).toBeVisible()
+    await expect(page.getByText(/rotation preview blocked/i)).toBeVisible()
+    await expect(page.getByText(/No reveal required/i)).toBeVisible()
+    await expect(
+      page.getByText(/rotation-plan-reset-serviceadmin-session-signing/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/retry-window-reset-serviceadmin-session-signing/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/restart-serviceadmin-runtime-session-loader/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/dependent service restart and reload plan checked/i)
+    ).toBeVisible()
+    await expect(page.getByText(/generatedValue/i).first()).toBeVisible()
+    await expect(page.getByText(/replacementValue/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/operator can rotate without opening a controlled reveal/i)
+    ).toBeVisible()
     await expect(
       page.getByText(/Single-secret operation history/i)
     ).toBeVisible()
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
     await expect(page.getByText(/No raw payload/i)).toBeVisible()
-    await expect(page.getByText(/Omitted unsafe fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted unsafe fields/i).first()).toBeVisible()
     await expect(page.getByText(/requestBodyEcho/i)).toBeVisible()
     await expect(page.getByText(/not copied into query strings/i)).toBeVisible()
     await expect(
@@ -489,7 +509,9 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/Fresh preview first/i)).toBeVisible()
     await expect(
-      page.getByText(/idem-reset-serviceadmin-session-signing-metadata-submit/i)
+      page
+        .getByText(/idem-reset-serviceadmin-session-signing-metadata-submit/i)
+        .first()
     ).toBeVisible()
     await expect(
       page.getByText(/corr-reset-serviceadmin-session-signing-metadata-submit/i)


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only reset/rotate safety preview before single-secret submit.
- Show rotation plan, idempotency/retry refs, dependent service restart/reload refs, provider capability checks, audit event refs, omitted unsafe fields, and fail-closed blockers.
- Keep rotation independent of controlled reveal and never render generated/current secret values.

## Scope
- In scope: Service Admin stub/preview model, UI panel, docs, unit and browser coverage for the focused rotation safety preview.
- Out of scope: production Secrets Broker mutation API wiring, real provider rotation execution, full #231 closure.

## Spec / contract / fixture impact
- Updated: `docs/secret-inventory.md` documents the reset/rotate preview safety contract.
- Not required: no public API/schema/release contract changes; this is UI/model preview evidence only.

## Nash invariant impact
- Invariant: secret material must not appear in tables, routes, query strings, storage, diagnostics, screenshots, support evidence, or tests.
- Preservation proof: preview fields are allowlisted metadata; tests assert no raw value sentinels and model redaction helpers return false.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/unit-secrets-rotation-preview-after-prettier.log` (15 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "safe action previews"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/playwright-secrets-rotation-preview-after-prettier.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/format-check-rotation-preview-after-prettier.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/lint-rotation-preview-after-prettier.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260622-172514/issue-231-rotation-safety-preview/build-rotation-preview.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: Project #1 item #231 is Ready / Ready for Agent; issue start comment records preflight and selected slice.

## Cleanup
- Branch: `agent/issue-231-rotation-safety-preview`
- Release-to-demo gate: pending after merge/release. This PR changes `lasso-serviceadmin`, which is demo-consumed; do not claim #231 done until Service Admin is released, core `@serviceadmin` pin is updated, and the canonical demo on port 17883 is recycled and verified with matching expected/live tag.