### PR TITLE
feat(secrets): persist secrets table state in URL

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   type ColumnDef,
-  type ColumnFiltersState,
-  type PaginationState,
   type SortingState,
   flexRender,
   getCoreRowModel,
@@ -26,6 +24,7 @@ import {
 import { usePageMetadata } from '@/lib/page-metadata'
 import { isServiceAdminStubModeEnabled } from '@/lib/service-lasso-dashboard/stub'
 import { cn } from '@/lib/utils'
+import { type NavigateFn, useTableUrlState } from '@/hooks/use-table-url-state'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -134,7 +133,15 @@ const actionButtonLabels: Record<
   policy: 'Apply policy preview',
 }
 
-export function SecretsManagementPage() {
+type SecretsManagementPageProps = {
+  search: Record<string, unknown>
+  navigate: NavigateFn
+}
+
+export function SecretsManagementPage({
+  search,
+  navigate,
+}: SecretsManagementPageProps) {
   const stubModeEnabled = isServiceAdminStubModeEnabled()
   const [valueQuery, setValueQuery] = useState('')
   const [valueSearchSupported, setValueSearchSupported] = useState(false)
@@ -176,11 +183,24 @@ export function SecretsManagementPage() {
   const [bulkApplyResult, setBulkApplyResult] =
     useState<BulkSecretCampaignApplyResult | null>(null)
   const [sorting, setSorting] = useState<SortingState>([])
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-  const [globalFilter, setGlobalFilter] = useState('')
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
+
+  const {
+    globalFilter,
+    onGlobalFilterChange,
+    columnFilters,
+    onColumnFiltersChange,
+    pagination,
+    onPaginationChange,
+    ensurePageInRange,
+  } = useTableUrlState({
+    search,
+    navigate,
+    pagination: { defaultPage: 1, defaultPageSize: 10 },
+    globalFilter: { key: 'secret' },
+    columnFilters: [
+      { columnId: 'provider', searchKey: 'provider', type: 'array' },
+      { columnId: 'state', searchKey: 'state', type: 'array' },
+    ],
   })
 
   usePageMetadata({
@@ -564,9 +584,9 @@ export function SecretsManagementPage() {
       pagination,
     },
     onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
+    onColumnFiltersChange,
+    onGlobalFilterChange,
+    onPaginationChange,
     globalFilterFn: (row, _columnId, filterValue) => {
       const query = String(filterValue ?? '')
         .trim()
@@ -598,16 +618,8 @@ export function SecretsManagementPage() {
   })
 
   useEffect(() => {
-    if (
-      pagination.pageIndex > 0 &&
-      pagination.pageIndex >= table.getPageCount()
-    ) {
-      setPagination((current) => ({
-        ...current,
-        pageIndex: Math.max(table.getPageCount() - 1, 0),
-      }))
-    }
-  }, [pagination.pageIndex, table])
+    ensurePageInRange(table.getPageCount())
+  }, [table, ensurePageInRange])
 
   if (!stubModeEnabled) {
     return (

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -151,6 +151,34 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
+  it('restores metadata search and table filters from the route URL', async () => {
+    await renderRoute(
+      '/secrets-broker/secrets?secret=payments&provider=provider%20connection&state=missing'
+    )
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(screen.getByPlaceholderText(/Search secret metadata/i)).toHaveValue(
+      'payments'
+    )
+    expect(screen.getByText(/Metadata matches: 1/i)).toBeVisible()
+    expect(screen.getByText(/PAYMENTS_SIGNING_REF/i)).toBeVisible()
+    expect(screen.getByText(/Readiness: 0 ready \/ 5 blocked/i)).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('restores pagination from the route URL without exposing secret values', async () => {
+    await renderRoute('/secrets-broker/secrets?page=2&pageSize=1')
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(screen.getAllByText(/Page 2 of 4/i)[0]).toBeVisible()
+    expect(screen.getByText(/ZITADEL_CLIENT_CREDENTIAL/i)).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
   it('shows broker-backed value search supported and unsupported states without raw values', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')

--- a/src/routes/_authenticated/secrets-broker/secrets.tsx
+++ b/src/routes/_authenticated/secrets-broker/secrets.tsx
@@ -1,6 +1,32 @@
+/* eslint-disable react-refresh/only-export-components */
+import z from 'zod'
 import { createFileRoute } from '@tanstack/react-router'
 import { SecretsManagementPage } from '@/features/secrets-broker/secrets-management-page'
 
+const optionalStringArraySearchParam = z
+  .union([
+    z.array(z.string()),
+    z.string().transform((value) => (value.length > 0 ? [value] : undefined)),
+  ])
+  .optional()
+  .catch(undefined)
+
+const secretsManagementSearchSchema = z.object({
+  page: z.number().optional().catch(undefined),
+  pageSize: z.number().optional().catch(undefined),
+  secret: z.string().optional().catch(''),
+  provider: optionalStringArraySearchParam,
+  state: optionalStringArraySearchParam,
+})
+
+function SecretsManagementRoute() {
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+
+  return <SecretsManagementPage search={search} navigate={navigate} />
+}
+
 export const Route = createFileRoute('/_authenticated/secrets-broker/secrets')({
-  component: SecretsManagementPage,
+  validateSearch: secretsManagementSearchSchema,
+  component: SecretsManagementRoute,
 })


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Wire the `Secrets Broker > Secrets` table search, provider/status filters, and pagination to URL-backed route search params.
- Add route search validation that accepts direct single-value URLs and router-generated array filter params.
- Add focused route-render tests proving direct filtered/paginated Secrets table loads restore state without rendering raw secret values.

## Scope
- In scope: metadata-only Secrets table URL state for search/filter/pagination, focused tests.
- Out of scope: backend mutation/reveal contracts, bulk raw reveal/export, release/pin/recycle after merge.

## Spec / contract / fixture impact
- Updated: Service Admin route/search behavior for `/secrets-broker/secrets` supports `secret`, `provider`, `state`, `page`, and `pageSize` params.
- Not required: no public backend API/schema change; this is a UI route-state enhancement over existing metadata fixtures.

## Service Lasso invariant impact
- Invariant: Secrets UI must not expose raw values, credentials, tokens, cookies, private keys, recovery material, or raw environment values.
- Preservation proof: new tests keep asserting `DEMO_REVEAL_VALUE_42` is absent on direct filtered and paginated route loads; the table state uses metadata-only row fields and existing redaction boundaries.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/issue-231-secrets-table-url-state/focused-secrets-management.log` (`17` tests passed)
- PASS `npm run lint` — `.work-agent/logs/issue-231-secrets-table-url-state/lint.log`
- PASS `npm run build` — `.work-agent/logs/issue-231-secrets-table-url-state/build.log`
- PASS `npm run format:check` — `.work-agent/logs/issue-231-secrets-table-url-state/format-check.log`
- PASS `git diff --check` — `.work-agent/logs/issue-231-secrets-table-url-state/git-diff-check.log`

## Approval trail
- Required: normal PR review/merge authorization.
- Evidence: #231 is Project #1 Status Ready / Agent lane Ready for Agent; issue start comment records preflight, open-PR gate, and dirty-state checks.

## Cleanup
- Branch cleanup after merge.
- Release-to-demo gate applies after merge because this changes demo-consumed `lasso-serviceadmin`: publish/release Service Admin, update the core demo `@serviceadmin` pin, recycle canonical demo on port `17883`, and run `npm run demo:verify-canonical` before claiming #231 complete.