### PR TITLE
feat(secrets): add owner action tickets

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -72,6 +72,7 @@ import {
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretPolicyPreview,
   buildSingleSecretOperatorHandoff,
+  buildSingleSecretOwnerActionTicket,
   buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
   buildSingleSecretRevealPreview,
@@ -391,6 +392,13 @@ export function SecretsManagementPage({
           singleRecoveryDecision
         )
       : null
+  const singleOwnerActionTicket = singleOperatorHandoff
+    ? buildSingleSecretOwnerActionTicket(
+        selectedRow,
+        singleOperationPlan,
+        singleOperatorHandoff
+      )
+    : null
   const singleHistoryReview = useMemo(
     () =>
       buildSingleSecretOperationHistoryReview(
@@ -3788,6 +3796,122 @@ export function SecretsManagementPage({
                         </div>
                         <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
                           {singleOperatorHandoff.safeHandoffRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {singleOwnerActionTicket ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <ListChecks className='size-4 text-primary' />
+                      <div className='font-medium'>Owner action ticket</div>
+                      <Badge variant='secondary'>Metadata only</Badge>
+                      <Badge variant='outline'>
+                        {singleOwnerActionTicket.owner}
+                      </Badge>
+                      <Badge
+                        variant={
+                          singleOwnerActionTicket.severity === 'critical'
+                            ? 'destructive'
+                            : singleOwnerActionTicket.severity === 'warning'
+                              ? 'secondary'
+                              : 'outline'
+                        }
+                      >
+                        {singleOwnerActionTicket.lane}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Ticket
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleOwnerActionTicket.ticketId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Acknowledgement
+                        </div>
+                        <div className='mt-1'>
+                          {singleOwnerActionTicket.acknowledgementStatus}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Escalation
+                        </div>
+                        <div className='mt-1'>
+                          {singleOwnerActionTicket.safeEscalationRoute}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Required action
+                        </div>
+                        <div className='mt-2'>
+                          {singleOwnerActionTicket.requiredAction}
+                        </div>
+                        <div className='mt-2 text-muted-foreground'>
+                          {singleOwnerActionTicket.freshPreviewRequired
+                            ? 'Fresh preview required before retry'
+                            : 'No retry preview required for this state'}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Evidence refs
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOwnerActionTicket.evidenceRefs.map((ref) => (
+                            <Badge key={ref} variant='outline'>
+                              {ref}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed ticket fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOwnerActionTicket.allowedTicketFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted ticket fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleOwnerActionTicket.omittedTicketFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe ticket evidence
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleOwnerActionTicket.safeTicketRows.map((row) => (
                             <li key={row}>{row}</li>
                           ))}
                         </ul>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -17,6 +17,7 @@ import {
   buildSingleSecretOperationAuditTrail,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperatorHandoff,
+  buildSingleSecretOwnerActionTicket,
   buildSingleSecretPolicyPreview,
   buildSingleSecretRecoveryDecision,
   buildSingleSecretRevealLifecycle,
@@ -40,6 +41,7 @@ import {
   managedSecretHistoryReviewHasSecretMaterial,
   managedSecretLeakEvidenceHasSecretMaterial,
   managedSecretOperatorHandoffHasSecretMaterial,
+  managedSecretOwnerActionTicketHasSecretMaterial,
   managedSecretPolicyPreviewHasSecretMaterial,
   managedSecretRecoveryDecisionHasSecretMaterial,
   managedSecretRevealLifecycleHasSecretMaterial,
@@ -2302,6 +2304,50 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretOperatorHandoffHasSecretMaterial(operatorHandoff)).toBe(
       false
     )
+    const ownerActionTicket = buildSingleSecretOwnerActionTicket(
+      managedSecretRows[0],
+      rotatePlan,
+      operatorHandoff
+    )
+    expect(ownerActionTicket).toMatchObject({
+      ticketId: 'owner-action-reset-serviceadmin-session-signing-applied',
+      operationId: rotatePlan.operationId,
+      lane: 'settled',
+      owner: 'operator',
+      severity: 'info',
+      freshPreviewRequired: false,
+      acknowledgementStatus:
+        'acknowledge terminal broker metadata before closing operator review',
+      safeEscalationRoute:
+        'keep in operator queue with metadata-only evidence refs',
+    })
+    expect(ownerActionTicket.allowedTicketFields).toEqual(
+      expect.arrayContaining([
+        'ticketId',
+        'operationId',
+        'auditEventId',
+        'correlationId',
+        'statusEndpoint',
+      ])
+    )
+    expect(ownerActionTicket.omittedTicketFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'diagnosticPayloadsWithBodies',
+      ])
+    )
+    expect(ownerActionTicket.safeTicketRows).toEqual(
+      expect.arrayContaining([
+        'owner action tickets are generated from the safe handoff packet only',
+        'no mutation payload is retained while the operation is monitored or settled',
+      ])
+    )
+    expect(
+      managedSecretOwnerActionTicketHasSecretMaterial(ownerActionTicket)
+    ).toBe(false)
     const authRequiredMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],
       rotatePlan,
@@ -2380,6 +2426,31 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(
       managedSecretOperatorHandoffHasSecretMaterial(authRequiredHandoff)
+    ).toBe(false)
+    const authRequiredTicket = buildSingleSecretOwnerActionTicket(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredHandoff
+    )
+    expect(authRequiredTicket).toMatchObject({
+      ticketId: 'owner-action-reset-serviceadmin-session-signing-auth-required',
+      lane: 'provider-auth',
+      owner: 'provider owner',
+      severity: 'warning',
+      acknowledgementStatus:
+        'owner acknowledgement required before another broker preview',
+      freshPreviewRequired: true,
+      safeEscalationRoute:
+        'keep in operator queue with metadata-only evidence refs',
+    })
+    expect(authRequiredTicket.safeTicketRows).toEqual(
+      expect.arrayContaining([
+        'fresh broker preview is required after owner action before any mutation retry',
+        'provider authentication happens outside Service Admin and omits provider credentials',
+      ])
+    )
+    expect(
+      managedSecretOwnerActionTicketHasSecretMaterial(authRequiredTicket)
     ).toBe(false)
     const auditUnavailableTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -312,6 +312,23 @@ export type SingleSecretOperatorHandoff = {
   safeHandoffRows: string[]
 }
 
+export type SingleSecretOwnerActionTicket = {
+  ticketId: string
+  operationId: string
+  ref: string
+  lane: SingleSecretOperatorHandoff['lane']
+  owner: string
+  severity: SingleSecretOperatorHandoff['severity']
+  acknowledgementStatus: string
+  requiredAction: string
+  freshPreviewRequired: boolean
+  evidenceRefs: string[]
+  safeEscalationRoute: string
+  allowedTicketFields: string[]
+  omittedTicketFields: string[]
+  safeTicketRows: string[]
+}
+
 export type SingleSecretDecommissionPreview = {
   ref: string
   operationId: string
@@ -3679,6 +3696,80 @@ export function buildSingleSecretOperatorHandoff(
   }
 }
 
+export function buildSingleSecretOwnerActionTicket(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  handoff: SingleSecretOperatorHandoff
+): SingleSecretOwnerActionTicket {
+  const slug = safeOperationSlug(plan.action, row)
+  const freshPreviewRequired =
+    handoff.lane !== 'monitor' && handoff.lane !== 'settled'
+
+  return {
+    ticketId: `owner-action-${slug}-${handoff.outcome}`,
+    operationId: handoff.operationId,
+    ref: row.ref,
+    lane: handoff.lane,
+    owner: handoff.owner,
+    severity: handoff.severity,
+    acknowledgementStatus:
+      handoff.lane === 'settled'
+        ? 'acknowledge terminal broker metadata before closing operator review'
+        : handoff.lane === 'monitor'
+          ? 'watch broker status endpoint until terminal metadata arrives'
+          : 'owner acknowledgement required before another broker preview',
+    requiredAction: handoff.requiredAction,
+    freshPreviewRequired,
+    evidenceRefs: handoff.shareableEvidenceRefs,
+    safeEscalationRoute:
+      handoff.severity === 'critical'
+        ? 'route to broker/audit operator with metadata-only evidence refs'
+        : 'keep in operator queue with metadata-only evidence refs',
+    allowedTicketFields: [
+      'ticketId',
+      'operationId',
+      'ref',
+      'action',
+      'lane',
+      'owner',
+      'severity',
+      'auditEventId',
+      'correlationId',
+      'statusEndpoint',
+      'impactRef',
+      'rollbackRef',
+      'recoveryRef',
+    ],
+    omittedTicketFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+    ],
+    safeTicketRows: [
+      'owner action tickets are generated from the safe handoff packet only',
+      'ticket evidence is shareable because it contains ids, refs, owners, lanes, and typed outcomes only',
+      freshPreviewRequired
+        ? 'fresh broker preview is required after owner action before any mutation retry'
+        : 'no mutation payload is retained while the operation is monitored or settled',
+      handoff.lane === 'provider-auth'
+        ? 'provider authentication happens outside Service Admin and omits provider credentials'
+        : handoff.lane === 'audit-recovery'
+          ? 'audit recovery ticket carries sink status metadata only'
+          : handoff.lane === 'provider-recovery'
+            ? 'provider recovery ticket carries connector metadata only'
+            : 'owner queue omits request bodies, response bodies, and secret material',
+    ],
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -3742,6 +3833,12 @@ export function managedSecretOperatorHandoffHasSecretMaterial(
   handoff: SingleSecretOperatorHandoff
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(handoff))
+}
+
+export function managedSecretOwnerActionTicketHasSecretMaterial(
+  ticket: SingleSecretOwnerActionTicket
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(ticket))
 }
 
 export function managedSecretSubmitEnvelopeHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -624,6 +624,25 @@ test.describe('Secrets Broker browser coverage', () => {
         /handoff evidence can be copied into issue or audit notes/i
       )
     ).toBeVisible()
+    await expect(
+      page.getByText('Owner action ticket', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(/owner-action-reset-serviceadmin-session-signing-submitted/i)
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/Metadata only/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/watch broker status endpoint until terminal metadata/i)
+    ).toBeVisible()
+    await expect(page.getByText(/Allowed ticket fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted ticket fields/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /owner action tickets are generated from the safe handoff/i
+      )
+    ).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('applied')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -713,6 +732,22 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(
       page.getByText(/paused for broker reauthentication/i)
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(
+          /owner-action-reset-serviceadmin-session-signing-auth-required/i
+        )
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/provider owner/i).first()).toBeVisible()
+    await expect(
+      page.getByText(/owner acknowledgement required before another broker/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /fresh broker preview is required after owner action before any mutation retry/i
+      )
     ).toBeVisible()
     await expect(page.getByText(/4 submitted/i)).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('audit-unavailable')


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only owner action ticket generated from each single-secret operator handoff.
- Surface owner, lane, acknowledgement status, safe escalation route, evidence refs, allowed fields, omitted fields, and fresh-preview retry rules.
- Extend unit and browser coverage proving the ticket remains safe for applied/monitoring and auth-required blocked outcomes.

## Scope
- In scope: Service Admin Secrets Broker single-secret follow-up ticket metadata after stub operation handoffs.
- Out of scope: live Secrets Broker mutation API wiring, raw value display, raw copy/export, broad #231 completion.

## Spec / contract / fixture impact
- Updated: UI/model fixtures for the existing stubbed single-secret management surface.
- Not required because: this is a metadata-only UI contract advancement and does not change backend routes or service manifests.

## Nash invariant impact
- Invariant: secret material must not be rendered, logged, routed, persisted, copied, exported, or included in diagnostics/support evidence.
- Preservation proof: owner action tickets are built from safe handoff metadata only and explicitly omit raw values, request/response bodies, credentials, tokens, cookies, keys, recovery material, environment values, screenshots with values, and diagnostics payloads with bodies.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-next-slice/unit-secrets-management-owner-ticket.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-next-slice/playwright-owner-ticket.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-next-slice/format-check-owner-ticket.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-next-slice/lint-owner-ticket.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-next-slice/build-owner-ticket.log`
- PASS `git diff --check`

## Approval trail
- Required: no special approval requirement documented for this focused UI/test advancement.
- Evidence: local checks above; hosted PR checks pending.

## Cleanup
- Branch: `agent/issue-231-owner-action-ticket`
- Post-merge plan: release Service Admin, pin the exact release in core, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, then delete branch if merged.