### PR TITLE
feat(secrets): show route storage leak evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -64,6 +64,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
@@ -276,6 +277,11 @@ export function SecretsManagementPage({
   const singleSubmitEnvelope = buildSingleSecretSubmitEnvelope(
     selectedRow,
     singleOperationPlan
+  )
+  const singleLeakEvidence = buildSingleSecretLeakEvidence(
+    selectedRow,
+    singleOperationPlan,
+    singleSubmitEnvelope
   )
   const editPreview =
     selectedAction === 'edit'
@@ -1779,6 +1785,121 @@ export function SecretsManagementPage({
                       <li key={row}>{row}</li>
                     ))}
                   </ul>
+                </div>
+              </div>
+            </div>
+            <div className='rounded-md border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <DatabaseZap className='size-4 text-primary' />
+                <div className='font-medium'>
+                  Route and storage leak evidence
+                </div>
+                <Badge variant='secondary'>Metadata only</Badge>
+                <Badge
+                  variant={
+                    singleLeakEvidence.safeForScreenshots
+                      ? 'outline'
+                      : 'destructive'
+                  }
+                >
+                  Screenshot safe
+                </Badge>
+              </div>
+              <div className='grid gap-3 lg:grid-cols-4'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Route
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleLeakEvidence.route}
+                  </div>
+                  <div className='mt-2 text-xs text-muted-foreground'>
+                    {singleLeakEvidence.routeState}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Selected ref
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleLeakEvidence.selectedRef}
+                  </div>
+                  <div className='mt-2 text-xs text-muted-foreground'>
+                    Action: {singleLeakEvidence.action}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Browser storage
+                  </div>
+                  <div className='mt-1'>
+                    {singleLeakEvidence.browserStorageWrites}
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleLeakEvidence.browserStorageKeys.map((key) => (
+                      <Badge key={key} variant='outline'>
+                        {key}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Diagnostics
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleLeakEvidence.diagnosticsRef}
+                  </div>
+                  <div className='mt-2 text-xs break-all text-muted-foreground'>
+                    {singleLeakEvidence.supportBundleRef}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Allowed route params
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleLeakEvidence.allowedRouteParams.map((param) => (
+                      <Badge key={param} variant='outline'>
+                        {param}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted from browser surfaces
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleLeakEvidence.omittedFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Screenshot policy
+                </div>
+                <div className='mt-2'>
+                  {singleLeakEvidence.screenshotPolicy}
+                </div>
+              </div>
+              <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Safe evidence rows
+                </div>
+                <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                  {singleLeakEvidence.safeEvidenceRows.map((row) => (
+                    <li key={row}>{row}</li>
+                  ))}
+                </ul>
+                <div className='mt-3 text-xs break-all text-muted-foreground'>
+                  Console event: {singleLeakEvidence.consoleEvent}
                 </div>
               </div>
             </div>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -10,6 +10,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
@@ -30,6 +31,7 @@ import {
   managedSecretEditPreviewHasSecretMaterial,
   managedSecretEvidenceBundleHasSecretMaterial,
   managedSecretHistoryReviewHasSecretMaterial,
+  managedSecretLeakEvidenceHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
@@ -96,15 +98,21 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Delete dry-run/i)[0]).toBeVisible()
     expect(screen.getAllByText(/Apply policy preview/i)[0]).toBeVisible()
     expect(screen.getByText(/Broker operation contract/i)).toBeVisible()
-    expect(screen.getByText(/single-metadata/i)).toBeVisible()
+    expect(screen.getAllByText(/single-metadata/i)[0]).toBeVisible()
     expect(
       screen.getAllByText(
         /GET \/v1\/management\/secrets\/\{ref\}\/metadata/i
       )[0]
     ).toBeVisible()
     expect(screen.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    expect(screen.getByText(/Route and storage leak evidence/i)).toBeVisible()
     expect(screen.getByText(/Submit blocked/i)).toBeVisible()
     expect(screen.getByText(/No raw payload/i)).toBeVisible()
+    expect(screen.getByText(/Allowed route params/i)).toBeVisible()
+    expect(screen.getByText(/localStorage writes: none/i)).toBeVisible()
+    expect(
+      screen.getByText(/secrets-management:route-storage-leak-evidence/i)
+    ).toBeVisible()
     expect(screen.getByText(/Omitted unsafe fields/i)).toBeVisible()
     expect(
       screen.getByText(/no local storage or session storage/i)
@@ -1322,6 +1330,49 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretSubmitEnvelopeHasSecretMaterial(rotateSubmitEnvelope)
     ).toBe(false)
+    const rotateLeakEvidence = buildSingleSecretLeakEvidence(
+      managedSecretRows[0],
+      rotatePlan,
+      rotateSubmitEnvelope
+    )
+    expect(rotateLeakEvidence).toMatchObject({
+      route: '/secrets-broker/secrets',
+      selectedRef: 'secret://local/default/@serviceadmin/SESSION_SIGNING_KEY',
+      action: 'reset',
+      browserStorageWrites:
+        'localStorage writes: none; sessionStorage writes: none',
+      diagnosticsRef:
+        'diagnostics-reset-serviceadmin-session-signing-metadata-only',
+      supportBundleRef:
+        'support-reset-serviceadmin-session-signing-metadata-only',
+      safeForScreenshots: true,
+    })
+    expect(rotateLeakEvidence.allowedRouteParams).toEqual(
+      expect.arrayContaining([
+        'ref=<managed secret ref>',
+        'action=reset',
+        'secret=<metadata table search>',
+        'page/pageSize=<table pagination>',
+      ])
+    )
+    expect(rotateLeakEvidence.omittedFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerAuthMaterial',
+        'supportBundlePayloadBodies',
+      ])
+    )
+    expect(rotateLeakEvidence.safeEvidenceRows).toEqual(
+      expect.arrayContaining([
+        'route state uses only ref/action metadata and table filters',
+        'browser storage remains unused for selected action state and submit envelopes',
+      ])
+    )
+    expect(managedSecretLeakEvidenceHasSecretMaterial(rotateLeakEvidence)).toBe(
+      false
+    )
 
     const appliedResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -80,6 +80,23 @@ export type SingleSecretSubmitEnvelope = {
   blockedReason: string
 }
 
+export type SingleSecretLeakEvidence = {
+  route: string
+  selectedRef: string
+  action: ManagedSecretAction
+  routeState: string
+  allowedRouteParams: string[]
+  browserStorageWrites: string
+  browserStorageKeys: string[]
+  diagnosticsRef: string
+  supportBundleRef: string
+  screenshotPolicy: string
+  consoleEvent: string
+  omittedFields: string[]
+  safeEvidenceRows: string[]
+  safeForScreenshots: boolean
+}
+
 export type SingleSecretEditPreview = {
   ref: string
   operationId: string
@@ -663,6 +680,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:stub-mutation-apply-status',
     'secrets-management:single-secret-operation-history',
     'secrets-management:single-secret-operation-audit-trail',
+    'secrets-management:route-storage-leak-evidence',
     'secrets-management:single-secret-decommission-preview',
     'secrets-management:single-secret-policy-preview',
     'secrets-management:stub-delete-preview',
@@ -1810,6 +1828,58 @@ export function buildSingleSecretSubmitEnvelope(
     blockedReason: plan.canSubmit
       ? 'ready after final broker revalidation'
       : (plan.blockers[0] ?? plan.applyGate),
+  }
+}
+
+export function buildSingleSecretLeakEvidence(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  envelope: SingleSecretSubmitEnvelope
+): SingleSecretLeakEvidence {
+  const slug = safeOperationSlug(plan.action, row)
+  const actionParam =
+    plan.action === 'metadata'
+      ? 'action omitted for default metadata view'
+      : `action=${plan.action}`
+
+  return {
+    route: managedSecretSafeSurfaces.route,
+    selectedRef: row.ref,
+    action: plan.action,
+    routeState:
+      'selected ref and action are represented as allowlisted metadata only',
+    allowedRouteParams: [
+      'ref=<managed secret ref>',
+      actionParam,
+      'secret=<metadata table search>',
+      'provider=<provider filter>',
+      'state=<state filter>',
+      'page/pageSize=<table pagination>',
+    ],
+    browserStorageWrites:
+      'localStorage writes: none; sessionStorage writes: none',
+    browserStorageKeys: ['none'],
+    diagnosticsRef: `diagnostics-${slug}-metadata-only`,
+    supportBundleRef: `support-${slug}-metadata-only`,
+    screenshotPolicy:
+      'screenshots may include refs, operation ids, badges, and typed outcomes; value display stays hidden',
+    consoleEvent: 'secrets-management:route-storage-leak-evidence',
+    omittedFields: [
+      ...envelope.omittedFields,
+      'requestBody',
+      'responseBody',
+      'providerAuthMaterial',
+      'recoveryMaterial',
+      'supportBundlePayloadBodies',
+    ],
+    safeEvidenceRows: [
+      'route state uses only ref/action metadata and table filters',
+      'browser storage remains unused for selected action state and submit envelopes',
+      `submit envelope ${envelope.operationId} omits value and provider auth fields`,
+      'diagnostics and support bundles carry refs, operation ids, correlation ids, action names, and typed status only',
+      'safe screenshots keep value display regions hidden or redacted',
+    ],
+    safeForScreenshots: true,
   }
 }
 
@@ -3137,6 +3207,12 @@ export function managedSecretSubmitEnvelopeHasSecretMaterial(
   envelope: SingleSecretSubmitEnvelope
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(envelope))
+}
+
+export function managedSecretLeakEvidenceHasSecretMaterial(
+  evidence: SingleSecretLeakEvidence
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(evidence))
 }
 
 export function managedSecretEditPreviewHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -408,9 +408,13 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/Single-secret operation history/i)
     ).toBeVisible()
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    await expect(
+      page.getByText(/Route and storage leak evidence/i)
+    ).toBeVisible()
     await expect(page.getByText(/No raw payload/i)).toBeVisible()
     await expect(page.getByText(/Omitted unsafe fields/i).first()).toBeVisible()
