### PR TITLE
feat(secrets): add single-secret operator handoff

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -69,6 +69,7 @@ import {
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
+  buildSingleSecretOperatorHandoff,
   buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
@@ -364,6 +365,16 @@ export function SecretsManagementPage({
           singleOperationPlan,
           singleApplyResult,
           singleStatusMonitor
+        )
+      : null
+  const singleOperatorHandoff =
+    singleApplyResult && singleStatusMonitor && singleRecoveryDecision
+      ? buildSingleSecretOperatorHandoff(
+          selectedRow,
+          singleOperationPlan,
+          singleApplyResult,
+          singleStatusMonitor,
+          singleRecoveryDecision
         )
       : null
   const singleHistoryReview = useMemo(
@@ -3414,6 +3425,135 @@ export function SecretsManagementPage({
                           <li key={row}>{row}</li>
                         ))}
                       </ul>
+                    </div>
+                  </div>
+                ) : null}
+                {singleOperatorHandoff ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <ShieldCheck className='size-4 text-primary' />
+                      <div className='font-medium'>Operator handoff packet</div>
+                      <Badge variant='secondary'>Shareable metadata</Badge>
+                      <Badge variant='outline'>
+                        {singleOperatorHandoff.badge}
+                      </Badge>
+                      <Badge
+                        variant={
+                          singleOperatorHandoff.severity === 'critical'
+                            ? 'destructive'
+                            : singleOperatorHandoff.severity === 'warning'
+                              ? 'secondary'
+                              : 'outline'
+                        }
+                      >
+                        {singleOperatorHandoff.lane}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 md:grid-cols-4'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Handoff
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleOperatorHandoff.handoffId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Owner
+                        </div>
+                        <div className='mt-1'>
+                          {singleOperatorHandoff.owner}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Outcome
+                        </div>
+                        <div className='mt-1'>
+                          {singleOperatorHandoff.outcome}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Blocker
+                        </div>
+                        <div className='mt-1'>
+                          {singleOperatorHandoff.blockedReason ?? 'none'}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Required action
+                        </div>
+                        <div className='mt-2'>
+                          {singleOperatorHandoff.requiredAction}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Validator note
+                        </div>
+                        <div className='mt-2'>
+                          {singleOperatorHandoff.validatorNote}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3 md:col-span-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Shareable evidence refs
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOperatorHandoff.shareableEvidenceRefs.map(
+                            (ref) => (
+                              <Badge key={ref} variant='outline'>
+                                {ref}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed handoff fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOperatorHandoff.allowedHandoffFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted handoff fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOperatorHandoff.omittedHandoffFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe handoff evidence
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleOperatorHandoff.safeHandoffRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
                     </div>
                   </div>
                 ) : null}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -14,6 +14,7 @@ import {
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
+  buildSingleSecretOperatorHandoff,
   buildSingleSecretPolicyPreview,
   buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
@@ -34,6 +35,7 @@ import {
   managedSecretEvidenceBundleHasSecretMaterial,
   managedSecretHistoryReviewHasSecretMaterial,
   managedSecretLeakEvidenceHasSecretMaterial,
+  managedSecretOperatorHandoffHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRecoveryDecisionHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
@@ -2111,6 +2113,59 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretRecoveryDecisionHasSecretMaterial(recoveryDecision)
     ).toBe(false)
+    const operatorHandoff = buildSingleSecretOperatorHandoff(
+      managedSecretRows[0],
+      rotatePlan,
+      appliedResult,
+      statusMonitor,
+      recoveryDecision
+    )
+    expect(operatorHandoff).toMatchObject({
+      handoffId: 'handoff-reset-serviceadmin-session-signing-applied',
+      operationId: rotatePlan.operationId,
+      outcome: 'applied',
+      lane: 'settled',
+      owner: 'operator',
+      severity: 'info',
+      badge: 'closed',
+      blockedReason: null,
+      requiredAction: 'review terminal status and no further mutation action',
+    })
+    expect(operatorHandoff.shareableEvidenceRefs).toEqual(
+      expect.arrayContaining([
+        'audit-reset-serviceadmin-session-signing-preview',
+        'corr-reset-serviceadmin-session-signing-applied',
+        'impact-reset-serviceadmin-session-signing-applied-metadata',
+        statusMonitor.statusEndpoint,
+      ])
+    )
+    expect(operatorHandoff.allowedHandoffFields).toEqual(
+      expect.arrayContaining([
+        'handoffId',
+        'operationId',
+        'auditEventId',
+        'correlationId',
+        'statusEndpoint',
+      ])
+    )
+    expect(operatorHandoff.omittedHandoffFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'screenshotsWithVisibleValues',
+      ])
+    )
+    expect(operatorHandoff.safeHandoffRows).toEqual(
+      expect.arrayContaining([
+        'operator handoffs use ids, refs, typed outcomes, owner lanes, and audit metadata only',
+        'handoff evidence can be copied into issue or audit notes without raw secret material',
+      ])
+    )
+    expect(managedSecretOperatorHandoffHasSecretMaterial(operatorHandoff)).toBe(
+      false
+    )
     const authRequiredMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],
       rotatePlan,
