### PR TITLE
feat(secrets): add single-secret confirmation receipt

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -64,6 +64,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretConfirmationReceipt,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
@@ -280,6 +281,13 @@ export function SecretsManagementPage({
   const singleSubmitEnvelope = buildSingleSecretSubmitEnvelope(
     selectedRow,
     singleOperationPlan
+  )
+  const singleConfirmationReceipt = buildSingleSecretConfirmationReceipt(
+    selectedRow,
+    singleOperationPlan,
+    singleSubmitEnvelope,
+    auditReason,
+    confirmed
   )
   const singleReplayGuard = buildSingleSecretReplayGuard(
     selectedRow,
@@ -2817,6 +2825,111 @@ export function SecretsManagementPage({
               </ul>
               <div className='mt-3 rounded-md border bg-muted/40 p-3'>
                 {stubMutationPreview.nextStep}
+              </div>
+            </div>
+
+            <div className='rounded-lg border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <ShieldCheck className='size-4 text-primary' />
+                <div className='font-medium'>Confirmation receipt</div>
+                <Badge
+                  variant={
+                    singleConfirmationReceipt.accepted ? 'default' : 'secondary'
+                  }
+                >
+                  {singleConfirmationReceipt.accepted ? 'Accepted' : 'Blocked'}
+                </Badge>
+                <Badge variant='outline'>Metadata only</Badge>
+              </div>
+              <div className='grid gap-3 md:grid-cols-3'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Receipt
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleConfirmationReceipt.receiptId}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Audit reason
+                  </div>
+                  <div className='mt-1'>
+                    {singleConfirmationReceipt.auditReasonStatus}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Confirmation
+                  </div>
+                  <div className='mt-1'>
+                    {singleConfirmationReceipt.confirmationStatus}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Dry-run binding
+                  </div>
+                  <div className='mt-1'>
+                    {singleConfirmationReceipt.dryRunBinding}
+                  </div>
+                  <div className='mt-2 text-muted-foreground'>
+                    Blocker: {singleConfirmationReceipt.blockedReason}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Policy and capability
+                  </div>
+                  <div className='mt-1'>
+                    {singleConfirmationReceipt.policyBinding}
+                  </div>
+                  <div className='mt-2 text-muted-foreground'>
+                    {singleConfirmationReceipt.capabilityBinding}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Allowed receipt fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleConfirmationReceipt.allowedReceiptFields.map(
+                      (field) => (
+                        <Badge key={field} variant='outline'>
+                          {field}
+                        </Badge>
+                      )
+                    )}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Omitted receipt fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleConfirmationReceipt.omittedReceiptFields.map(
+                      (field) => (
+                        <Badge key={field} variant='secondary'>
+                          {field}
+                        </Badge>
+                      )
+                    )}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Safe receipt evidence
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleConfirmationReceipt.safeReceiptRows.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             </div>
 

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -10,6 +10,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretConfirmationReceipt,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
@@ -30,6 +31,7 @@ import {
   managedSecretBulkApplyResultHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
+  managedSecretConfirmationReceiptHasSecretMaterial,
   managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretEditPreviewHasSecretMaterial,
   managedSecretEvidenceBundleHasSecretMaterial,
@@ -111,6 +113,10 @@ describe('Secrets Broker secrets management page', () => {
       )[0]
     ).toBeVisible()
     expect(screen.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    expect(screen.getAllByText(/Confirmation receipt/i)[0]).toBeVisible()
+    expect(screen.getByText(/receipt-metadata-serviceadmin/i)).toBeVisible()
+    expect(screen.getByText(/confirmation receipt blocked/i)).toBeVisible()
+    expect(screen.getAllByText(/auditReasonText/i)[0]).toBeVisible()
     expect(screen.getByText(/Replay and idempotency guard/i)).toBeVisible()
     expect(screen.getByText(/No cross-ref replay/i)).toBeVisible()
     expect(screen.getByText(/plan-fp-metadata/i)).toBeVisible()
@@ -1002,12 +1008,22 @@ describe('Secrets Broker secrets management page', () => {
       screen.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeDisabled()
 
+    await user.click(
+      screen.getAllByRole('button', { name: /Reset\/rotate dry-run/i })[0]
+    )
+
     await user.type(
       screen.getByLabelText(/Audit reason for stub preview/i),
       'operator requested rotation preview'
     )
     await user.click(screen.getByLabelText(/I confirm this is a stub preview/i))
     expect(screen.getByText(/Stub apply can be simulated/i)).toBeVisible()
+    expect(screen.getByText(/confirmation receipt accepted/i)).toBeVisible()
+    expect(screen.getByText(/accepted as broker audit metadata/i)).toBeVisible()
+    expect(
+      screen.getByText(/explicit stub preview confirmation accepted/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Blocker: none/i)).toBeVisible()
     expect(
       screen.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeEnabled()
@@ -1354,6 +1370,49 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretSubmitEnvelopeHasSecretMaterial(rotateSubmitEnvelope)
     ).toBe(false)
+    const rotateReceipt = buildSingleSecretConfirmationReceipt(
+      managedSecretRows[0],
+      rotatePlan,
+      rotateSubmitEnvelope,
+      'operator requested rotation preview',
+      true
+    )
+    expect(rotateReceipt).toMatchObject({
+      receiptId: 'receipt-reset-serviceadmin-session-signing-accepted',
+      operationId: rotatePlan.operationId,
+      accepted: true,
+      auditReasonStatus: 'accepted as broker audit metadata',
+      confirmationStatus: 'explicit stub preview confirmation accepted',
+      blockedReason: 'none',
+    })
+    expect(rotateReceipt.allowedReceiptFields).toEqual(
+      expect.arrayContaining([
+        'receiptId',
+        'operationId',
+        'auditReasonStatus',
+        'confirmationStatus',
+        'idempotencyKey',
+        'correlationId',
+      ])
+    )
+    expect(rotateReceipt.omittedReceiptFields).toEqual(
+      expect.arrayContaining([
+        'auditReasonText',
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+      ])
+    )
+    expect(rotateReceipt.safeReceiptRows).toEqual(
+      expect.arrayContaining([
+        'confirmation receipt accepted; submit remains operation-id scoped',
+        'audit reason text is represented only by broker audit metadata status',
+      ])
+    )
+    expect(
+      managedSecretConfirmationReceiptHasSecretMaterial(rotateReceipt)
+    ).toBe(false)
     const rotateReplayGuard = buildSingleSecretReplayGuard(
       managedSecretRows[0],
       rotatePlan,
@@ -1405,6 +1464,29 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretRows[3],
       missingPlan
     )
+    const blockedReceipt = buildSingleSecretConfirmationReceipt(
+      managedSecretRows[3],
+      missingPlan,
+      blockedSubmitEnvelope,
+      'operator requested rotation preview',
+      true
+    )
+    expect(blockedReceipt).toMatchObject({
+      receiptId: 'receipt-reset-payments-signing-ref-blocked',
+      accepted: false,
+      auditReasonStatus: 'accepted as broker audit metadata',
+      confirmationStatus: 'explicit stub preview confirmation accepted',
+      blockedReason: 'ref unavailable',
+    })
+    expect(blockedReceipt.safeReceiptRows).toEqual(
+      expect.arrayContaining([
+        'confirmation receipt blocked before broker mutation',
+        'submit envelope blocked: ref unavailable',
+      ])
+    )
+    expect(
+      managedSecretConfirmationReceiptHasSecretMaterial(blockedReceipt)
+    ).toBe(false)
     const blockedReplayGuard = buildSingleSecretReplayGuard(
       managedSecretRows[3],
       missingPlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -80,6 +80,23 @@ export type SingleSecretSubmitEnvelope = {
   blockedReason: string
 }
 
+export type SingleSecretConfirmationReceipt = {
+  receiptId: string
+  operationId: string
+  ref: string
+  action: ManagedSecretAction
+  accepted: boolean
+  auditReasonStatus: string
+  confirmationStatus: string
+  dryRunBinding: string
+  policyBinding: string
+  capabilityBinding: string
+  blockedReason: string
+  allowedReceiptFields: string[]
+  omittedReceiptFields: string[]
+  safeReceiptRows: string[]
+}
+
 export type SingleSecretReplayGuard = {
   operationId: string
   replayScope: string
@@ -1893,6 +1910,77 @@ export function buildSingleSecretSubmitEnvelope(
   }
 }
 
+export function buildSingleSecretConfirmationReceipt(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  envelope: SingleSecretSubmitEnvelope,
+  auditReason: string,
+  confirmed: boolean
+): SingleSecretConfirmationReceipt {
+  const slug = safeOperationSlug(plan.action, row)
+  const hasAuditReason = auditReason.trim().length >= 8
+  const accepted = plan.canSubmit && envelope.readyForSubmit
+  const metadataOnly = plan.action === 'metadata'
+
+  return {
+    receiptId: `receipt-${slug}-${accepted ? 'accepted' : 'blocked'}`,
+    operationId: plan.operationId,
+    ref: row.ref,
+    action: plan.action,
+    accepted,
+    auditReasonStatus: metadataOnly
+      ? 'not required for metadata view'
+      : hasAuditReason
+        ? 'accepted as broker audit metadata'
+        : 'missing or too short',
+    confirmationStatus: metadataOnly
+      ? 'not required for metadata view'
+      : confirmed
+        ? 'explicit stub preview confirmation accepted'
+        : 'explicit confirmation missing',
+    dryRunBinding:
+      'receipt binds the latest dry-run operation id, selected ref, action, and idempotency key',
+    policyBinding: plan.policyDecision,
+    capabilityBinding: plan.capabilityDecision,
+    blockedReason: accepted ? 'none' : envelope.blockedReason,
+    allowedReceiptFields: [
+      'receiptId',
+      'operationId',
+      'ref',
+      'action',
+      'auditReasonStatus',
+      'confirmationStatus',
+      'capabilityDecision',
+      'policyDecision',
+      'idempotencyKey',
+      'correlationId',
+    ],
+    omittedReceiptFields: [
+      'auditReasonText',
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    safeReceiptRows: [
+      accepted
+        ? 'confirmation receipt accepted; submit remains operation-id scoped'
+        : 'confirmation receipt blocked before broker mutation',
+      'audit reason text is represented only by broker audit metadata status',
+      'operator confirmation is recorded as a boolean gate, not as free-form payload',
+      'receipt evidence can be copied to audit notes without raw secret material',
+      envelope.readyForSubmit
+        ? 'submit envelope is ready after final broker revalidation'
+        : `submit envelope blocked: ${envelope.blockedReason}`,
+    ],
+  }
+}
+
 export function buildSingleSecretReplayGuard(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -3582,6 +3670,12 @@ export function managedSecretSubmitEnvelopeHasSecretMaterial(
   envelope: SingleSecretSubmitEnvelope
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(envelope))
+}
+
+export function managedSecretConfirmationReceiptHasSecretMaterial(
+  receipt: SingleSecretConfirmationReceipt
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(receipt))
 }
 
 export function managedSecretReplayGuardHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -413,6 +413,15 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
     await expect(
+      page.getByText('Confirmation receipt', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page.getByText(/receipt-reset-serviceadmin-session-signing-blocked/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/confirmation receipt blocked before broker mutation/i)
+    ).toBeVisible()
+    await expect(
       page.getByText(/Route and storage leak evidence/i)
     ).toBeVisible()
     await expect(page.getByText(/No raw payload/i)).toBeVisible()
@@ -434,6 +443,13 @@ test.describe('Secrets Broker browser coverage', () => {
       .fill('operator requested preview')
     await page.getByLabel(/I confirm this is a stub preview/i).check()
     await expect(page.getByText(/Stub apply can be simulated/i)).toBeVisible()
+    await expect(
+      page.getByText(/receipt-reset-serviceadmin-session-signing-accepted/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(/accepted as broker audit metadata/i)
+    ).toBeVisible()
+    await expect(page.getByText(/confirmation receipt accepted/i)).toBeVisible()
     await expect(
       page.getByRole('button', { name: /Simulate stub apply/i })
     ).toBeEnabled()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Added a metadata-only single-secret confirmation receipt to the Secrets Broker > Secrets preview gate.
- Shows accepted/blocked receipt state, audit reason status, confirmation status, dry-run binding, policy/capability binding, allowed fields, omitted fields, and safe receipt evidence before stub apply.
- Extended unit and browser coverage so accepted and blocked receipt states remain raw-value safe.

## Scope
- In scope: one bounded single-secret operator confirmation/receipt slice for the existing stub preview gate.
- Out of scope: completing all #231 edit/reveal/rotate/delete/policy workflow requirements, production Secrets Broker mutation wiring, and bulk workflow changes.

## Spec / contract / fixture impact
- Updated: Service Admin UI model/test fixture behavior for the existing deterministic Secrets page stub.
- Not required because: this does not change public backend API contracts or service manifests.

## Service Lasso invariant impact
- Invariant: no raw secret values, provider credentials, tokens, cookies, private keys, recovery material, raw env values, request bodies, or response bodies appear in UI state, routes, tests, screenshots, support evidence, or logs.
- Preservation proof: new receipt model has allowlisted fields and explicit omitted field evidence; tests cover `managedSecretConfirmationReceiptHasSecretMaterial(...) === false` for accepted and blocked receipts.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/unit-secrets-management-after-fix.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/playwright-rotate-receipt.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/lint.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/build.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-20260625T223757/issue-231-confirmation-receipt/git-diff-check.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test slice.
- Evidence: PR is non-draft and will use hosted checks before merge.

## Cleanup
- Branch: `agent/issue-231-confirmation-receipt`
- Release-to-demo gate: applies after merge because Service Admin is demo-consumed. Do not claim #231 done until the Service Admin release is published, core `@serviceadmin` pin is updated/merged, canonical demo is recycled on port `17883`, and `npm run demo:verify-canonical` plus live tag checks prove the exact release is installed.