### PR TITLE
feat(secrets): add metadata-only audit receipts

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -63,6 +63,7 @@ import {
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
+  buildSingleSecretAuditReceipt,
   buildSingleSecretEvidenceBundle,
   buildSingleSecretExportGuardrail,
   buildSingleSecretConfirmationReceipt,
@@ -357,6 +358,15 @@ export function SecretsManagementPage({
         singleApplyResult.outcome
       )
     : []
+  const singleAuditReceipt =
+    singleApplyResult && singleOperationAuditTrail.length > 0
+      ? buildSingleSecretAuditReceipt(
+          selectedRow,
+          singleOperationPlan,
+          singleApplyResult,
+          singleOperationAuditTrail
+        )
+      : null
   const singleStatusMonitor = singleApplyResult
     ? buildSingleSecretStatusMonitor(
         selectedRow,
@@ -3965,6 +3975,90 @@ export function SecretsManagementPage({
                     </Table>
                   </div>
                 </div>
+                {singleAuditReceipt ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <ShieldCheck className='size-4 text-primary' />
+                      <div className='font-medium'>Audit receipt</div>
+                      <Badge variant='secondary'>Metadata only</Badge>
+                      <Badge variant='outline'>
+                        {singleAuditReceipt.retentionStatus}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 lg:grid-cols-4'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Receipt
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleAuditReceipt.receiptId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Checksum
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleAuditReceipt.receiptChecksum}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Audit event
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleAuditReceipt.auditEventId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Terminal evidence
+                        </div>
+                        <div className='mt-1'>
+                          {singleAuditReceipt.terminalStepStatus}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe receipt fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleAuditReceipt.safeReceiptFields.map((field) => (
+                            <Badge key={field} variant='outline'>
+                              {field}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted receipt artifacts
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleAuditReceipt.omittedReceiptArtifacts.map(
+                            (artifact) => (
+                              <Badge key={artifact} variant='secondary'>
+                                {artifact}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 rounded-md border bg-background p-3'>
+                      <div className='text-xs font-medium text-muted-foreground uppercase'>
+                        Safe receipt evidence
+                      </div>
+                      <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                        {singleAuditReceipt.safeReceiptRows.map((row) => (
+                          <li key={row}>{row}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
 

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -15,6 +15,7 @@ import {
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
+  buildSingleSecretAuditReceipt,
   buildSingleSecretOperationHistoryEntry,
   buildSingleSecretOperatorHandoff,
   buildSingleSecretOwnerActionTicket,
@@ -49,6 +50,7 @@ import {
   managedSecretReplayGuardHasSecretMaterial,
   managedSecretRotationPreviewHasSecretMaterial,
   managedSecretSingleAuditTrailHasSecretMaterial,
+  managedSecretAuditReceiptHasSecretMaterial,
   managedSecretStatusMonitorHasSecretMaterial,
   managedSecretSubmitEnvelopeHasSecretMaterial,
   managedSecretRows,
@@ -2106,6 +2108,57 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretSingleAuditTrailHasSecretMaterial(auditTrail)).toBe(
       false
     )
+    const auditReceipt = buildSingleSecretAuditReceipt(
+      managedSecretRows[0],
+      rotatePlan,
+      appliedResult,
+      auditTrail
+    )
+    expect(auditReceipt).toMatchObject({
+      receiptId: 'audit-receipt-reset-serviceadmin-session-signing-applied',
+      operationId: rotatePlan.operationId,
+      outcome: 'applied',
+      auditEventId: 'audit-reset-serviceadmin-session-signing-preview',
+      correlationId: 'corr-reset-serviceadmin-session-signing-applied',
+      terminalStepStatus: 'terminal success',
+      retentionStatus:
+        'audit receipt retained with metadata-only terminal evidence',
+    })
+    expect(auditReceipt.receiptChecksum).toMatch(/^safe-audit-\d{5}$/)
+    expect(auditReceipt.safeReceiptFields).toEqual(
+      expect.arrayContaining([
+        'receiptId',
+        'operationId',
+        'ref',
+        'action',
+        'outcome',
+        'auditEventId',
+        'correlationId',
+        'receiptChecksum',
+      ])
+    )
+    expect(auditReceipt.omittedReceiptArtifacts).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'requestHeaders',
+        'providerCredentials',
+        'providerTokens',
+        'cookies',
+        'privateKeys',
+        'recoveryMaterial',
+        'environmentValues',
+      ])
+    )
+    expect(auditReceipt.safeReceiptRows).toEqual(
+      expect.arrayContaining([
+        'audit receipts are derived from operation ids, refs, typed outcomes, audit ids, and correlation ids only',
+        'receipt checksum proves the metadata set reviewed without hashing or storing secret payloads',
+        'retained audit receipts are shareable for support and issue trails without raw values',
+      ])
+    )
+    expect(managedSecretAuditReceiptHasSecretMaterial(auditReceipt)).toBe(false)
     const authRequiredTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],
       rotatePlan,
@@ -2117,6 +2170,21 @@ describe('Secrets Broker secrets management page', () => {
     })
     expect(
       managedSecretSingleAuditTrailHasSecretMaterial(authRequiredTrail)
+    ).toBe(false)
+    const authRequiredReceipt = buildSingleSecretAuditReceipt(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult,
+      authRequiredTrail
+    )
+    expect(authRequiredReceipt).toMatchObject({
+      outcome: 'auth-required',
+      terminalStepStatus: 'paused for broker reauthentication',
+      retentionStatus:
+        'audit receipt retained with metadata-only terminal evidence',
+    })
+    expect(
+      managedSecretAuditReceiptHasSecretMaterial(authRequiredReceipt)
     ).toBe(false)
     const statusMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -449,6 +449,22 @@ export type SingleSecretOperationAuditTrailStep = {
   terminal: boolean
 }
 
+export type SingleSecretAuditReceipt = {
+  receiptId: string
+  operationId: string
+  ref: string
+  action: ManagedSecretAction
+  outcome: SingleSecretOperationOutcome
+  auditEventId: string
+  correlationId: string
+  receiptChecksum: string
+  retentionStatus: string
+  terminalStepStatus: string
+  safeReceiptFields: string[]
+  omittedReceiptArtifacts: string[]
+  safeReceiptRows: string[]
+}
+
 export type StubSecretMutationState =
   | 'ready'
   | 'denied'
@@ -3272,6 +3288,83 @@ export function buildSingleSecretOperationAuditTrail(
   ]
 }
 
+export function buildSingleSecretAuditReceipt(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  result: SingleSecretOperationResult,
+  auditTrail: SingleSecretOperationAuditTrailStep[]
+): SingleSecretAuditReceipt {
+  const slug = safeOperationSlug(plan.action, row)
+  const terminalStep =
+    auditTrail.find((step) => step.terminal) ??
+    auditTrail[auditTrail.length - 1]
+  const checksumSeed = [
+    result.operationId,
+    row.ref,
+    plan.action,
+    result.outcome,
+    result.auditFeedback.auditEventId,
+    result.auditFeedback.correlationId,
+    terminalStep.status,
+  ].join('|')
+  const checksum = Array.from(checksumSeed).reduce(
+    (total, char) => (total + char.charCodeAt(0) * 17) % 100000,
+    0
+  )
+
+  return {
+    receiptId: `audit-receipt-${slug}-${result.outcome}`,
+    operationId: result.operationId,
+    ref: row.ref,
+    action: plan.action,
+    outcome: result.outcome,
+    auditEventId: result.auditFeedback.auditEventId,
+    correlationId: result.auditFeedback.correlationId,
+    receiptChecksum: `safe-audit-${checksum.toString().padStart(5, '0')}`,
+    retentionStatus:
+      result.outcome === 'submitted'
+        ? 'receipt pending terminal broker metadata'
+        : result.outcome === 'audit-unavailable'
+          ? 'audit receipt blocked until sink retention is restored'
+          : 'audit receipt retained with metadata-only terminal evidence',
+    terminalStepStatus: terminalStep.status,
+    safeReceiptFields: [
+      'receiptId',
+      'operationId',
+      'ref',
+      'action',
+      'outcome',
+      'auditEventId',
+      'correlationId',
+      'terminalStepStatus',
+      'receiptChecksum',
+      'retentionStatus',
+    ],
+    omittedReceiptArtifacts: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'requestHeaders',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+    ],
+    safeReceiptRows: [
+      'audit receipts are derived from operation ids, refs, typed outcomes, audit ids, and correlation ids only',
+      'receipt checksum proves the metadata set reviewed without hashing or storing secret payloads',
+      result.outcome === 'audit-unavailable'
+        ? 'audit-unavailable receipts remain blocked and require sink recovery before retry'
+        : 'retained audit receipts are shareable for support and issue trails without raw values',
+      'receipt exports omit request bodies, response bodies, headers, credentials, tokens, cookies, keys, recovery material, and environment values',
+    ],
+  }
+}
+
 export function buildSingleSecretStatusMonitor(
   row: ManagedSecretRow,
   plan: SingleSecretOperationPlan,
@@ -3809,6 +3902,12 @@ export function managedSecretSingleAuditTrailHasSecretMaterial(
   entries: SingleSecretOperationAuditTrailStep[]
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(entries))
+}
+
+export function managedSecretAuditReceiptHasSecretMaterial(
+  receipt: SingleSecretAuditReceipt
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(receipt))
 }
 
 export function managedSecretStatusMonitorHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -731,7 +731,28 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/provider reauthentication happens outside Service Admin/i)
     ).toBeVisible()
     await expect(
-      page.getByText(/paused for broker reauthentication/i)
+      page.getByText(/paused for broker reauthentication/i).first()
+    ).toBeVisible()
+    await expect(page.getByText('Audit receipt', { exact: true })).toBeVisible()
+    await expect(
+      page
+        .getByText(
+          /audit-receipt-reset-serviceadmin-session-signing-auth-required/i
+        )
+        .first()
+    ).toBeVisible()
+    await expect(page.getByText(/safe-audit-\d{5}/i)).toBeVisible()
+    await expect(page.getByText(/Safe receipt fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted receipt artifacts/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /audit receipts are derived from operation ids, refs, typed outcomes/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /receipt checksum proves the metadata set reviewed without hashing/i
+      )
     ).toBeVisible()
     await expect(
       page


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add a metadata-only single-secret audit receipt derived from operation id, ref, action, typed outcome, audit event id, correlation id, and terminal audit step status.
- Render the receipt in `Secrets Broker > Secrets` after a broker result, including checksum, retention status, safe receipt fields, omitted artifacts, and safe receipt evidence.
- Extend unit and browser coverage to prove audit receipts stay payload-free and visible on an auth-required operation result.

## Scope
- In scope: Service Admin single-secret result receipt metadata and no-raw-value UI/test coverage.
- Out of scope: completing all remaining #231 flows, changing real Secrets Broker APIs, or claiming #231 done.

## Spec / contract / fixture impact
- Updated: Service Admin stub/model surface for single-secret audit receipt evidence.
- Not required: no backend API/schema change; this is a UI/model safe-evidence slice over existing stub broker metadata.

## Security / invariant impact
- Raw secret values, request/response bodies, request headers, credentials, tokens, cookies, private keys, recovery material, environment values, screenshots with visible values, and diagnostic payload bodies are explicitly omitted from receipt fields.
- Receipt checksum is generated from metadata identifiers only, not from secret payloads.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/unit-secrets-management.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/playwright-audit-receipt.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/lint.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-audit-receipt/diff-check.log`

## Approval trail
- Required: no human approval requested by this branch before opening PR.
- Evidence: hosted checks pending after PR creation.

## Cleanup
- Branch: `agent/issue-231-audit-receipt`
- Post-merge gate: this Service Admin UI change is demo-consumed. After merge, release Service Admin, pin the exact release in `service-lasso/service-lasso`, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and verify live installed `@serviceadmin` matches the new release before claiming this slice demo-gated.