### PR TITLE
feat(secrets): add single-secret recovery decision evidence

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -69,6 +69,7 @@ import {
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
+  buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
   buildSingleSecretRotationPreview,
@@ -350,6 +351,15 @@ export function SecretsManagementPage({
   const singleEvidenceBundle =
     singleApplyResult && singleStatusMonitor
       ? buildSingleSecretEvidenceBundle(
+          selectedRow,
+          singleOperationPlan,
+          singleApplyResult,
+          singleStatusMonitor
+        )
+      : null
+  const singleRecoveryDecision =
+    singleApplyResult && singleStatusMonitor
+      ? buildSingleSecretRecoveryDecision(
           selectedRow,
           singleOperationPlan,
           singleApplyResult,
@@ -3271,6 +3281,136 @@ export function SecretsManagementPage({
                       </div>
                       <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
                         {singleEvidenceBundle.safeEvidenceRows.map((row) => (
+                          <li key={row}>{row}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                ) : null}
+                {singleRecoveryDecision ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <RotateCcw className='size-4 text-primary' />
+                      <div className='font-medium'>
+                        Recovery and retry decision
+                      </div>
+                      <Badge variant='secondary'>Metadata only</Badge>
+                      <Badge variant='outline'>
+                        {singleRecoveryDecision.badge}
+                      </Badge>
+                      <Badge
+                        variant={
+                          singleRecoveryDecision.retryAllowed
+                            ? 'default'
+                            : 'outline'
+                        }
+                      >
+                        {singleRecoveryDecision.retryAllowed
+                          ? 'Retry eligible'
+                          : 'Retry blocked'}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 lg:grid-cols-4'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Decision
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleRecoveryDecision.decisionId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Recovery ref
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleRecoveryDecision.recoveryRef}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Rollback ref
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleRecoveryDecision.rollbackRef}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Status
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleRecoveryDecision.statusEndpoint}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Operator action
+                        </div>
+                        <div className='mt-2'>
+                          {singleRecoveryDecision.operatorAction}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Broker action
+                        </div>
+                        <div className='mt-2'>
+                          {singleRecoveryDecision.brokerAction}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Retry ref
+                        </div>
+                        <div className='mt-2 break-all'>
+                          {singleRecoveryDecision.retryRef}
+                        </div>
+                        <div className='mt-2 text-muted-foreground'>
+                          {singleRecoveryDecision.freshPreviewRequired
+                            ? 'Fresh preview required'
+                            : 'No fresh preview required for this state'}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed recovery fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleRecoveryDecision.allowedRecoveryFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted recovery fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleRecoveryDecision.omittedRecoveryFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Safe recovery evidence
+                      </div>
+                      <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                        {singleRecoveryDecision.safeRecoveryRows.map((row) => (
                           <li key={row}>{row}</li>
                         ))}
                       </ul>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -15,6 +15,7 @@ import {
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
+  buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
   buildSingleSecretRotationPreview,
@@ -34,6 +35,7 @@ import {
   managedSecretHistoryReviewHasSecretMaterial,
   managedSecretLeakEvidenceHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
+  managedSecretRecoveryDecisionHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
   managedSecretRevealPreviewHasSecretMaterial,
   managedSecretReplayGuardHasSecretMaterial,
@@ -825,6 +827,21 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       screen.getByText(/localStorage\/sessionStorage evidence contains no/i)
     ).toBeVisible()
+    expect(screen.getByText(/Recovery and retry decision/i)).toBeVisible()
+    expect(
+      screen.getAllByText(
+        /recovery-reset-serviceadmin-session-signing-submitted/i
+      )[0]
+    ).toBeVisible()
+    expect(screen.getAllByText(/Retry blocked/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(/wait for broker terminal status before any retry/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Allowed recovery fields/i)).toBeVisible()
+    expect(screen.getByText(/Omitted recovery fields/i)).toBeVisible()
+    expect(
+      screen.getByText(/recovery decisions are derived from typed broker/i)
+    ).toBeVisible()
     expect(screen.getAllByText(/Audit event/i)[0]).toBeVisible()
     expect(
       screen.getAllByText(
@@ -1067,9 +1084,9 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/provider outage/i)[0]).toBeVisible()
     expect(screen.getByText(/Provider recovery evidence/i)).toBeVisible()
     expect(
-      screen.getByText(
+      screen.getAllByText(
         /provider-recovery-[a-z-]+-serviceadmin-session-signing-metadata/i
-      )
+      )[0]
     ).toBeVisible()
     expect(
       screen.getByText(/Broker-owned recovery metadata only/i)
@@ -1735,6 +1752,32 @@ describe('Secrets Broker secrets management page', () => {
     expect(failedResult.brokerFailureRef).not.toMatch(
       /credential|token|cookie|private key|request body|response body|DEMO_REVEAL_VALUE_42/i
     )
+    const failedMonitor = buildSingleSecretStatusMonitor(
+      managedSecretRows[0],
+      rotatePlan,
+      failedResult
+    )
+    const failedRecoveryDecision = buildSingleSecretRecoveryDecision(
+      managedSecretRows[0],
+      rotatePlan,
+      failedResult,
+      failedMonitor
+    )
+    expect(failedRecoveryDecision).toMatchObject({
+      outcome: 'failed',
+      badge: 'retry gated',
+      retryAllowed: true,
+      freshPreviewRequired: true,
+      operatorAction:
+        'retry only with the same operation id after reviewing broker failure metadata',
+      brokerAction:
+        'allow one operation-id retry when broker marks it retry-safe',
+      blocker: 'broker safe failure metadata review required',
+      retryRef: 'retry-reset-serviceadmin-session-signing-operation-id-only',
+    })
+    expect(
+      managedSecretRecoveryDecisionHasSecretMaterial(failedRecoveryDecision)
+    ).toBe(false)
 
     const historyEntry = buildSingleSecretOperationHistoryEntry(
       managedSecretRows[0],
@@ -2020,6 +2063,54 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretEvidenceBundleHasSecretMaterial(evidenceBundle)).toBe(
       false
     )
+    const recoveryDecision = buildSingleSecretRecoveryDecision(
+      managedSecretRows[0],
+      rotatePlan,
+      appliedResult,
+      statusMonitor
+    )
+    expect(recoveryDecision).toMatchObject({
+      decisionId: 'recovery-reset-serviceadmin-session-signing-applied',
+      operationId: rotatePlan.operationId,
+      outcome: 'applied',
+      badge: 'settled',
+      retryAllowed: false,
+      freshPreviewRequired: false,
+      operatorAction:
+        'review terminal metadata and dependent service freshness',
+      brokerAction: 'retain terminal status and audit metadata for review',
+      blocker: 'none',
+      rollbackRef:
+        'rotation-monitor-reset-serviceadmin-session-signing-metadata',
+      retryRef: 'retry blocked until a fresh broker preview is created',
+    })
+    expect(recoveryDecision.allowedRecoveryFields).toEqual(
+      expect.arrayContaining([
+        'decisionId',
+        'operationId',
+        'correlationId',
+        'auditEventId',
+        'retryAllowed',
+      ])
+    )
+    expect(recoveryDecision.omittedRecoveryFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBodyEcho',
+        'responseBodyEcho',
+        'providerCredentials',
+        'environmentValues',
+      ])
+    )
+    expect(recoveryDecision.safeRecoveryRows).toEqual(
+      expect.arrayContaining([
+        'recovery decisions are derived from typed broker metadata only',
+        'retry eligibility is scoped to operation id, ref, action, and correlation id',
+      ])
+    )
+    expect(
+      managedSecretRecoveryDecisionHasSecretMaterial(recoveryDecision)
+    ).toBe(false)
     const authRequiredMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],
       rotatePlan,
@@ -2045,6 +2136,32 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(
       managedSecretStatusMonitorHasSecretMaterial(authRequiredMonitor)
+    ).toBe(false)
+    const authRequiredRecoveryDecision = buildSingleSecretRecoveryDecision(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult,
+      authRequiredMonitor
+    )
+    expect(authRequiredRecoveryDecision).toMatchObject({
+      outcome: 'auth-required',
+      badge: 'fresh preview required',
+      retryAllowed: false,
+      freshPreviewRequired: true,
+      operatorAction:
+        'complete provider reauthentication, then create a fresh audited preview',
+      brokerAction: 'issue broker-owned provider challenge metadata only',
+      blocker: 'auth required',
+    })
+    expect(authRequiredRecoveryDecision.safeRecoveryRows).toEqual(
+      expect.arrayContaining([
+        'provider challenge stays broker-owned and omits auth material',
+      ])
+    )
+    expect(
+      managedSecretRecoveryDecisionHasSecretMaterial(
+        authRequiredRecoveryDecision
+      )
     ).toBe(false)
     const auditUnavailableTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -234,6 +234,26 @@ export type SingleSecretEvidenceBundle = {
   safeEvidenceRows: string[]
 }
 
+export type SingleSecretRecoveryDecision = {
+  decisionId: string
+  operationId: string
+  ref: string
+  outcome: SingleSecretOperationOutcome
+  badge: string
+  retryAllowed: boolean
+  freshPreviewRequired: boolean
+  operatorAction: string
+  brokerAction: string
+  blocker: string
+  recoveryRef: string
+  rollbackRef: string
+  retryRef: string
+  statusEndpoint: string
+  allowedRecoveryFields: string[]
+  omittedRecoveryFields: string[]
+  safeRecoveryRows: string[]
+}
+
 export type SingleSecretDecommissionPreview = {
   ref: string
   operationId: string
@@ -3213,6 +3233,132 @@ export function buildSingleSecretEvidenceBundle(
   }
 }
 
+export function buildSingleSecretRecoveryDecision(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  result: SingleSecretOperationResult,
+  monitor: SingleSecretStatusMonitor
+): SingleSecretRecoveryDecision {
+  const slug = safeOperationSlug(plan.action, row)
+  const retryAllowed = result.outcome === 'failed' && plan.action !== 'reveal'
+  const freshPreviewRequired =
+    result.outcome !== 'submitted' && result.outcome !== 'applied'
+
+  const operatorAction =
+    result.outcome === 'applied'
+      ? 'review terminal metadata and dependent service freshness'
+      : result.outcome === 'submitted'
+        ? 'wait for broker terminal status before any retry or recovery'
+        : result.outcome === 'auth-required'
+          ? 'complete provider reauthentication, then create a fresh audited preview'
+          : result.outcome === 'audit-unavailable'
+            ? 'restore audit persistence, then create a fresh audited preview'
+            : result.outcome === 'provider-unavailable'
+              ? 'restore provider connectivity or capability support, then create a fresh audited preview'
+              : result.outcome === 'policy-denied'
+                ? 'request least-privilege approval or choose a permitted policy, then create a fresh preview'
+                : result.outcome === 'stale-plan'
+                  ? 'discard the rejected dry-run token and create a fresh preview'
+                  : result.outcome === 'cancelled'
+                    ? 'resume only by creating a fresh preview with a new confirmation'
+                    : 'retry only with the same operation id after reviewing broker failure metadata'
+
+  const brokerAction =
+    result.outcome === 'submitted'
+      ? 'continue polling operation status by operation id'
+      : result.outcome === 'applied'
+        ? 'retain terminal status and audit metadata for review'
+        : result.outcome === 'auth-required'
+          ? 'issue broker-owned provider challenge metadata only'
+          : result.outcome === 'audit-unavailable'
+            ? 'block mutation until audit retention can be confirmed'
+            : result.outcome === 'provider-unavailable'
+              ? 'refresh provider health and capability metadata'
+              : result.outcome === 'policy-denied'
+                ? 'retain policy decision reference without mutation'
+                : result.outcome === 'stale-plan'
+                  ? 'reject replayed or expired dry-run token'
+                  : result.outcome === 'cancelled'
+                    ? 'retain cancellation metadata without broker mutation'
+                    : 'allow one operation-id retry when broker marks it retry-safe'
+
+  const blocker =
+    result.outcome === 'submitted' || result.outcome === 'applied'
+      ? 'none'
+      : result.outcome === 'failed'
+        ? 'broker safe failure metadata review required'
+        : result.outcome.replace('-', ' ')
+
+  return {
+    decisionId: `recovery-${slug}-${result.outcome}`,
+    operationId: result.operationId,
+    ref: row.ref,
+    outcome: result.outcome,
+    badge:
+      result.outcome === 'applied'
+        ? 'settled'
+        : result.outcome === 'submitted'
+          ? 'monitor'
+          : retryAllowed
+            ? 'retry gated'
+            : 'fresh preview required',
+    retryAllowed,
+    freshPreviewRequired,
+    operatorAction,
+    brokerAction,
+    blocker,
+    recoveryRef:
+      result.providerRecoveryRef ??
+      result.brokerFailureRef ??
+      `recovery-${slug}-${result.outcome}-metadata`,
+    rollbackRef: result.impactEvidence.rollbackRef,
+    retryRef: retryAllowed
+      ? monitor.retryToken
+      : 'retry blocked until a fresh broker preview is created',
+    statusEndpoint: monitor.statusEndpoint,
+    allowedRecoveryFields: [
+      'decisionId',
+      'operationId',
+      'ref',
+      'action',
+      'outcome',
+      'correlationId',
+      'auditEventId',
+      'statusBadge',
+      'retryAllowed',
+      'recoveryRef',
+      'rollbackRef',
+    ],
+    omittedRecoveryFields: [
+      'rawValue',
+      'requestBodyEcho',
+      'responseBodyEcho',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    safeRecoveryRows: [
+      'recovery decisions are derived from typed broker metadata only',
+      'retry eligibility is scoped to operation id, ref, action, and correlation id',
+      freshPreviewRequired
+        ? 'fresh preview is required before any new broker mutation attempt'
+        : 'terminal or pending state does not reuse a mutation payload',
+      result.outcome === 'policy-denied'
+        ? 'policy denial recovery requires a new authorized policy path'
+        : result.outcome === 'audit-unavailable'
+          ? 'audit recovery requires confirmed retention before a new preview'
+          : result.outcome === 'auth-required'
+            ? 'provider challenge stays broker-owned and omits auth material'
+            : result.outcome === 'provider-unavailable'
+              ? 'provider recovery stores connector metadata only'
+              : 'recovery evidence stores ids, refs, typed outcomes, and next actions only',
+    ],
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -3264,6 +3410,12 @@ export function managedSecretEvidenceBundleHasSecretMaterial(
   bundle: SingleSecretEvidenceBundle
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(bundle))
+}
+
+export function managedSecretRecoveryDecisionHasSecretMaterial(
+  decision: SingleSecretRecoveryDecision
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(decision))
 }
 
 export function managedSecretSubmitEnvelopeHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -501,9 +501,9 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
     await expect(page.getByText(/Broker status monitor/i)).toBeVisible()
     await expect(
-      page.getByText(
-        /GET \/v1\/management\/secret-operations\/\{operationId\}/i
-      )
+      page
+        .getByText(/GET \/v1\/management\/secret-operations\/\{operationId\}/i)
+        .first()
     ).toBeVisible()
     await expect(
       page.getByText(/poll every 5 seconds until broker terminal metadata/i)
@@ -564,6 +564,21 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(
       page.getByText(/track rotation operation id until provider status/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Recovery and retry decision/i)).toBeVisible()
+    await expect(
+      page
+        .getByText(/recovery-reset-serviceadmin-session-signing-submitted/i)
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/Retry blocked/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/wait for broker terminal status before any retry/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Allowed recovery fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted recovery fields/i)).toBeVisible()
+    await expect(
+      page.getByText(/recovery decisions are derived from typed broker/i)
     ).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('applied')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
@@ -696,9 +711,11 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText('Provider recovery evidence', { exact: true })
     ).toBeVisible()
     await expect(
-      page.getByText(
-        /provider-recovery-reset-serviceadmin-session-signing-metadata/i
-      )
+      page
+        .getByText(
+          /provider-recovery-reset-serviceadmin-session-signing-metadata/i
+        )
+        .first()
     ).toBeVisible()
     await expect(
       page.getByText(/Broker-owned recovery metadata only/i)
@@ -747,9 +764,11 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText('Broker failure evidence', { exact: true })
     ).toBeVisible()
     await expect(
-      page.getByText(
-        /broker-failure-reset-serviceadmin-session-signing-metadata/i
-      )
+      page
+        .getByText(
+          /broker-failure-reset-serviceadmin-session-signing-metadata/i
+        )
+        .first()
     ).toBeVisible()
     await expect(page.getByText(/provider_retryable_safe_error/i)).toBeVisible()
     await expect(
@@ -757,7 +776,7 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/terminal safe failure/i).first()).toBeVisible()
     await expect(
-      page.getByText(/retry-reset-serviceadmin-session-signing/i)
+      page.getByText(/retry-reset-serviceadmin-session-signing/i).first()
     ).toBeVisible()
     await expect(
       page.getByText(/retry only with the same operation id/i).first()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only `SingleSecretRecoveryDecision` model for single-secret operation outcomes.
- Shows recovery/retry decisions in the Secrets page after stub submit: operator action, broker action, retry eligibility, recovery/rollback refs, allowed fields, omitted unsafe fields, and safe evidence rows.
- Extends unit and browser coverage for submitted, applied, auth-required, failed, and existing duplicate safe-metadata rendering paths without raw value exposure.

## Scope
- In scope: Service Admin UI/model/test advancement for single-secret recovery and retry guidance.
- Out of scope: production broker mutation implementation, backend contract changes, full #231 completion, and bulk campaign behavior changes.

## Spec / contract / fixture impact
- Not required because this is a stubbed Service Admin UI/model slice and does not change a public backend API or service manifest.

## Nash invariant impact
- Invariant: secret operation surfaces must stay metadata-only and fail closed.
- Preservation proof: recovery decisions are derived from operation ids, refs, typed outcomes, correlation/audit refs, and next-action metadata only; tests assert omitted raw values, request/response bodies, provider credentials/tokens, cookies, keys, recovery material, and environment values.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/focused-secrets-management-after-format.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/playwright-rotate-recovery-after-format.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/format-check-pass.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/lint.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-recovery-decision/git-diff-check-pass.log`
- PASS canonical preflight during selection: Service Admin `http://192.168.1.53:17700/` HTTP 200; runtime `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.

## Approval trail
- Required: no special approval documented for this focused UI/test advancement.
- Evidence: existing #231 issue trail has prior focused slices merged under the same PR-ready/release-to-demo pattern.

## Cleanup
- Branch `agent/issue-231-single-secret-recovery-decision` is pushed.
- Release-to-demo gate applies after merge/release/pin/recycle because this Service Admin UI is demo-consumed; this PR does not claim #231 completion or demo-current status.