### PR TITLE
feat(service-detail): add Terminal tab

### DIFF
--- a/src/features/logs/provider.ts
+++ b/src/features/logs/provider.ts
@@ -13,20 +13,54 @@ export type ServiceLogInfo = {
   serviceId: string
   type: ServiceLogType
   path?: string | null
+  available?: boolean
   availableTypes: ServiceLogType[]
+  source?: ServiceLogSource
+  sources?: ServiceLogSource[]
+  stdin?: ServiceTerminalStdinCapability
+  capabilities?: {
+    stdin?: ServiceTerminalStdinCapability
+  }
 }
 
 export type ServiceLogChunk = {
   serviceId: string
   type: ServiceLogType
   path?: string | null
+  available?: boolean
+  source?: ServiceLogSource
   totalLines: number
   start: number
   end: number
   hasMore: boolean
   nextBefore: number
+  cursor?: string | null
+  nextCursor?: string | null
   limit: number
   lines: string[]
+}
+
+export type ServiceLogSource = {
+  kind?: 'current' | 'archive' | string
+  stream?: 'combined' | 'stdout' | 'stderr' | string
+  runId?: string
+  path?: string | null
+  available?: boolean
+}
+
+export type ServiceTerminalStdinCapability = {
+  available: boolean
+  reason?: string
+  auditRequired?: boolean
+  policy?: 'allowed' | 'denied' | 'unavailable' | string
+  provider?: string
+}
+
+export type ServiceTerminalInputResult = {
+  serviceId: string
+  accepted: boolean
+  auditId?: string
+  message?: string
 }
 
 export type ServiceLogOverviewEntry = {
@@ -101,6 +135,12 @@ function buildServiceLogsOverviewUrl(serviceId: string) {
   return `${resolveLogsApiBaseUrl()}/api/services/${encodeServiceId(
     serviceId
   )}/logs`
+}
+
+function buildServiceTerminalInputUrl(serviceId: string) {
+  return `${resolveLogsApiBaseUrl()}/api/services/${encodeServiceId(
+    serviceId
+  )}/stdin`
 }
 
 export async function fetchServiceLogInfo(
@@ -198,4 +238,23 @@ export async function fetchServiceLogChunk(
   })
 
   return safeChunk
+}
+
+export async function sendServiceTerminalInput(
+  service: DashboardService,
+  input: string
+) {
+  const response = await fetch(buildServiceTerminalInputUrl(service.id), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      input,
+      stream: 'stdin',
+      actor: 'service-admin-web',
+    }),
+  })
+
+  return parseJsonResponse<ServiceTerminalInputResult>(response)
 }

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useMemo,
   useState,
+  type FormEvent,
   type ReactNode,
 } from 'react'
 import { Link } from '@tanstack/react-router'
@@ -25,10 +26,15 @@ import {
   Link2,
   Network,
   PackageCheck,
+  Pause,
+  Play,
+  RefreshCw,
   Save,
   ScanSearch,
   ScrollText,
+  Send,
   Split,
+  Terminal,
   Undo2,
   Wrench,
 } from 'lucide-react'
@@ -89,6 +95,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Tooltip,
   TooltipContent,
@@ -105,8 +112,10 @@ import { ThemeSwitch } from '@/components/theme-switch'
 import {
   fetchServiceLogChunk,
   fetchServiceLogInfo,
+  sendServiceTerminalInput,
   type ServiceLogChunk,
   type ServiceLogInfo,
+  type ServiceTerminalStdinCapability,
 } from '@/features/logs/provider'
 import { buildMetadataTableRows } from './metadata-table'
 import { ServiceConfigEditor } from './service-config-editor'
@@ -746,6 +755,7 @@ const SERVICE_DETAIL_RUN_STREAMS: Array<{
 
 const SERVICE_DETAIL_LOG_STREAM_LIMIT = 80
 const SERVICE_DETAIL_LOG_STREAM_POLL_MS = 4000
+const SERVICE_DETAIL_TERMINAL_LIMIT = 240
 
 function createRunStreamState(
   loading = false
@@ -963,6 +973,312 @@ function ServiceRunStreams({ service }: { service: DashboardService }) {
         ))}
       </div>
     </div>