@@ -2162,6 +2217,33 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretRecoveryDecisionHasSecretMaterial(
         authRequiredRecoveryDecision
       )
+    ).toBe(false)
+    const authRequiredHandoff = buildSingleSecretOperatorHandoff(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult,
+      authRequiredMonitor,
+      authRequiredRecoveryDecision
+    )
+    expect(authRequiredHandoff).toMatchObject({
+      outcome: 'auth-required',
+      lane: 'provider-auth',
+      owner: 'provider owner',
+      severity: 'warning',
+      badge: 'owner action required',
+      blockedReason: 'auth required',
+      requiredAction:
+        'complete provider reauthentication, then create a fresh audited preview',
+      validatorNote:
+        'blocked state must be revalidated with a fresh preview before another mutation attempt',
+    })
+    expect(authRequiredHandoff.safeHandoffRows).toEqual(
+      expect.arrayContaining([
+        'blocked handoffs require owner action and a fresh broker preview before another submit',
+      ])
+    )
+    expect(
+      managedSecretOperatorHandoffHasSecretMaterial(authRequiredHandoff)
     ).toBe(false)
     const auditUnavailableTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -254,6 +254,32 @@ export type SingleSecretRecoveryDecision = {
   safeRecoveryRows: string[]
 }
 
+export type SingleSecretOperatorHandoff = {
+  handoffId: string
+  operationId: string
+  ref: string
+  outcome: SingleSecretOperationOutcome
+  lane:
+    | 'monitor'
+    | 'settled'
+    | 'policy-review'
+    | 'provider-auth'
+    | 'audit-recovery'
+    | 'provider-recovery'
+    | 'broker-review'
+    | 'fresh-preview'
+  badge: string
+  owner: string
+  severity: 'info' | 'warning' | 'critical'
+  requiredAction: string
+  shareableEvidenceRefs: string[]
+  blockedReason: string | null
+  validatorNote: string
+  allowedHandoffFields: string[]
+  omittedHandoffFields: string[]
+  safeHandoffRows: string[]
+}
+
 export type SingleSecretDecommissionPreview = {
   ref: string
   operationId: string
@@ -3359,6 +3385,134 @@ export function buildSingleSecretRecoveryDecision(
   }
 }
 
