### PR TITLE
feat(secrets): persist selected action preview in URL

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -133,6 +133,22 @@ const actionButtonLabels: Record<
   policy: 'Apply policy preview',
 }
 
+const managedSecretActionValues: ManagedSecretAction[] = [
+  'metadata',
+  'reveal',
+  'edit',
+  'reset',
+  'delete',
+  'policy',
+]
+
+function isManagedSecretAction(value: unknown): value is ManagedSecretAction {
+  return (
+    typeof value === 'string' &&
+    managedSecretActionValues.includes(value as ManagedSecretAction)
+  )
+}
+
 type SecretsManagementPageProps = {
   search: Record<string, unknown>
   navigate: NavigateFn
@@ -143,11 +159,23 @@ export function SecretsManagementPage({
   navigate,
 }: SecretsManagementPageProps) {
   const stubModeEnabled = isServiceAdminStubModeEnabled()
+  const selectedSearchRef =
+    typeof search.ref === 'string' ? search.ref.trim() : ''
+  const selectedSearchRow =
+    managedSecretRows.find(
+      (row) => row.ref === selectedSearchRef || row.id === selectedSearchRef
+    ) ?? null
+  const selectedSearchAction = selectedSearchRow
+    ? isManagedSecretAction(search.action)
+      ? search.action
+      : 'metadata'
+    : 'metadata'
+  const selectedSearchRowId = selectedSearchRow?.id ?? managedSecretRows[0].id
   const [valueQuery, setValueQuery] = useState('')
   const [valueSearchSupported, setValueSearchSupported] = useState(false)
-  const [selectedRowId, setSelectedRowId] = useState(managedSecretRows[0].id)
+  const [selectedRowId, setSelectedRowId] = useState(selectedSearchRowId)
   const [selectedAction, setSelectedAction] =
-    useState<ManagedSecretAction>('metadata')
+    useState<ManagedSecretAction>(selectedSearchAction)
   const [stubState, setStubState] = useState<StubSecretMutationState>('ready')
   const [auditReason, setAuditReason] = useState('')
   const [confirmed, setConfirmed] = useState(false)
@@ -330,17 +358,33 @@ export function SecretsManagementPage({
     setBulkApplyResult(null)
   }, [])
 
+  useEffect(() => {
+    setSelectedRowId(selectedSearchRowId)
+    setSelectedAction(selectedSearchAction)
+    setSingleApplyResult(null)
+  }, [selectedSearchAction, selectedSearchRowId])
+
   function resetBulkApplyResult() {
     setBulkApplyResult(null)
   }
 
   const chooseAction = useCallback(
     (rowId: string, action: ManagedSecretAction) => {
+      const row = managedSecretRows.find((item) => item.id === rowId)
+      const isDefaultSelection =
+        row?.id === managedSecretRows[0].id && action === 'metadata'
       setSelectedRowId(rowId)
       setSelectedAction(action)
       setSingleApplyResult(null)
+      navigate({
+        search: (prev) => ({
+          ...(prev as Record<string, unknown>),
+          ref: isDefaultSelection ? undefined : row?.ref,
+          action: action === 'metadata' ? undefined : action,
+        }),
+      })
     },
-    []
+    [navigate]
   )
 
   const toggleBulkSelection = useCallback(

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -179,6 +179,63 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
+  it('restores a selected secret action preview from allowlisted route params', async () => {
+    await renderRoute(
+      '/secrets-broker/secrets?ref=secret%3A%2F%2Fprovider%2Fzitadel%2Fclient-credential&action=reset'
+    )
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Reset\/rotate dry-run for ZITADEL_CLIENT_CREDENTIAL/i)
+    ).toBeVisible()
+    expect(
+      screen.getAllByText(/secret:\/\/provider\/zitadel\/client-credential/i)[0]
+    ).toBeVisible()
+    expect(screen.getByText(/Rotation safety preview/i)).toBeVisible()
+    expect(
+      screen.getAllByText(/single-reset-zitadel-client-credential/i)[0]
+    ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('falls back to metadata view when a selected ref param is unknown', async () => {
+    await renderRoute(
+      '/secrets-broker/secrets?ref=secret%3A%2F%2Funknown%2Fmissing&action=delete'
+    )
+
+    expect(
+      await screen.findByRole('heading', { name: /^Secrets$/i })
+    ).toBeVisible()
+    expect(
+      screen.getByText(/Metadata view for SESSION_SIGNING_KEY/i)
+    ).toBeVisible()
+    expect(screen.queryByText(/Delete dry-run for/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
+  it('writes selected secret action previews back to safe route params', async () => {
+    const user = userEvent.setup()
+    const { router } = await renderRoute('/secrets-broker/secrets')
+
+    await user.type(
+      screen.getByPlaceholderText(/Search secret metadata/i),
+      'payments'
+    )
+    await user.click(screen.getByRole('button', { name: /Delete dry-run/i }))
+
+    expect(router.state.location.search).toMatchObject({
+      secret: 'payments',
+      ref: 'secret://provider/payments/signing-ref',
+      action: 'delete',
+    })
+    expect(
+      screen.getByText(/Delete dry-run for PAYMENTS_SIGNING_REF/i)
+    ).toBeVisible()
+    expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
+  })
+
   it('shows broker-backed value search supported and unsupported states without raw values', async () => {
     const user = userEvent.setup()
     await renderRoute('/secrets-broker/secrets')

--- a/src/routes/_authenticated/secrets-broker/secrets.tsx
+++ b/src/routes/_authenticated/secrets-broker/secrets.tsx
@@ -15,6 +15,11 @@ const secretsManagementSearchSchema = z.object({
   page: z.number().optional().catch(undefined),
   pageSize: z.number().optional().catch(undefined),
   secret: z.string().optional().catch(''),
+  ref: z.string().optional().catch(undefined),
+  action: z
+    .enum(['metadata', 'reveal', 'edit', 'reset', 'delete', 'policy'])
+    .optional()
+    .catch('metadata'),
   provider: optionalStringArraySearchParam,
   state: optionalStringArraySearchParam,
 })


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds allowlisted `ref` and `action` search params to `/secrets-broker/secrets`.
- Restores the selected secret/action preview from safe route metadata on reload or direct link.
- Writes row action clicks back to safe route params while preserving existing table search/filter state.

## Scope
- In scope: selected single-secret preview URL state for metadata/reveal/edit/reset/delete/policy actions.
- Out of scope: production broker mutation wiring, raw value reveal, bulk raw export, or full #231 closure.

## Spec / contract / fixture impact
- Updated: route search schema for metadata-only `ref` and `action` params.
- Not required: public backend API/Secrets Broker contract is unchanged.

## Service Lasso invariant impact
- Invariant: secret-bearing material must not appear in routes, storage, diagnostics, screenshots, reports, or tests.
- Preservation proof: only secret refs/action ids are persisted; unknown refs fall back to safe metadata view; tests assert `DEMO_REVEAL_VALUE_42` is never rendered.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/focused-secrets-management.log` (20 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/lint.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/build.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/git-diff-check.log`
- PASS canonical preflight before work: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: normal PR review/merge rules.
- Evidence: focused UI/test slice; hosted checks pending after PR open.

## Cleanup
- Branch: `agent/issue-231-secret-action-url-state`
- Release-to-demo gate: pending. This Service Admin UI change is demo-consumed and must be merged, released, pinned in core, canonical demo recycled on port 17883, and verified before any done/demo-current claim.