+  )
+}
+
+function extractRuntimePid(service: DashboardService) {
+  const values = [service.note, service.runtimeHealth.summary]
+
+  for (const value of values) {
+    const match = value.match(/\bpid\s+(\d+)\b/i)
+    if (match?.[1]) return match[1]
+  }
+
+  return null
+}
+
+function resolveRunId(
+  info: ServiceLogInfo | null,
+  chunk: ServiceLogChunk | null
+) {
+  return (
+    chunk?.source?.runId ??
+    info?.source?.runId ??
+    info?.sources?.find((source) => source.stream === 'stdout')?.runId ??
+    info?.sources?.find((source) => source.kind === 'current')?.runId ??
+    null
+  )
+}
+
+function resolveStdinCapability(
+  service: DashboardService,
+  info: ServiceLogInfo | null
+): ServiceTerminalStdinCapability {
+  const advertised = info?.stdin ?? info?.capabilities?.stdin
+
+  if (service.status !== 'running') {
+    return {
+      available: false,
+      reason: 'The managed process is not running.',
+    }
+  }
+
+  if (advertised?.available) {
+    return advertised
+  }
+
+  return {
+    available: false,
+    reason:
+      advertised?.reason ??
+      'The runtime has not advertised a safe stdin channel for this service.',
+  }
+}
+
+function ServiceTerminalPanel({ service }: { service: DashboardService }) {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<ServiceLogInfo | null>(null)
+  const [chunk, setChunk] = useState<ServiceLogChunk | null>(null)
+  const [paused, setPaused] = useState(false)
+  const [input, setInput] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [submitMessage, setSubmitMessage] = useState<string | null>(null)
+
+  const loadStdout = useCallback(async () => {
+    setError(null)
+
+    try {
+      const [nextInfo, nextChunk] = await Promise.all([
+        fetchServiceLogInfo(service, 'stdout'),
+        fetchServiceLogChunk(
+          service,
+          'stdout',
+          undefined,
+          SERVICE_DETAIL_TERMINAL_LIMIT
+        ),
+      ])
+
+      setInfo(nextInfo)
+      setChunk(nextChunk)
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : 'The runtime did not return stdout history.'
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [service])
+
+  useEffect(() => {
+    let cancelled = false
+
+    setLoading(true)
+    setInfo(null)
+    setChunk(null)
+
+    void (async () => {
+      await loadStdout()
+      if (cancelled) return
+      setLoading(false)
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [loadStdout])
+
+  useEffect(() => {
+    if (service.status !== 'running' || paused) return
+
+    const intervalId = window.setInterval(() => {
+      void fetchServiceLogChunk(
+        service,
+        'stdout',
+        undefined,
+        SERVICE_DETAIL_TERMINAL_LIMIT
+      )
+        .then((nextChunk) => {
+          setError(null)
+          setChunk(nextChunk)
+        })
+        .catch(() => {
+          // Preserve the visible scrollback during transient tail failures.
+        })
+    }, SERVICE_DETAIL_LOG_STREAM_POLL_MS)
+
+    return () => window.clearInterval(intervalId)
+  }, [paused, service])
+
+  const stdinCapability = resolveStdinCapability(service, info)
+  const canSendInput = stdinCapability.available && input.trim().length > 0
+  const pid = extractRuntimePid(service)
+  const runId = resolveRunId(info, chunk)
+  const lines = chunk?.lines ?? []
+  const logText = lines.join('\n')
+
+  async function handleSubmitInput(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedInput = input.trim()
+    if (!stdinCapability.available || !trimmedInput) return
+
+    setSubmitting(true)
+    setSubmitMessage(null)
+
+    try {
+      const result = await sendServiceTerminalInput(service, trimmedInput)
+      setSubmitMessage(
+        result.message ??
+          (result.accepted
+            ? 'Input accepted by runtime stdin.'
+            : 'Runtime rejected the stdin write.')
+      )
+      setInput('')
+    } catch (nextError) {
+      setSubmitMessage(
+        nextError instanceof Error
+          ? nextError.message
+          : 'Runtime stdin write failed.'
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Card data-service-detail-terminal>
+      <CardHeader>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
+          <div>
+            <CardTitle className='flex items-center gap-2'>
+              <Terminal className='size-4' /> Terminal
+            </CardTitle>
+            <CardDescription>
+              Current-run stdout history and safe process input state.
+            </CardDescription>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() => setPaused((value) => !value)}
+            >
+              {paused ? (
+                <Play className='mr-2 size-4' />
+              ) : (
+                <Pause className='mr-2 size-4' />
+              )}
+              {paused ? 'Resume' : 'Pause'}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              onClick={() => void loadStdout()}
+            >
+              <RefreshCw className='mr-2 size-4' />
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        <div className='grid gap-3 md:grid-cols-4'>
+          <MetadataRow label='State' value={service.status} />
+          <MetadataRow
+            label='Started'
+            value={service.runtimeHealth.lastRestartAt}
+          />
+          <MetadataRow label='PID' value={pid ?? undefined} />
+          <MetadataRow label='Run' value={runId ?? undefined} />
+        </div>
+
+        <div className='rounded-md border'>
+          <div className='flex flex-wrap items-center justify-between gap-2 border-b p-3'>
+            <div>
+              <div className='font-medium'>Stdout</div>
+              <div className='font-mono text-xs break-all text-muted-foreground'>
+                {chunk?.path ?? info?.path ?? 'No stdout source reported'}
+              </div>
+            </div>
+            <Badge variant={paused ? 'outline' : 'secondary'}>
+              {paused ? 'paused' : 'following'}
+            </Badge>
+          </div>
+          <div className='p-3'>
+            {loading ? (
+              <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+                Loading stdout history...
+              </div>
+            ) : error ? (
+              <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+                Stdout history unavailable. {error}
+              </div>
+            ) : lines.length ? (
+              <div>
+                <pre
+                  className='sr-only'
+                  data-testid='service-detail-terminal-lines'
+                >
+                  {logText}
+                </pre>
+                <div className='h-[360px] overflow-hidden rounded-md border'>
+                  <ScrollFollow
+                    startFollowing={!paused}
+                    render={({ follow }) => (
+                      <LazyLog
+                        text={logText}
+                        follow={!paused && follow}
+                        enableSearch
+                        selectableLines
+                        style={{
+                          height: '360px',
+                          width: '100%',
+                          background: 'transparent',
+                        }}
+                      />
+                    )}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+                No stdout lines are available for this service run.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <form className='space-y-3' onSubmit={handleSubmitInput}>
+          <div className='grid gap-3 lg:grid-cols-[1fr_auto]'>
+            <Textarea
+              aria-label='Terminal input'
+              data-terminal-input
+              value={input}
+              onChange={(event) => setInput(event.currentTarget.value)}
+              disabled={!stdinCapability.available || submitting}
+              placeholder={
+                stdinCapability.available
+                  ? 'Write to managed process stdin'
+                  : (stdinCapability.reason ?? 'Stdin is unavailable')
+              }
+              className='min-h-24 font-mono'
+            />
+            <Button
+              type='submit'
+              disabled={!canSendInput || submitting}
+              className='self-end'
+            >
+              <Send className='mr-2 size-4' />
+              Send input
+            </Button>
+          </div>
+          {!stdinCapability.available ? (
+            <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+              Input disabled. {stdinCapability.reason}
+            </div>
+          ) : null}
+          {submitMessage ? (
+            <div className='rounded-md border p-3 text-sm text-muted-foreground'>
+              {submitMessage}
+            </div>
+          ) : null}
+        </form>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -1652,6 +1968,10 @@ export function ServiceDetail({
                         <ServiceLogViewer entries={service.recentLogs} />
                       </CardContent>
                     </Card>
+                  </TabsContent>
+
+                  <TabsContent value='terminal' className='mt-0'>
+                    <ServiceTerminalPanel service={service} />
                   </TabsContent>
                 </Tabs>
               </>

--- a/src/features/service-detail/service-detail-tabs.ts
+++ b/src/features/service-detail/service-detail-tabs.ts
@@ -5,6 +5,7 @@ export const serviceDetailTabs = [
   { id: 'variables', label: 'Variables', shortcut: 'Ctrl+4' },
   { id: 'config', label: 'Config', shortcut: 'Ctrl+5' },
   { id: 'logs', label: 'Logs', shortcut: 'Ctrl+6' },
+  { id: 'terminal', label: 'Terminal', shortcut: 'Ctrl+7' },
 ] as const
 
 export type ServiceDetailTabId = (typeof serviceDetailTabs)[number]['id']

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -312,6 +312,286 @@ describe('service detail quick actions', () => {
     expect(within(streams).queryByText(/hidden-value/)).not.toBeInTheDocument()
     expect(within(streams).queryByText(/hunter2/)).not.toBeInTheDocument()
   })
+
+  it('renders the Terminal tab from safe stdout history without leaking values', async () => {
+    const user = userEvent.setup()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url, 'http://localhost')
+        const serviceId = parsed.searchParams.get('service') ?? '@serviceadmin'
+
+        if (parsed.pathname === '/api/services/log-info') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type: 'stdout',
+              path: `C:\\runtime\\${serviceId}\\stdout.log`,
+              available: true,
+              availableTypes: ['default', 'stdout', 'stderr'],
+              sources: [
+                {
+                  kind: 'current',
+                  stream: 'stdout',
+                  runId: 'run-2026-06-25T05-00-00Z',
+                  path: `C:\\runtime\\${serviceId}\\stdout.log`,
+                  available: true,
+                },
+              ],
+              stdin: {
+                available: false,
+                reason: 'Provider does not expose stdin.',
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/logs/read') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type: 'stdout',
+              path: `C:\\runtime\\${serviceId}\\stdout.log`,
+              available: true,
+              source: {
+                kind: 'current',
+                stream: 'stdout',
+                runId: 'run-2026-06-25T05-00-00Z',
+                path: `C:\\runtime\\${serviceId}\\stdout.log`,
+                available: true,
+              },
+              totalLines: 2,
+              start: 0,
+              end: 2,
+              hasMore: false,
+              nextBefore: 0,
+              cursor: '2',
+              nextCursor: null,
+              limit: 240,
+              lines: [
+                'service ready token=hidden-value',
+                'listening on http://127.0.0.1:17700',
+              ],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        return new Response('not found', { status: 404 })
+      })
+    )
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /terminal/i }))
+
+    const terminal = screen.getByTestId('service-detail-terminal-lines')
+
+    await waitFor(() => {
+      expect(terminal).toHaveTextContent(/service ready/)
+    })
+
+    expect(terminal).toHaveTextContent(/token=\[redacted\]/)
+    expect(terminal).not.toHaveTextContent(/hidden-value/)
+    expect(screen.getByText('run-2026-06-25T05-00-00Z')).toBeVisible()
+    expect(
+      screen.getByRole('textbox', { name: /terminal input/i })
+    ).toBeDisabled()
+    expect(screen.getByText(/Provider does not expose stdin/i)).toBeVisible()
+  })
+
+  it('keeps Terminal input disabled when the managed service is stopped', async () => {
+    const user = userEvent.setup()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url, 'http://localhost')
+
+        if (parsed.pathname === '/api/services/log-info') {
+          return new Response(
+            JSON.stringify({
+              serviceId: 'dagu',
+              type: 'stdout',
+              path: 'C:\\runtime\\dagu\\stdout.log',
+              available: true,
+              availableTypes: ['default', 'stdout', 'stderr'],
+              stdin: { available: true },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/logs/read') {
+          return new Response(
+            JSON.stringify({
+              serviceId: 'dagu',
+              type: 'stdout',
+              path: 'C:\\runtime\\dagu\\stdout.log',
+              available: true,
+              totalLines: 0,
+              start: 0,
+              end: 0,
+              hasMore: false,
+              nextBefore: 0,
+              limit: 240,
+              lines: [],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        return new Response('not found', { status: 404 })
+      })
+    )
+
+    await renderRoute('/services/dagu')
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Dagu$/i })).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /terminal/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('textbox', { name: /terminal input/i })
+      ).toBeDisabled()
+    })
+
+    expect(screen.getByText(/managed process is not running/i)).toBeVisible()
+  })
+
+  it('sends Terminal input only through the managed stdin endpoint', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const parsed = new URL(url, 'http://localhost')
+      const serviceId = parsed.searchParams.get('service') ?? '@serviceadmin'
+
+      if (parsed.pathname === '/api/services/log-info') {
+        return new Response(
+          JSON.stringify({
+            serviceId,
+            type: 'stdout',
+            path: `C:\\runtime\\${serviceId}\\stdout.log`,
+            available: true,
+            availableTypes: ['default', 'stdout', 'stderr'],
+            stdin: {
+              available: true,
+              auditRequired: true,
+              provider: 'direct',
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      }
+
+      if (parsed.pathname === '/api/logs/read') {
+        return new Response(
+          JSON.stringify({
+            serviceId,
+            type: 'stdout',
+            path: `C:\\runtime\\${serviceId}\\stdout.log`,
+            available: true,
+            totalLines: 1,
+            start: 0,
+            end: 1,
+            hasMore: false,
+            nextBefore: 0,
+            limit: 240,
+            lines: ['interactive app ready'],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      }
+
+      if (
+        parsed.pathname === '/api/services/%40serviceadmin/stdin' ||
+        parsed.pathname === '/api/services/@serviceadmin/stdin'
+      ) {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          input: 'status',
+          stream: 'stdin',
+          actor: 'service-admin-web',
+        })
+
+        return new Response(
+          JSON.stringify({
+            serviceId: '@serviceadmin',
+            accepted: true,
+            auditId: 'audit-1',
+            message: 'Input accepted.',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      }
+
+      return new Response('not found', { status: 404 })
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /terminal/i }))
+
+    const terminalInput = await screen.findByRole('textbox', {
+      name: /terminal input/i,
+    })
+    await user.type(terminalInput, 'status')
+    await user.click(screen.getByRole('button', { name: /send input/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Input accepted/i)).toBeVisible()
+    })
+
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => {
+        const parsed = new URL(String(url), 'http://localhost')
+        return (
+          parsed.pathname.endsWith('/stdin') &&
+          init?.method === 'POST' &&
+          String(init?.body).includes('"input":"status"')
+        )
+      })
+    ).toBe(true)
+  })
 })
 
 describe('service detail tab keyboard shortcuts', () => {
@@ -359,7 +639,7 @@ describe('service detail tab keyboard shortcuts', () => {
     })
   })
 
-  it('uses Ctrl+1 through Ctrl+6 for the visible tab order', async () => {
+  it('uses Ctrl+1 through Ctrl+7 for the visible tab order', async () => {
     await renderRoute('/services/@serviceadmin')
 
     await waitFor(() => {
@@ -375,6 +655,7 @@ describe('service detail tab keyboard shortcuts', () => {
       ['4', /variables/i],
       ['5', /config/i],
       ['6', /logs/i],
+      ['7', /terminal/i],
     ] as const
 
     for (const [key, tabName] of shortcuts) {
@@ -391,6 +672,9 @@ describe('service detail tab keyboard shortcuts', () => {
       screen.getByRole('tab', { name: /overview.*ctrl\+1/i })
     ).toBeVisible()
     expect(screen.getByRole('tab', { name: /logs.*ctrl\+6/i })).toBeVisible()
+    expect(
+      screen.getByRole('tab', { name: /terminal.*ctrl\+7/i })
+    ).toBeVisible()
   })
 
   it('ignores unmodified number keys and Ctrl+number inside the config editor', async () => {


### PR DESCRIPTION
## Issue
Closes #275

## Summary
- Adds a Service Details `Terminal` tab with current-run stdout history, run metadata, pause/resume follow behavior, manual refresh, and redacted line rendering.
- Gates managed-process stdin input on an explicit runtime-advertised capability; current runtimes without that capability show a disabled state instead of pretending shell access exists.
- Adds a typed stdin client helper for the future safe managed-process stdin endpoint and focused UI tests for history, disabled states, and mocked successful send wiring.

## Scope
- In scope: Service Admin UI/contract consumption for the Terminal tab, stdout history display, safe stdin capability gating, and tests.
- Out of scope: arbitrary shell execution, raw environment/config display, and core runtime implementation of stdin support if it is not advertised by the runtime.

## Spec / contract / fixture impact
- Updated: Service Admin log provider types now accept current core stdout metadata (`available`, `source`, `sources`, cursors) plus optional stdin capability metadata.
- Not required because: no public route or persisted schema changes are introduced in Service Admin.

## Nash invariant impact
- Invariant: Terminal input must write only to a managed process stdin endpoint when runtime capability says it is available.
- Preservation proof: UI disables input for stopped services and for runtimes that do not advertise `stdin.available`; tests verify disabled and mocked-send states. Log lines continue through existing redaction before render.

## Validation
- PASS `npm test -- --run src/features/service-detail/service-detail.test.tsx` — 17 tests passed.
- PASS `npm run lint`.
- PASS `npm run build`.
- PASS `npm run format:check`.
- PASS `git diff --check`.
- Evidence logs: `C:\projects\service-lasso\.work-agent\logs\755b8bea-10c9-4a16-bd2b-172e57d11ff6\issue-275-*`.

## Approval trail
- Required: yes, normal PR review/merge gate applies.
- Evidence: branch is pushed from clean `master` and this PR targets `master`.

## Cleanup
- After merge: publish the Service Admin release, update the core `@serviceadmin` demo pin to the exact release, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live Service Admin/runtime before closing #275.