+export function buildSingleSecretOperatorHandoff(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  result: SingleSecretOperationResult,
+  monitor: SingleSecretStatusMonitor,
+  decision: SingleSecretRecoveryDecision
+): SingleSecretOperatorHandoff {
+  const slug = safeOperationSlug(plan.action, row)
+  const lane: SingleSecretOperatorHandoff['lane'] =
+    result.outcome === 'submitted'
+      ? 'monitor'
+      : result.outcome === 'applied'
+        ? 'settled'
+        : result.outcome === 'policy-denied'
+          ? 'policy-review'
+          : result.outcome === 'auth-required'
+            ? 'provider-auth'
+            : result.outcome === 'audit-unavailable'
+              ? 'audit-recovery'
+              : result.outcome === 'provider-unavailable'
+                ? 'provider-recovery'
+                : result.outcome === 'stale-plan' ||
+                    result.outcome === 'cancelled'
+                  ? 'fresh-preview'
+                  : 'broker-review'
+
+  const owner =
+    lane === 'monitor' || lane === 'settled'
+      ? 'operator'
+      : lane === 'policy-review'
+        ? 'policy approver'
+        : lane === 'provider-auth'
+          ? 'provider owner'
+          : lane === 'audit-recovery'
+            ? 'audit operator'
+            : lane === 'provider-recovery'
+              ? 'provider operator'
+              : lane === 'fresh-preview'
+                ? 'operator'
+                : 'broker operator'
+
+  const severity: SingleSecretOperatorHandoff['severity'] =
+    lane === 'settled' || lane === 'monitor'
+      ? 'info'
+      : lane === 'audit-recovery' || lane === 'provider-recovery'
+        ? 'critical'
+        : 'warning'
+
+  const requiredAction =
+    lane === 'settled'
+      ? 'review terminal status and no further mutation action'
+      : lane === 'monitor'
+        ? 'keep polling the broker status endpoint until terminal metadata arrives'
+        : decision.operatorAction
+
+  return {
+    handoffId: `handoff-${slug}-${result.outcome}`,
+    operationId: result.operationId,
+    ref: row.ref,
+    outcome: result.outcome,
+    lane,
+    badge:
+      lane === 'settled'
+        ? 'closed'
+        : lane === 'monitor'
+          ? 'monitoring'
+          : lane === 'fresh-preview'
+            ? 'new preview'
+            : 'owner action required',
+    owner,
+    severity,
+    requiredAction,
+    shareableEvidenceRefs: [
+      result.auditFeedback.auditEventId,
+      result.auditFeedback.correlationId,
+      result.impactEvidence.impactRef,
+      result.impactEvidence.rollbackRef,
+      decision.recoveryRef,
+      monitor.statusEndpoint,
+    ],
+    blockedReason:
+      result.outcome === 'submitted' || result.outcome === 'applied'
+        ? null
+        : decision.blocker,
+    validatorNote:
+      result.outcome === 'applied'
+        ? 'terminal success can be validated from audit id, correlation id, impact ref, and status endpoint only'
+        : result.outcome === 'submitted'
+          ? 'pending state remains evidence-only until broker terminal status is observed'
+          : 'blocked state must be revalidated with a fresh preview before another mutation attempt',
+    allowedHandoffFields: [
+      'handoffId',
+      'operationId',
+      'ref',
+      'action',
+      'outcome',
+      'lane',
+      'owner',
+      'auditEventId',
+      'correlationId',
+      'statusEndpoint',
+      'impactRef',
+      'rollbackRef',
+      'recoveryRef',
+    ],
+    omittedHandoffFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+    ],
+    safeHandoffRows: [
+      'operator handoffs use ids, refs, typed outcomes, owner lanes, and audit metadata only',
+      'handoff evidence can be copied into issue or audit notes without raw secret material',
+      result.outcome === 'submitted' || result.outcome === 'applied'
+        ? 'successful or pending handoffs do not include mutation payload echoes'
+        : 'blocked handoffs require owner action and a fresh broker preview before another submit',
+      `required action: ${requiredAction}`,
+    ],
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -3416,6 +3570,12 @@ export function managedSecretRecoveryDecisionHasSecretMaterial(
   decision: SingleSecretRecoveryDecision
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(decision))
+}
+
+export function managedSecretOperatorHandoffHasSecretMaterial(
+  handoff: SingleSecretOperatorHandoff
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(handoff))
 }
 
 export function managedSecretSubmitEnvelopeHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -293,9 +293,11 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/Delete\/decommission impact evidence/i)
     ).toBeVisible()
     await expect(
-      page.getByText(
-        /impact-delete-serviceadmin-session-signing-applied-metadata/i
-      )
+      page
+        .getByText(
+          /impact-delete-serviceadmin-session-signing-applied-metadata/i
+        )
+        .first()
     ).toBeVisible()
     await expect(
       page
@@ -352,9 +354,11 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/Policy assignment impact evidence/i)
     ).toBeVisible()
     await expect(
-      page.getByText(
-        /impact-policy-serviceadmin-session-signing-applied-metadata/i
-      )
+      page
+        .getByText(
+          /impact-policy-serviceadmin-session-signing-applied-metadata/i
+        )
+        .first()
     ).toBeVisible()
     await expect(
       page
@@ -579,6 +583,21 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(page.getByText(/Omitted recovery fields/i)).toBeVisible()
     await expect(
       page.getByText(/recovery decisions are derived from typed broker/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Operator handoff packet/i)).toBeVisible()
+    await expect(page.getByText(/Shareable metadata/i)).toBeVisible()
+    await expect(
+      page
+        .getByText(/handoff-reset-serviceadmin-session-signing-submitted/i)
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/Shareable evidence refs/i)).toBeVisible()
+    await expect(page.getByText(/Allowed handoff fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted handoff fields/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /handoff evidence can be copied into issue or audit notes/i
+      )
     ).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('applied')
     await page.getByLabel(/Stub API state/i).selectOption('ready')


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only single-secret operator handoff model after broker submit outcomes.
- Render an Operator handoff packet with owner lane, severity, required action, validator note, shareable evidence refs, and allowed/omitted fields.
- Extend focused unit and browser coverage to prove the handoff stays safe and visible after a rotate preview submit.

## Scope
- In scope: single-secret operation outcome handoff metadata and UI evidence for the existing Secrets workflow stub surface.
- Out of scope: production Secrets Broker mutation API wiring, raw value reveal/export, and full #231 completion.

## Spec / contract / fixture impact
- Updated: typed UI model only in `src/features/secrets-broker/secrets-management.ts`.
- Not required because: this does not change an external API/schema; it exposes safe metadata from the existing stub workflow.

## Nash invariant impact
- Invariant: no raw secret values, provider credentials, tokens, private keys, cookies, recovery material, env values, request bodies, or response bodies are rendered or persisted by the Secrets workflow.
- Preservation proof: handoff fields are allowlisted; omitted fields are shown explicitly; unit checks run `managedSecretOperatorHandoffHasSecretMaterial(...) === false`; browser coverage asserts shareable metadata only.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/unit-secrets-management-after-format.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/playwright-rotate-handoff-after-format.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/format-check-pass.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/lint.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/build.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-operator-handoff/git-diff-check.log`

## Approval trail
- Required: no special approval documented for this focused UI/test advancement; merge when hosted checks are green and repo rules allow.
- Evidence: local validation above; hosted `install-lint-build` pending after PR open.

## Cleanup
- Branch `agent/issue-231-single-secret-operator-handoff` tracks origin.
- Release-to-demo gate is pending after merge/release/pin/recycle because Service Admin is demo-consumed.