### PR TITLE
feat(secrets): add replay guard evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -74,6 +74,7 @@ import {
   buildSingleSecretRotationPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretReplayGuard,
   buildSingleSecretStatusMonitor,
   buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
@@ -277,6 +278,11 @@ export function SecretsManagementPage({
   const singleSubmitEnvelope = buildSingleSecretSubmitEnvelope(
     selectedRow,
     singleOperationPlan
+  )
+  const singleReplayGuard = buildSingleSecretReplayGuard(
+    selectedRow,
+    singleOperationPlan,
+    singleSubmitEnvelope
   )
   const singleLeakEvidence = buildSingleSecretLeakEvidence(
     selectedRow,
@@ -1782,6 +1788,110 @@ export function SecretsManagementPage({
                   </div>
                   <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
                     {singleSubmitEnvelope.diagnosticsGuardrails.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div className='rounded-md border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <ShieldCheck className='size-4 text-primary' />
+                <div className='font-medium'>Replay and idempotency guard</div>
+                <Badge
+                  variant={
+                    singleReplayGuard.readyForReplaySafeSubmit
+                      ? 'default'
+                      : 'secondary'
+                  }
+                >
+                  {singleReplayGuard.readyForReplaySafeSubmit
+                    ? 'Replay safe'
+                    : 'Replay blocked'}
+                </Badge>
+                <Badge variant='outline'>No cross-ref replay</Badge>
+              </div>
+              <div className='grid gap-3 lg:grid-cols-4'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Scope
+                  </div>
+                  <div className='mt-1'>{singleReplayGuard.replayScope}</div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Plan fingerprint
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleReplayGuard.planFingerprint}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Binding
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleReplayGuard.selectedRefBinding}
+                  </div>
+                  <div className='mt-1 text-muted-foreground'>
+                    {singleReplayGuard.actionBinding}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Decision
+                  </div>
+                  <div className='mt-1'>{singleReplayGuard.replayDecision}</div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 lg:grid-cols-3'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Retry keys
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleReplayGuard.idempotencyKey}
+                  </div>
+                  <div className='mt-1 break-all text-muted-foreground'>
+                    {singleReplayGuard.correlationId}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Stale plan guard
+                  </div>
+                  <div className='mt-1'>{singleReplayGuard.stalePlanGuard}</div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted replay fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleReplayGuard.omittedReplayFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Ref binding checks
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleReplayGuard.refBindingRows.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Safe replay evidence
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleReplayGuard.safeReplayRows.map((row) => (
                       <li key={row}>{row}</li>
                     ))}
                   </ul>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -20,6 +20,7 @@ import {
   buildSingleSecretRotationPreview,
   buildSingleSecretOperationResult,
   buildSingleSecretOperationPlan,
+  buildSingleSecretReplayGuard,
   buildSingleSecretStatusMonitor,
   buildSingleSecretSubmitEnvelope,
   buildStubSecretMutationPreview,
@@ -35,6 +36,7 @@ import {
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
+  managedSecretReplayGuardHasSecretMaterial,
   managedSecretRotationPreviewHasSecretMaterial,
   managedSecretSingleAuditTrailHasSecretMaterial,
   managedSecretStatusMonitorHasSecretMaterial,
@@ -105,6 +107,9 @@ describe('Secrets Broker secrets management page', () => {
       )[0]
     ).toBeVisible()
     expect(screen.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    expect(screen.getByText(/Replay and idempotency guard/i)).toBeVisible()
+    expect(screen.getByText(/No cross-ref replay/i)).toBeVisible()
+    expect(screen.getByText(/plan-fp-metadata/i)).toBeVisible()
     expect(screen.getByText(/Route and storage leak evidence/i)).toBeVisible()
     expect(screen.getByText(/Submit blocked/i)).toBeVisible()
     expect(screen.getByText(/No raw payload/i)).toBeVisible()
@@ -1330,6 +1335,73 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretSubmitEnvelopeHasSecretMaterial(rotateSubmitEnvelope)
     ).toBe(false)
+    const rotateReplayGuard = buildSingleSecretReplayGuard(
+      managedSecretRows[0],
+      rotatePlan,
+      rotateSubmitEnvelope
+    )
+    expect(rotateReplayGuard).toMatchObject({
+      operationId: rotatePlan.operationId,
+      planFingerprint:
+        'plan-fp-reset-serviceadmin-session-signing-metadata-only',
+      idempotencyKey: 'idem-reset-serviceadmin-session-signing-metadata-submit',
+      correlationId: 'corr-reset-serviceadmin-session-signing-metadata-submit',
+      readyForReplaySafeSubmit: true,
+      replayDecision:
+        'first submit and retry are allowed only with the same operation id and idempotency key',
+    })
+    expect(rotateReplayGuard.refBindingRows).toEqual(
+      expect.arrayContaining([
+        'cross-ref replay rejected before broker mutation',
+        'cross-action replay rejected before broker mutation',
+        'stale dry-run fingerprint requires a fresh preview',
+      ])
+    )
+    expect(rotateReplayGuard.omittedReplayFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'auditReasonText',
+      ])
+    )
+    expect(rotateReplayGuard.safeReplayRows).toEqual(
+      expect.arrayContaining([
+        'idempotency evidence uses operation id, correlation id, ref metadata, and action metadata only',
+        'retry status is operation-id scoped and never includes request or response bodies',
+      ])
+    )
+    expect(managedSecretReplayGuardHasSecretMaterial(rotateReplayGuard)).toBe(
+      false
+    )
+
+    const missingPlan = buildSingleSecretOperationPlan(
+      managedSecretRows[3],
+      'reset',
+      'operator requested rotation preview',
+      true,
+      'ready'
+    )
+    const blockedSubmitEnvelope = buildSingleSecretSubmitEnvelope(
+      managedSecretRows[3],
+      missingPlan
+    )
+    const blockedReplayGuard = buildSingleSecretReplayGuard(
+      managedSecretRows[3],
+      missingPlan,
+      blockedSubmitEnvelope
+    )
+    expect(blockedReplayGuard).toMatchObject({
+      readyForReplaySafeSubmit: false,
+      replayDecision: 'replay blocked: ref unavailable',
+    })
+    expect(blockedReplayGuard.stalePlanGuard).toMatch(
+      /reject submit if ref, action, policy/i
+    )
+    expect(managedSecretReplayGuardHasSecretMaterial(blockedReplayGuard)).toBe(
+      false
+    )
+
     const rotateLeakEvidence = buildSingleSecretLeakEvidence(
       managedSecretRows[0],
       rotatePlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -80,6 +80,22 @@ export type SingleSecretSubmitEnvelope = {
   blockedReason: string
 }
 
+export type SingleSecretReplayGuard = {
+  operationId: string
+  replayScope: string
+  planFingerprint: string
+  selectedRefBinding: string
+  actionBinding: string
+  idempotencyKey: string
+  correlationId: string
+  stalePlanGuard: string
+  replayDecision: string
+  readyForReplaySafeSubmit: boolean
+  omittedReplayFields: string[]
+  refBindingRows: string[]
+  safeReplayRows: string[]
+}
+
 export type SingleSecretLeakEvidence = {
   route: string
   selectedRef: string
@@ -1831,6 +1847,53 @@ export function buildSingleSecretSubmitEnvelope(
   }
 }
 
+export function buildSingleSecretReplayGuard(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  envelope: SingleSecretSubmitEnvelope
+): SingleSecretReplayGuard {
+  const slug = safeOperationSlug(plan.action, row)
+  const readyForReplaySafeSubmit = plan.canSubmit && envelope.readyForSubmit
+
+  return {
+    operationId: plan.operationId,
+    replayScope:
+      'single-secret operation id, selected ref, selected action, and broker-issued idempotency key',
+    planFingerprint: `plan-fp-${slug}-metadata-only`,
+    selectedRefBinding: `bound to selected ref ${row.ref}`,
+    actionBinding: `bound to ${managedSecretActionLabel(plan.action).toLowerCase()} action`,
+    idempotencyKey: envelope.idempotencyKey,
+    correlationId: envelope.correlationId,
+    stalePlanGuard:
+      'reject submit if ref, action, policy, capability, provider, audit, or plan fingerprint changed after dry-run',
+    replayDecision: readyForReplaySafeSubmit
+      ? 'first submit and retry are allowed only with the same operation id and idempotency key'
+      : `replay blocked: ${envelope.blockedReason}`,
+    readyForReplaySafeSubmit,
+    omittedReplayFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'auditReasonText',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'environmentValues',
+    ],
+    refBindingRows: [
+      'cross-ref replay rejected before broker mutation',
+      'cross-action replay rejected before broker mutation',
+      'stale dry-run fingerprint requires a fresh preview',
+    ],
+    safeReplayRows: [
+      'idempotency evidence uses operation id, correlation id, ref metadata, and action metadata only',
+      'retry status is operation-id scoped and never includes request or response bodies',
+      'operator audit reason text is represented by broker audit metadata only',
+    ],
+  }
+}
+
 export function buildSingleSecretLeakEvidence(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -3207,6 +3270,12 @@ export function managedSecretSubmitEnvelopeHasSecretMaterial(
   envelope: SingleSecretSubmitEnvelope
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(envelope))
+}
+
+export function managedSecretReplayGuardHasSecretMaterial(
+  guard: SingleSecretReplayGuard
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(guard))
 }
 
 export function managedSecretLeakEvidenceHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -518,7 +518,19 @@ test.describe('Secrets Broker browser coverage', () => {
         .first()
     ).toBeVisible()
     await expect(
-      page.getByText(/corr-reset-serviceadmin-session-signing-metadata-submit/i)
+      page
+        .getByText(/corr-reset-serviceadmin-session-signing-metadata-submit/i)
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/Replay and idempotency guard/i)).toBeVisible()
+    await expect(page.getByText(/No cross-ref replay/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /plan-fp-reset-serviceadmin-session-signing-metadata-only/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/cross-ref replay rejected before broker mutation/i)
     ).toBeVisible()
     await expect(page.getByText(/rotationReason/i).first()).toBeVisible()
     await expect(page.getByText(/providerCredentials/i).first()).toBeVisible()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only single-secret replay/idempotency guard for the existing dry-run submit path.
- Shows plan fingerprint, selected ref/action binding, idempotency/correlation metadata, stale plan guard, and retry decision in the Secrets page.
- Extends focused tests to prove stale/cross-ref replay prevention evidence stays metadata-only and free of forbidden secret material.

## Scope
- In scope: UI/model/test evidence for replay-safe single-secret submit metadata.
- Out of scope: backend mutation enforcement, real broker idempotency storage, raw value reveal, full #231 closure, and canonical demo release/pin/recycle before merge.

## Spec / contract / fixture impact
- Updated: no public API/schema change; this is metadata-only UI/model behavior around the existing stub Secrets management surface.
- Not required because: no Secrets Broker backend route or payload contract is changed.

## Nash invariant impact
- Invariant: raw secret values, provider credentials, request/response bodies, tokens, cookies, keys, recovery material, and environment values must not appear in submit/retry/replay evidence.
- Preservation proof: replay guard fields are allowlisted metadata, omitted unsafe fields are explicit, and the forbidden-material scanner covers ready and blocked replay guard states.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-replay-guard/focused-secrets-management-after-prettier.log` (20 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-replay-guard/format-check-after-prettier.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-replay-guard/lint-after-prettier.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-replay-guard/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-replay-guard/git-diff-check-after-prettier.log`
- PASS canonical health after local validation: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: normal PR review/merge rules.
- Evidence: focused UI/model/test slice; hosted checks pending after PR creation.

## Cleanup
- Branch cleanup after merge: delete `agent/issue-231-replay-guard` locally/remotely.
- Release-to-demo gate: required after merge because this changes demo-consumed Service Admin UI. Do not claim #231 done until Service Admin is released, core `@serviceadmin` pin is updated, canonical demo is recycled on port `17883`, and `npm run demo:verify-canonical` passes with matching expected/live tag.