-    await expect(page.getByText(/requestBodyEcho/i)).toBeVisible()
+    await expect(page.getByText(/requestBodyEcho/i).first()).toBeVisible()
+    await expect(page.getByText(/localStorage writes: none/i)).toBeVisible()
     await expect(page.getByText(/not copied into query strings/i)).toBeVisible()
     await expect(
       page.getByText(/no local storage or session storage/i)


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only route/storage/diagnostics leak evidence model for the selected single-secret action.
- Shows that evidence in the Secrets Broker > Secrets single-secret gate: allowed URL params, no browser storage writes, diagnostics/support refs, screenshot policy, and omitted unsafe fields.
- Extends focused tests to prove the panel renders and the new evidence object is free of forbidden secret material.

## Scope
- In scope: UI/model/test evidence for browser-surface leakage around the current selected single-secret preview.
- Out of scope: backend mutation enforcement, real value reveal, full #231 closure, and canonical demo release/pin/recycle before merge.

## Spec / contract / fixture impact
- Updated: no public API/schema change; this is metadata-only UI/model behavior inside the existing stub Secrets management surface.
- Not required because: no Secrets Broker backend route or payload contract is changed.

## Nash invariant impact
- Invariant: raw secret values, provider credentials, request/response bodies, tokens, cookies, keys, and recovery material must not appear in route state, browser storage, diagnostics, support bundles, screenshots, or tests.
- Preservation proof: the leak-evidence model explicitly allowlists browser-surface metadata and is checked with the existing forbidden-material scanner.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/focused-secrets-management.log` (20 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/lint.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/build.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260625T161906+1000/git-diff-check.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: branch is small and self-contained; hosted checks still need to run after PR creation.

## Cleanup
- Branch cleanup after merge: delete `agent/issue-231-secret-leak-evidence` locally/remotely.
- Release-to-demo gate: required after merge because this is demo-consumed Service Admin UI work; do not claim #231 done until release, core pin, canonical recycle, and verifier are complete.