### PR TITLE
fix: use Monaco diff for config backup compare

### DIFF
--- a/src/features/service-detail/service-config-editor.tsx
+++ b/src/features/service-detail/service-config-editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import Editor from '@monaco-editor/react'
+import Editor, { DiffEditor } from '@monaco-editor/react'
 import {
   CheckCircle2,
   FileClock,
@@ -168,21 +168,56 @@ function ComparePanel({
     )
   }
 
-  return (
-    <div className='grid gap-4 xl:grid-cols-2'>
-      <div className='min-w-0 space-y-2'>
-        <div className='text-sm font-medium'>
-          Backup {revisionLabel(revision)}
+  if (!revision.content.trim()) {
+    return (
+      <div className='rounded-md border border-destructive/45 p-4 text-sm'>
+        <div className='font-medium text-destructive'>
+          Backup content unavailable
         </div>
-        <pre className='max-h-[360px] overflow-auto rounded-md border bg-muted/35 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap'>
-          {revision.content}
-        </pre>
+        <div className='mt-1 text-muted-foreground'>
+          Select another backup revision or reload server.json before comparing.
+        </div>
       </div>
-      <div className='min-w-0 space-y-2'>
-        <div className='text-sm font-medium'>Current editor buffer</div>
-        <pre className='max-h-[360px] overflow-auto rounded-md border bg-muted/35 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap'>
-          {editorContent}
-        </pre>
+    )
+  }
+
+  return (
+    <div className='space-y-3'>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <div className='text-sm font-medium'>Monaco diff editor</div>
+          <div className='text-sm text-muted-foreground'>
+            Original backup revision compared with the current editor buffer.
+          </div>
+        </div>
+        <div className='flex flex-wrap gap-2'>
+          <Badge variant='outline'>
+            Original: backup {revisionLabel(revision)}
+          </Badge>
+          <Badge variant='secondary'>Modified: current editor buffer</Badge>
+        </div>
+      </div>
+      <div
+        className='min-w-0 overflow-hidden rounded-md border'
+        data-testid='service-config-diff-editor'
+      >
+        <DiffEditor
+          height='440px'
+          language='json'
+          original={revision.content}
+          modified={editorContent}
+          theme='vs-dark'
+          options={{
+            automaticLayout: true,
+            minimap: { enabled: false },
+            originalEditable: false,
+            readOnly: true,
+            renderSideBySide: true,
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+          }}
+          loading='Loading server.json diff editor'
+        />
       </div>
     </div>
   )

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -22,6 +22,18 @@ vi.mock('@/lib/service-lasso-dashboard/client', async () => {
 })
 
 vi.mock('@monaco-editor/react', () => ({
+  DiffEditor: ({
+    original,
+    modified,
+  }: {
+    original?: string
+    modified?: string
+  }) => (
+    <div aria-label='server.json backup diff editor' role='region'>
+      <pre data-testid='server-json-diff-original'>{original ?? ''}</pre>
+      <pre data-testid='server-json-diff-modified'>{modified ?? ''}</pre>
+    </div>
+  ),
   default: ({
     value,
     onChange,
@@ -416,10 +428,17 @@ describe('service detail server.json config editor', () => {
     expect(screen.getByText(/1 backups/i)).toBeVisible()
     expect(screen.getByText(/test config save/i)).toBeVisible()
     expect(screen.getAllByText(/Backup history/i).length).toBeGreaterThan(0)
-    expect(screen.getByText(/Current editor buffer/i)).toBeVisible()
+    expect(screen.getByText(/Monaco diff editor/i)).toBeVisible()
     expect(
-      screen.getAllByText(/Saved from config editor test/i).length
-    ).toBeGreaterThan(0)
+      screen.getByRole('region', { name: /server\.json backup diff editor/i })
+    ).toBeVisible()
+    expect(screen.getByText(/Modified: current editor buffer/i)).toBeVisible()
+    expect(screen.getByTestId('server-json-diff-modified')).toHaveTextContent(
+      /Saved from config editor test/i
+    )
+    expect(
+      screen.queryByText(/config-backups\\server\.json/i)
+    ).not.toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Issue
Closes #287

## Summary
- Replaced the backup compare `<pre>` panes with Monaco `DiffEditor` for server.json backup comparisons.
- Labels the original backup revision and modified current editor buffer, while keeping backup content read-only.
- Keeps unavailable backup content in a clear fail-closed state and extends the existing Service Detail test mock to cover the diff editor contract.

## Scope
- In scope: Service Details Config tab backup compare UI and focused test coverage.
- Out of scope: new config backup API fields, runtime persistence changes, or changing save/reload behavior.

## Spec / contract / fixture impact
- Updated: no public API/schema change.
- Not required because: this uses the existing `ServiceConfigRevision.content` and current editor buffer contract.

## Service Lasso invariant impact
- Invariant: server.json compare must not expose raw secret/provider material beyond the existing safe config-editor contract.
- Preservation proof: diff labels use revision timestamp/hash metadata only; tests assert backup storage path metadata is not rendered in the diff compare surface.

## Validation
- PASS `npm run test -- src/features/service-detail/service-detail.test.tsx` — 1 file, 10 tests passed (`.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-287-vitest-focused-rerun.log`).
- PASS `npm run build` — TypeScript and Vite build passed (`.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-287-build.log`).
- PASS `npm run lint` — ESLint passed (`.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-287-lint.log`).

## Approval trail
- Required: GitHub branch protection/review requirements as configured.
- Evidence: PR checks/review state should be verified before merge.

## Cleanup
- Branch can be deleted after merge. Canonical demo release-to-demo gate applies after this Service Admin change is merged/released; no demo pin was changed in this PR.