### PR TITLE
feat(service-detail): deep link tabs

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
 import { Link } from '@tanstack/react-router'
 import { LazyLog, ScrollFollow } from '@melloware/react-logviewer'
 import {
@@ -104,25 +110,17 @@ import {
 } from '@/features/logs/provider'
 import { buildMetadataTableRows } from './metadata-table'
 import { ServiceConfigEditor } from './service-config-editor'
+import {
+  defaultServiceDetailTab,
+  normalizeServiceDetailTab,
+  serviceDetailTabs,
+  serviceDetailTabsByShortcut,
+  type ServiceDetailTabId,
+} from './service-detail-tabs'
 
 const REDACTED_CONFIG_VALUE = '[redacted by Service Admin]'
 const SENSITIVE_CONFIG_KEY_PATTERN =
   /(?:password|passphrase|token|api[_-]?key|secret|private[_-]?key|credential|cookie)/i
-const serviceDetailTabs = [
-  { id: 'overview', label: 'Overview', shortcut: 'Ctrl+1' },
-  { id: 'dependencies', label: 'Dependencies', shortcut: 'Ctrl+2' },
-  { id: 'endpoints', label: 'Endpoints', shortcut: 'Ctrl+3' },
-  { id: 'variables', label: 'Variables', shortcut: 'Ctrl+4' },
-  { id: 'config', label: 'Config', shortcut: 'Ctrl+5' },
-  { id: 'logs', label: 'Logs', shortcut: 'Ctrl+6' },
-] as const
-
-type ServiceDetailTabId = (typeof serviceDetailTabs)[number]['id']
-
-const serviceDetailTabsByShortcut = Object.fromEntries(
-  serviceDetailTabs.map((tab, index) => [String(index + 1), tab.id])
-) as Record<string, ServiceDetailTabId>
-
 const editableShortcutTargetSelector = [
   'input',
   'textarea',
@@ -1316,10 +1314,28 @@ function ServiceDetailLoading() {
   )
 }
 
-export function ServiceDetail({ serviceId }: { serviceId: string }) {
+export function ServiceDetail({
+  serviceId,
+  activeTab,
+  onActiveTabChange,
+}: {
+  serviceId: string
+  activeTab?: ServiceDetailTabId
+  onActiveTabChange?: (tab: ServiceDetailTabId) => void
+}) {
   const serviceQuery = useDashboardService(serviceId)
   const serviceName = serviceQuery.data?.name ?? serviceId
-  const [activeTab, setActiveTab] = useState<ServiceDetailTabId>('overview')
+  const [localActiveTab, setLocalActiveTab] = useState<ServiceDetailTabId>(
+    activeTab ?? defaultServiceDetailTab
+  )
+  const selectedTab = activeTab ?? localActiveTab
+  const setSelectedTab = useCallback((nextTab: ServiceDetailTabId) => {
+    if (activeTab === undefined) {
+      setLocalActiveTab(nextTab)
+    }
+
+    onActiveTabChange?.(nextTab)
+  }, [activeTab, onActiveTabChange])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -1337,12 +1353,12 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
 
       if (!nextTab) return
       event.preventDefault()
-      setActiveTab(nextTab)
+      setSelectedTab(nextTab)
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [])
+  }, [setSelectedTab])
 
   usePageMetadata({
     title: `Service Admin - Service - ${serviceName}`,
@@ -1457,9 +1473,9 @@ export function ServiceDetail({ serviceId }: { serviceId: string }) {
                 </div>
 
                 <Tabs
-                  value={activeTab}
+                  value={selectedTab}
                   onValueChange={(value) =>
-                    setActiveTab(value as typeof activeTab)
+                    setSelectedTab(normalizeServiceDetailTab(value))
                   }
                   className='space-y-4'
                 >

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1329,13 +1329,16 @@ export function ServiceDetail({
     activeTab ?? defaultServiceDetailTab
   )
   const selectedTab = activeTab ?? localActiveTab
-  const setSelectedTab = useCallback((nextTab: ServiceDetailTabId) => {
-    if (activeTab === undefined) {
-      setLocalActiveTab(nextTab)
-    }
+  const setSelectedTab = useCallback(
+    (nextTab: ServiceDetailTabId) => {
+      if (activeTab === undefined) {
+        setLocalActiveTab(nextTab)
+      }
 
-    onActiveTabChange?.(nextTab)
-  }, [activeTab, onActiveTabChange])
+      onActiveTabChange?.(nextTab)
+    },
+    [activeTab, onActiveTabChange]
+  )
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/features/service-detail/service-detail-tabs.ts
+++ b/src/features/service-detail/service-detail-tabs.ts
@@ -1,0 +1,29 @@
+export const serviceDetailTabs = [
+  { id: 'overview', label: 'Overview', shortcut: 'Ctrl+1' },
+  { id: 'dependencies', label: 'Dependencies', shortcut: 'Ctrl+2' },
+  { id: 'endpoints', label: 'Endpoints', shortcut: 'Ctrl+3' },
+  { id: 'variables', label: 'Variables', shortcut: 'Ctrl+4' },
+  { id: 'config', label: 'Config', shortcut: 'Ctrl+5' },
+  { id: 'logs', label: 'Logs', shortcut: 'Ctrl+6' },
+] as const
+
+export type ServiceDetailTabId = (typeof serviceDetailTabs)[number]['id']
+
+export const defaultServiceDetailTab: ServiceDetailTabId = 'overview'
+
+export const serviceDetailTabsByShortcut = Object.fromEntries(
+  serviceDetailTabs.map((tab, index) => [String(index + 1), tab.id])
+) as Record<string, ServiceDetailTabId>
+
+const serviceDetailTabIds = new Set<ServiceDetailTabId>(
+  serviceDetailTabs.map((tab) => tab.id)
+)
+
+export function normalizeServiceDetailTab(
+  value: unknown
+): ServiceDetailTabId {
+  return typeof value === 'string' &&
+    serviceDetailTabIds.has(value as ServiceDetailTabId)
+    ? (value as ServiceDetailTabId)
+    : defaultServiceDetailTab
+}

--- a/src/features/service-detail/service-detail-tabs.ts
+++ b/src/features/service-detail/service-detail-tabs.ts
@@ -19,9 +19,7 @@ const serviceDetailTabIds = new Set<ServiceDetailTabId>(
   serviceDetailTabs.map((tab) => tab.id)
 )
 
-export function normalizeServiceDetailTab(
-  value: unknown
-): ServiceDetailTabId {
+export function normalizeServiceDetailTab(value: unknown): ServiceDetailTabId {
   return typeof value === 'string' &&
     serviceDetailTabIds.has(value as ServiceDetailTabId)
     ? (value as ServiceDetailTabId)

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -315,6 +315,50 @@ describe('service detail quick actions', () => {
 })
 
 describe('service detail tab keyboard shortcuts', () => {
+  it('opens a Service Details tab from the route search state', async () => {
+    await renderRoute('/services/@serviceadmin?tab=variables')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    expect(screen.getByRole('tab', { name: /variables/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+    expect(screen.getByText('VITE_SERVICE_LASSO_API_BASE_URL')).toBeVisible()
+  })
+
+  it('updates URL search state on tab changes and falls back from unknown tabs', async () => {
+    const user = userEvent.setup()
+    const { router } = await renderRoute('/services/@serviceadmin?tab=unknown')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    expect(screen.getByRole('tab', { name: /overview/i })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    )
+
+    await user.click(screen.getByRole('tab', { name: /logs/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ tab: 'logs' })
+    })
+
+    await user.click(screen.getByRole('tab', { name: /overview/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.search).not.toHaveProperty('tab')
+    })
+  })
+
   it('uses Ctrl+1 through Ctrl+6 for the visible tab order', async () => {
     await renderRoute('/services/@serviceadmin')
 

--- a/src/routes/_authenticated/services.$serviceId.tsx
+++ b/src/routes/_authenticated/services.$serviceId.tsx
@@ -1,12 +1,40 @@
 /* eslint-disable react-refresh/only-export-components */
+import z from 'zod'
 import { createFileRoute } from '@tanstack/react-router'
 import { ServiceDetail } from '@/features/service-detail'
+import {
+  defaultServiceDetailTab,
+  normalizeServiceDetailTab,
+} from '@/features/service-detail/service-detail-tabs'
+
+const serviceDetailSearchSchema = z.object({
+  tab: z.string().optional().catch(undefined),
+})
 
 function ServicesDetailRoute() {
   const { serviceId } = Route.useParams()
-  return <ServiceDetail key={serviceId} serviceId={serviceId} />
+  const search = Route.useSearch()
+  const navigate = Route.useNavigate()
+  const activeTab = normalizeServiceDetailTab(search.tab)
+
+  return (
+    <ServiceDetail
+      key={serviceId}
+      serviceId={serviceId}
+      activeTab={activeTab}
+      onActiveTabChange={(tab) => {
+        void navigate({
+          search: (previous) => ({
+            ...previous,
+            tab: tab === defaultServiceDetailTab ? undefined : tab,
+          }),
+        })
+      }}
+    />
+  )
 }
 
 export const Route = createFileRoute('/_authenticated/services/$serviceId')({
+  validateSearch: serviceDetailSearchSchema,
   component: ServicesDetailRoute,
 })

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -158,6 +158,39 @@ test('service detail variables table keeps long values inside their columns', as
   await expect(row.getByRole('link', { name: 'Open variables' })).toBeVisible()
 })
 
+test('service detail tabs are deep-linkable and restore through browser history', async ({
+  page,
+}) => {
+  await page.goto('/services/@serviceadmin?tab=variables')
+
+  await expect(
+    page.getByRole('heading', { name: 'Service Admin UI' })
+  ).toBeVisible()
+  await expect(page.getByRole('tab', { name: /variables/i })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
+  await expect(page.getByText('VITE_SERVICE_LASSO_API_BASE_URL')).toBeVisible()
+
+  await page.getByRole('tab', { name: /logs/i }).click()
+  await expect(page).toHaveURL(/\/services\/%40serviceadmin\?tab=logs$/)
+
+  await page.getByRole('tab', { name: /variables/i }).click()
+  await expect(page).toHaveURL(/\/services\/%40serviceadmin\?tab=variables$/)
+
+  await page.getByRole('link', { name: 'Open all variables' }).click()
+  await expect(page).toHaveURL(/\/variables\?service=%40serviceadmin$/)
+
+  await page.goBack()
+  await expect(page).toHaveURL(
+    /\/services\/%40serviceadmin\?tab=variables$/
+  )
+  await expect(page.getByRole('tab', { name: /variables/i })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  )
+})
+
 test('runtime, network, installed, and variables tables render', async ({
   page,
 }) => {

--- a/tests/ui/service-admin.spec.ts
+++ b/tests/ui/service-admin.spec.ts
@@ -182,9 +182,7 @@ test('service detail tabs are deep-linkable and restore through browser history'
   await expect(page).toHaveURL(/\/variables\?service=%40serviceadmin$/)
 
   await page.goBack()
-  await expect(page).toHaveURL(
-    /\/services\/%40serviceadmin\?tab=variables$/
-  )
+  await expect(page).toHaveURL(/\/services\/%40serviceadmin\?tab=variables$/)
   await expect(page.getByRole('tab', { name: /variables/i })).toHaveAttribute(
     'aria-selected',
     'true'


### PR DESCRIPTION
## Issue
Closes #284

## Summary
- Adds URL-backed Service Details tab state with `?tab=` deep links.
- Preserves browser history for tab changes so Back/Forward restore the selected tab.
- Falls back safely to Overview for unknown tab ids.

## Scope
- In scope: Service Details tab search-param routing, controlled tab state, direct load and nested navigation/back coverage.
- Out of scope: adding new Terminal runtime support; this PR preserves the existing visible Service Detail tab set.

## Spec / contract / fixture impact
- Updated: route search contract for `/services/$serviceId?tab=<tabId>`.
- Not required because: no backend API/schema or fixture shape changes.

## Nash invariant impact
- Invariant: UI navigation state remains linkable without leaking service config, environment values, or log payloads into new routes.
- Preservation proof: only a small allowlisted tab id is written to the query string; service payload data remains unchanged.

## Validation
- PASS `npm run format:check` — `.work-agent/logs/284/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/284/lint-3.log`
- PASS `npm run test:unit -- src/features/service-detail/service-detail.test.tsx` — `.work-agent/logs/284/vitest-service-detail-3.log`
- PASS `npx playwright test tests/ui/service-admin.spec.ts` — `.work-agent/logs/284/playwright-service-admin-3.log`
- PASS `npm run build` — `.work-agent/logs/284/build-3.log`

## Approval trail
- Required: no explicit human approval found for this bounded UI issue.
- Evidence: Project #1 Status Ready / issue has `agent-ready` and priority labels; start comment posted on #284.

## Cleanup
- Branch: `issue-284-service-detail-tab-links`
- Latest commit: `b3d2fbee4d1719a134ea73712ed29079843bc62b`
- Post-merge: release-to-demo gate applies because Service Admin UI is demo-consumed. Canonical demo must consume the exact merged release/commit before issue completion.