### PR TITLE
feat(secrets): add single-secret export guard

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -64,6 +64,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretExportGuardrail,
   buildSingleSecretConfirmationReceipt,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
@@ -295,6 +296,11 @@ export function SecretsManagementPage({
     singleSubmitEnvelope
   )
   const singleLeakEvidence = buildSingleSecretLeakEvidence(
+    selectedRow,
+    singleOperationPlan,
+    singleSubmitEnvelope
+  )
+  const singleExportGuardrail = buildSingleSecretExportGuardrail(
     selectedRow,
     singleOperationPlan,
     singleSubmitEnvelope
@@ -2040,6 +2046,125 @@ export function SecretsManagementPage({
                 <div className='mt-3 text-xs break-all text-muted-foreground'>
                   Console event: {singleLeakEvidence.consoleEvent}
                 </div>
+              </div>
+            </div>
+            <div className='rounded-md border p-3'>
+              <div className='mb-3 flex flex-wrap items-center gap-2'>
+                <ListChecks className='size-4 text-primary' />
+                <div className='font-medium'>Export and copy guardrail</div>
+                <Badge variant='secondary'>Metadata only</Badge>
+                <Badge variant='outline'>Raw export blocked</Badge>
+              </div>
+              <div className='grid gap-3 lg:grid-cols-4'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Guard
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleExportGuardrail.exportGuardId}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Operation
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleExportGuardrail.operationId}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Ref / action
+                  </div>
+                  <div className='mt-1 break-all'>
+                    {singleExportGuardrail.ref}
+                  </div>
+                  <div className='mt-2 text-xs text-muted-foreground'>
+                    {singleExportGuardrail.action}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Copy status
+                  </div>
+                  <div className='mt-1'>{singleExportGuardrail.copyStatus}</div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Metadata export
+                  </div>
+                  <div className='mt-2'>
+                    {singleExportGuardrail.metadataExportStatus}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Raw export
+                  </div>
+                  <div className='mt-2'>
+                    {singleExportGuardrail.rawExportStatus}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Allowed export fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleExportGuardrail.allowedExportFields.map((field) => (
+                      <Badge key={field} variant='outline'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Blocked export fields
+                  </div>
+                  <div className='mt-2 flex flex-wrap gap-1'>
+                    {singleExportGuardrail.blockedExportFields.map((field) => (
+                      <Badge key={field} variant='secondary'>
+                        {field}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Export routes
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleExportGuardrail.exportRoutes.map((route) => (
+                      <li key={route}>{route}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className='rounded-md border bg-muted/30 p-3'>
+                  <div className='text-xs font-medium text-muted-foreground uppercase'>
+                    Storage guardrails
+                  </div>
+                  <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                    {singleExportGuardrail.storageGuardrails.map((row) => (
+                      <li key={row}>{row}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+              <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                <div className='text-xs font-medium text-muted-foreground uppercase'>
+                  Safe export evidence
+                </div>
+                <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                  {singleExportGuardrail.safeExportRows.map((row) => (
+                    <li key={row}>{row}</li>
+                  ))}
+                </ul>
               </div>
             </div>
             {revealPreview ? (

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -10,6 +10,7 @@ import {
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
   buildSingleSecretEvidenceBundle,
+  buildSingleSecretExportGuardrail,
   buildSingleSecretConfirmationReceipt,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
@@ -35,6 +36,7 @@ import {
   managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretEditPreviewHasSecretMaterial,
   managedSecretEvidenceBundleHasSecretMaterial,
+  managedSecretExportGuardrailHasSecretMaterial,
   managedSecretHistoryReviewHasSecretMaterial,
   managedSecretLeakEvidenceHasSecretMaterial,
   managedSecretOperatorHandoffHasSecretMaterial,
@@ -121,6 +123,11 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getByText(/No cross-ref replay/i)).toBeVisible()
     expect(screen.getByText(/plan-fp-metadata/i)).toBeVisible()
     expect(screen.getByText(/Route and storage leak evidence/i)).toBeVisible()
+    expect(screen.getByText(/Export and copy guardrail/i)).toBeVisible()
+    expect(screen.getByText(/Raw export blocked/i)).toBeVisible()
+    expect(
+      screen.getByText(/spreadsheet-style payload export are unavailable/i)
+    ).toBeVisible()
     expect(screen.getByText(/Submit blocked/i)).toBeVisible()
     expect(screen.getByText(/No raw payload/i)).toBeVisible()
     expect(screen.getByText(/Allowed route params/i)).toBeVisible()
@@ -1546,6 +1553,53 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretLeakEvidenceHasSecretMaterial(rotateLeakEvidence)).toBe(
       false
     )
+
+    const rotateExportGuard = buildSingleSecretExportGuardrail(
+      managedSecretRows[0],
+      rotatePlan,
+      rotateSubmitEnvelope
+    )
+    expect(rotateExportGuard).toMatchObject({
+      exportGuardId: 'export-guard-reset-serviceadmin-session-signing-metadata',
+      operationId: rotatePlan.operationId,
+      ref: 'secret://local/default/@serviceadmin/SESSION_SIGNING_KEY',
+      action: 'reset',
+      metadataExportStatus:
+        'metadata report available for operation ids, refs, audit refs, typed outcomes, and next actions only',
+      rawExportStatus:
+        'raw value copy, raw export, and spreadsheet-style payload export are unavailable',
+    })
+    expect(rotateExportGuard.allowedExportFields).toEqual(
+      expect.arrayContaining([
+        'operationId',
+        'ref',
+        'action',
+        'auditEventId',
+        'correlationId',
+        'nextAction',
+      ])
+    )
+    expect(rotateExportGuard.blockedExportFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'providerTokens',
+        'recoveryMaterial',
+        'environmentValues',
+      ])
+    )
+    expect(rotateExportGuard.safeExportRows).toEqual(
+      expect.arrayContaining([
+        'metadata export is scoped to the selected ref and operation id',
+        'raw value export and bulk raw reveal are out of scope',
+        'spreadsheet-style secret editing remains unavailable',
+      ])
+    )
+    expect(
+      managedSecretExportGuardrailHasSecretMaterial(rotateExportGuard)
+    ).toBe(false)
 
     const appliedResult = buildSingleSecretOperationResult(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -130,6 +130,21 @@ export type SingleSecretLeakEvidence = {
   safeForScreenshots: boolean
 }
 
+export type SingleSecretExportGuardrail = {
+  exportGuardId: string
+  operationId: string
+  ref: string
+  action: ManagedSecretAction
+  metadataExportStatus: string
+  rawExportStatus: string
+  copyStatus: string
+  allowedExportFields: string[]
+  blockedExportFields: string[]
+  exportRoutes: string[]
+  storageGuardrails: string[]
+  safeExportRows: string[]
+}
+
 export type SingleSecretEditPreview = {
   ref: string
   operationId: string
@@ -2080,6 +2095,69 @@ export function buildSingleSecretLeakEvidence(
   }
 }
 
+export function buildSingleSecretExportGuardrail(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  envelope: SingleSecretSubmitEnvelope
+): SingleSecretExportGuardrail {
+  const slug = safeOperationSlug(plan.action, row)
+
+  return {
+    exportGuardId: `export-guard-${slug}-metadata`,
+    operationId: plan.operationId,
+    ref: row.ref,
+    action: plan.action,
+    metadataExportStatus:
+      'metadata report available for operation ids, refs, audit refs, typed outcomes, and next actions only',
+    rawExportStatus:
+      'raw value copy, raw export, and spreadsheet-style payload export are unavailable',
+    copyStatus:
+      envelope.readyForSubmit || plan.blockers.length === 0
+        ? 'copy support evidence only after audit reason and confirmation metadata are bound'
+        : 'copy disabled until the selected action passes the dry-run gate',
+    allowedExportFields: [
+      'exportGuardId',
+      'operationId',
+      'ref',
+      'action',
+      'owner',
+      'provider',
+      'policy',
+      'auditEventId',
+      'correlationId',
+      'outcome',
+      'nextAction',
+    ],
+    blockedExportFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+    ],
+    exportRoutes: [
+      '/secrets-broker/secrets',
+      '/secrets-broker/secrets?ref=<encoded-ref>&action=<metadata-action>',
+    ],
+    storageGuardrails: [
+      'browser storage keeps table and action selection only',
+      'metadata reports are generated from typed refs and operation ids',
+      'diagnostics and support bundles omit request and response bodies',
+    ],
+    safeExportRows: [
+      'metadata export is scoped to the selected ref and operation id',
+      'raw value export and bulk raw reveal are out of scope',
+      'copyable evidence excludes source payloads, generated values, provider auth material, and recovery material',
+      'spreadsheet-style secret editing remains unavailable',
+      `support evidence reuses ${envelope.correlationId} without including secret material`,
+    ],
+  }
+}
+
 function editConsumerRefsForRow(row: ManagedSecretRow) {
   if (row.owningService === '@serviceadmin') {
     return ['@serviceadmin operator API', '@serviceadmin runtime config loader']
@@ -3688,6 +3766,12 @@ export function managedSecretLeakEvidenceHasSecretMaterial(
   evidence: SingleSecretLeakEvidence
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(evidence))
+}
+
+export function managedSecretExportGuardrailHasSecretMaterial(
+  guardrail: SingleSecretExportGuardrail
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(guardrail))
 }
 
 export function managedSecretEditPreviewHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -519,6 +519,15 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/rotation can be requested without controlled reveal/i)
     ).toBeVisible()
     await expect(page.getByText(/Metadata-only submit envelope/i)).toBeVisible()
+    await expect(page.getByText(/Export and copy guardrail/i)).toBeVisible()
+    await expect(page.getByText(/Raw export blocked/i)).toBeVisible()
+    await expect(
+      page.getByText(/spreadsheet-style payload export are unavailable/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Blocked export fields/i)).toBeVisible()
+    await expect(
+      page.getByText(/metadata export is scoped to the selected ref/i)
+    ).toBeVisible()
     await expect(page.getByText(/Broker status monitor/i)).toBeVisible()
     await expect(
       page


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only export/copy guardrail to the single-secret workflow.
- Shows allowed metadata fields, blocked payload fields, export routes, storage guardrails, and safe export evidence.
- Extends unit/browser coverage that raw value export and spreadsheet-style payload export remain unavailable.

## Scope
- In scope: single-secret Secrets page guardrails for metadata report/copy/export evidence.
- Out of scope: production Secrets Broker mutation/export APIs, raw secret export, bulk raw reveal/export, and full #231 closure.

## Spec / contract / fixture impact
- Updated: deterministic Service Admin stub/model contract for single-secret export/copy guardrail metadata.
- Not required because: no public backend API or service manifest contract changed.

## Service Lasso invariant impact
- Invariant: Secrets Broker-managed raw values and provider credentials stay out of UI routes, storage, diagnostics, screenshots, support evidence, and export surfaces.
- Preservation proof: guardrail model includes only allowlisted metadata fields and blocks raw values, request/response bodies, credentials, tokens, cookies, private keys, recovery material, and environment values.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/unit-secrets-management.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/playwright-rotate-export-guard.log` (1 passed)
- PASS `npm run format:check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/format-check.log`
- PASS `npm run lint` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/lint.log`
- PASS `npm run build` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/build.log`
- PASS `git diff --check` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/issue-231-export-guard/git-diff-check.log`
- PASS canonical preflight before work: Service Admin HTTP 200; runtime `/api/health` HTTP 200 / `status: ok` - `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T000400+1000/canonical-demo-health-preflight.json`

## Approval trail
- Required: no special reviewer requirement found for this focused UI/test slice.
- Evidence: PR is non-draft and will wait for hosted checks before merge.

## Cleanup
- Branch cleanup after merge: delete `agent/issue-231-export-guard` locally/remotely, update `master`, then complete release-to-demo gate if merged.
- Release-to-demo gate is pending because this Service Admin UI change is demo-consumed and not yet merged/released/pinned/recycled.