### PR TITLE
feat(secrets): add operation closure review

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -67,6 +67,7 @@ import {
   buildSingleSecretEvidenceBundle,
   buildSingleSecretExportGuardrail,
   buildSingleSecretConfirmationReceipt,
+  buildSingleSecretClosureReview,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
@@ -409,6 +410,24 @@ export function SecretsManagementPage({
         singleOperatorHandoff
       )
     : null
+  const singleClosureReview =
+    singleApplyResult &&
+    singleStatusMonitor &&
+    singleEvidenceBundle &&
+    singleAuditReceipt &&
+    singleOperatorHandoff &&
+    singleOwnerActionTicket
+      ? buildSingleSecretClosureReview(
+          selectedRow,
+          singleOperationPlan,
+          singleApplyResult,
+          singleStatusMonitor,
+          singleEvidenceBundle,
+          singleAuditReceipt,
+          singleOperatorHandoff,
+          singleOwnerActionTicket
+        )
+      : null
   const singleHistoryReview = useMemo(
     () =>
       buildSingleSecretOperationHistoryReview(
@@ -3922,6 +3941,148 @@ export function SecretsManagementPage({
                         </div>
                         <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
                           {singleOwnerActionTicket.safeTicketRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {singleClosureReview ? (
+                  <div className='mt-3 rounded-md border bg-muted/30 p-3'>
+                    <div className='mb-3 flex flex-wrap items-center gap-2'>
+                      <CheckCircle2 className='size-4 text-primary' />
+                      <div className='font-medium'>Operator closure review</div>
+                      <Badge variant='secondary'>Metadata only</Badge>
+                      <Badge
+                        variant={
+                          singleClosureReview.canCloseOperatorReview
+                            ? 'default'
+                            : singleClosureReview.reviewState === 'monitoring'
+                              ? 'outline'
+                              : 'secondary'
+                        }
+                      >
+                        {singleClosureReview.badge}
+                      </Badge>
+                    </div>
+                    <div className='grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Closure review
+                        </div>
+                        <div className='mt-1 break-all'>
+                          {singleClosureReview.closureId}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Review state
+                        </div>
+                        <div className='mt-1'>
+                          {singleClosureReview.reviewState}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Operator close
+                        </div>
+                        <div className='mt-1'>
+                          {singleClosureReview.canCloseOperatorReview
+                            ? 'Allowed after audit acknowledgement'
+                            : 'Blocked until required checks complete'}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Required before close
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleClosureReview.requiredBeforeClose.map(
+                            (row) => (
+                              <li key={row}>{row}</li>
+                            )
+                          )}
+                        </ul>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Retained evidence refs
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleClosureReview.retainedEvidenceRefs.map(
+                            (ref) => (
+                              <Badge key={ref} variant='outline'>
+                                {ref}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Audit refs
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleClosureReview.auditRefs.map((ref) => (
+                            <Badge key={ref} variant='outline'>
+                              {ref}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Support refs
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleClosureReview.supportRefs.map((ref) => (
+                            <Badge key={ref} variant='secondary'>
+                              {ref}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-3'>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed closure fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleClosureReview.allowedClosureFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted closure fields
+                        </div>
+                        <div className='mt-2 flex flex-wrap gap-1'>
+                          {singleClosureReview.omittedClosureFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div className='rounded-md border bg-background p-3'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe closure evidence
+                        </div>
+                        <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {singleClosureReview.safeClosureRows.map((row) => (
                             <li key={row}>{row}</li>
                           ))}
                         </ul>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -12,6 +12,7 @@ import {
   buildSingleSecretEvidenceBundle,
   buildSingleSecretExportGuardrail,
   buildSingleSecretConfirmationReceipt,
+  buildSingleSecretClosureReview,
   buildSingleSecretLeakEvidence,
   buildSingleSecretOperationHistoryReview,
   buildSingleSecretOperationAuditTrail,
@@ -34,6 +35,7 @@ import {
   managedSecretBulkApplyResultHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
+  managedSecretClosureReviewHasSecretMaterial,
   managedSecretConfirmationReceiptHasSecretMaterial,
   managedSecretDecommissionPreviewHasSecretMaterial,
   managedSecretEditPreviewHasSecretMaterial,
@@ -829,7 +831,9 @@ describe('Secrets Broker secrets management page', () => {
     ).toBeVisible()
     expect(screen.getByText(/Support evidence bundle/i)).toBeVisible()
     expect(
-      screen.getByText(/support-evidence-reset-serviceadmin-session-signing/i)
+      screen.getAllByText(
+        /support-evidence-reset-serviceadmin-session-signing/i
+      )[0]
     ).toBeVisible()
     expect(screen.getByText(/Screenshot redaction/i)).toBeVisible()
     expect(
@@ -844,7 +848,9 @@ describe('Secrets Broker secrets management page', () => {
       screen.getAllByText(/diagnosticPayloadsWithBodies/i)[0]
     ).toBeVisible()
     expect(
-      screen.getByText(/localStorage\/sessionStorage evidence contains no/i)
+      screen.getAllByText(
+        /localStorage\/sessionStorage evidence contains no/i
+      )[0]
     ).toBeVisible()
     expect(screen.getByText(/Recovery and retry decision/i)).toBeVisible()
     expect(
@@ -2416,6 +2422,78 @@ describe('Secrets Broker secrets management page', () => {
     expect(
       managedSecretOwnerActionTicketHasSecretMaterial(ownerActionTicket)
     ).toBe(false)
+    const closureReview = buildSingleSecretClosureReview(
+      managedSecretRows[0],
+      rotatePlan,
+      appliedResult,
+      statusMonitor,
+      evidenceBundle,
+      auditReceipt,
+      operatorHandoff,
+      ownerActionTicket
+    )
+    expect(closureReview).toMatchObject({
+      closureId: 'closure-review-reset-serviceadmin-session-signing-applied',
+      operationId: rotatePlan.operationId,
+      outcome: 'applied',
+      reviewState: 'ready-to-close',
+      badge: 'operator review can close',
+      canCloseOperatorReview: true,
+    })
+    expect(closureReview.requiredBeforeClose).toEqual(
+      expect.arrayContaining([
+        'acknowledge terminal audit receipt',
+        'retain support evidence bundle reference',
+        'confirm dependent service status is reviewed',
+      ])
+    )
+    expect(closureReview.retainedEvidenceRefs).toEqual(
+      expect.arrayContaining([
+        auditReceipt.receiptId,
+        auditReceipt.receiptChecksum,
+        evidenceBundle.bundleId,
+        evidenceBundle.reportRef,
+        statusMonitor.statusEndpoint,
+        operatorHandoff.handoffId,
+        ownerActionTicket.ticketId,
+      ])
+    )
+    expect(closureReview.allowedClosureFields).toEqual(
+      expect.arrayContaining([
+        'closureId',
+        'operationId',
+        'auditEventId',
+        'correlationId',
+        'receiptChecksum',
+        'statusEndpoint',
+        'ownerActionTicketId',
+      ])
+    )
+    expect(closureReview.omittedClosureFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'providerTokens',
+        'cookies',
+        'privateKeys',
+        'recoveryMaterial',
+        'environmentValues',
+        'screenshotsWithVisibleValues',
+        'diagnosticPayloadsWithBodies',
+      ])
+    )
+    expect(closureReview.safeClosureRows).toEqual(
+      expect.arrayContaining([
+        'closure review stores only ids, refs, typed outcomes, audit refs, and support evidence refs',
+        'operator review may close after terminal metadata and audit receipt acknowledgement',
+        'closing or keeping the review open never requires raw value reveal, request body replay, provider credentials, or diagnostic payload bodies',
+      ])
+    )
+    expect(managedSecretClosureReviewHasSecretMaterial(closureReview)).toBe(
+      false
+    )
     const authRequiredMonitor = buildSingleSecretStatusMonitor(
       managedSecretRows[0],
       rotatePlan,
@@ -2519,6 +2597,45 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(
       managedSecretOwnerActionTicketHasSecretMaterial(authRequiredTicket)
+    ).toBe(false)
+    const authRequiredEvidenceBundle = buildSingleSecretEvidenceBundle(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult,
+      authRequiredMonitor
+    )
+    const authRequiredClosureReview = buildSingleSecretClosureReview(
+      managedSecretRows[0],
+      rotatePlan,
+      authRequiredResult,
+      authRequiredMonitor,
+      authRequiredEvidenceBundle,
+      authRequiredReceipt,
+      authRequiredHandoff,
+      authRequiredTicket
+    )
+    expect(authRequiredClosureReview).toMatchObject({
+      closureId:
+        'closure-review-reset-serviceadmin-session-signing-auth-required',
+      outcome: 'auth-required',
+      reviewState: 'owner-action-required',
+      badge: 'owner action required before close',
+      canCloseOperatorReview: false,
+    })
+    expect(authRequiredClosureReview.requiredBeforeClose).toEqual(
+      expect.arrayContaining([
+        'complete provider reauthentication, then create a fresh audited preview',
+        'complete owner acknowledgement',
+        'create a fresh preview before any new mutation attempt',
+      ])
+    )
+    expect(authRequiredClosureReview.safeClosureRows).toEqual(
+      expect.arrayContaining([
+        'blocked operations stay open until owner action and a fresh preview are completed',
+      ])
+    )
+    expect(
+      managedSecretClosureReviewHasSecretMaterial(authRequiredClosureReview)
     ).toBe(false)
     const auditUnavailableTrail = buildSingleSecretOperationAuditTrail(
       managedSecretRows[0],

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -329,6 +329,23 @@ export type SingleSecretOwnerActionTicket = {
   safeTicketRows: string[]
 }
 
+export type SingleSecretClosureReview = {
+  closureId: string
+  operationId: string
+  ref: string
+  outcome: SingleSecretOperationOutcome
+  reviewState: 'ready-to-close' | 'monitoring' | 'owner-action-required'
+  badge: string
+  canCloseOperatorReview: boolean
+  requiredBeforeClose: string[]
+  retainedEvidenceRefs: string[]
+  auditRefs: string[]
+  supportRefs: string[]
+  allowedClosureFields: string[]
+  omittedClosureFields: string[]
+  safeClosureRows: string[]
+}
+
 export type SingleSecretDecommissionPreview = {
   ref: string
   operationId: string
@@ -3863,6 +3880,112 @@ export function buildSingleSecretOwnerActionTicket(
   }
 }
 
+export function buildSingleSecretClosureReview(
+  row: ManagedSecretRow,
+  plan: SingleSecretOperationPlan,
+  result: SingleSecretOperationResult,
+  monitor: SingleSecretStatusMonitor,
+  evidenceBundle: SingleSecretEvidenceBundle,
+  auditReceipt: SingleSecretAuditReceipt,
+  handoff: SingleSecretOperatorHandoff,
+  ticket: SingleSecretOwnerActionTicket
+): SingleSecretClosureReview {
+  const slug = safeOperationSlug(plan.action, row)
+  const reviewState: SingleSecretClosureReview['reviewState'] =
+    result.outcome === 'applied'
+      ? 'ready-to-close'
+      : result.outcome === 'submitted'
+        ? 'monitoring'
+        : 'owner-action-required'
+  const canCloseOperatorReview = reviewState === 'ready-to-close'
+
+  return {
+    closureId: `closure-review-${slug}-${result.outcome}`,
+    operationId: result.operationId,
+    ref: row.ref,
+    outcome: result.outcome,
+    reviewState,
+    badge: canCloseOperatorReview
+      ? 'operator review can close'
+      : reviewState === 'monitoring'
+        ? 'wait for broker terminal metadata'
+        : 'owner action required before close',
+    canCloseOperatorReview,
+    requiredBeforeClose: canCloseOperatorReview
+      ? [
+          'acknowledge terminal audit receipt',
+          'retain support evidence bundle reference',
+          'confirm dependent service status is reviewed',
+        ]
+      : reviewState === 'monitoring'
+        ? [
+            'wait for terminal broker status metadata',
+            'refresh status endpoint before deciding retry or close',
+            'keep operation in history without retaining payload bodies',
+          ]
+        : [
+            ticket.requiredAction,
+            'complete owner acknowledgement',
+            'create a fresh preview before any new mutation attempt',
+          ],
+    retainedEvidenceRefs: [
+      auditReceipt.receiptId,
+      auditReceipt.receiptChecksum,
+      evidenceBundle.bundleId,
+      evidenceBundle.reportRef,
+      monitor.statusEndpoint,
+      handoff.handoffId,
+      ticket.ticketId,
+    ],
+    auditRefs: [
+      result.auditFeedback.auditEventId,
+      result.auditFeedback.correlationId,
+      auditReceipt.terminalStepStatus,
+    ],
+    supportRefs: [
+      evidenceBundle.diagnosticsRef,
+      evidenceBundle.supportBundleStatus,
+      evidenceBundle.storageEvidence,
+    ],
+    allowedClosureFields: [
+      'closureId',
+      'operationId',
+      'ref',
+      'action',
+      'outcome',
+      'auditEventId',
+      'correlationId',
+      'receiptChecksum',
+      'statusEndpoint',
+      'supportEvidenceRef',
+      'ownerActionTicketId',
+    ],
+    omittedClosureFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+    ],
+    safeClosureRows: [
+      'closure review stores only ids, refs, typed outcomes, audit refs, and support evidence refs',
+      canCloseOperatorReview
+        ? 'operator review may close after terminal metadata and audit receipt acknowledgement'
+        : reviewState === 'monitoring'
+          ? 'pending operations remain open until broker terminal metadata arrives'
+          : 'blocked operations stay open until owner action and a fresh preview are completed',
+      'closing or keeping the review open never requires raw value reveal, request body replay, provider credentials, or diagnostic payload bodies',
+      `operator lane: ${handoff.lane}`,
+    ],
+  }
+}
+
 const forbiddenSecretPattern =
   /(secret-value|plaintext|correct-horse-battery-staple|portable-master-key|raw key|sk-[a-z0-9]|ghp_[a-z0-9]|AKIA[0-9A-Z]{16}|password\s*=|api[_-]?key\s*=|private key|cookie=|bearer\s+[a-z0-9])/i
 
@@ -3938,6 +4061,12 @@ export function managedSecretOwnerActionTicketHasSecretMaterial(
   ticket: SingleSecretOwnerActionTicket
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(ticket))
+}
+
+export function managedSecretClosureReviewHasSecretMaterial(
+  review: SingleSecretClosureReview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(review))
 }
 
 export function managedSecretSubmitEnvelopeHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -643,6 +643,27 @@ test.describe('Secrets Broker browser coverage', () => {
         /owner action tickets are generated from the safe handoff/i
       )
     ).toBeVisible()
+    await expect(
+      page.getByText('Operator closure review', { exact: true })
+    ).toBeVisible()
+    await expect(
+      page
+        .getByText(
+          /closure-review-reset-serviceadmin-session-signing-submitted/i
+        )
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/wait for broker terminal metadata/i).first()
+    ).toBeVisible()
+    await expect(page.getByText(/Retained evidence refs/i)).toBeVisible()
+    await expect(page.getByText(/Allowed closure fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted closure fields/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /pending operations remain open until broker terminal metadata arrives/i
+      )
+    ).toBeVisible()
     await page.getByLabel(/Result status/i).selectOption('applied')
     await page.getByLabel(/Stub API state/i).selectOption('ready')
     await page.getByRole('button', { name: /Simulate stub apply/i }).click()
@@ -659,6 +680,17 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(
       page.getByText(/no retry needed after broker success/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/operator review can close/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Allowed after audit acknowledgement/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /operator review may close after terminal metadata and audit receipt acknowledgement/i
+      )
     ).toBeVisible()
     await expect(page.getByText(/2 submitted/i)).toBeVisible()
     await expect(page.getByText(/2 shown/i)).toBeVisible()
@@ -741,7 +773,7 @@ test.describe('Secrets Broker browser coverage', () => {
         )
         .first()
     ).toBeVisible()
-    await expect(page.getByText(/safe-audit-\d{5}/i)).toBeVisible()
+    await expect(page.getByText(/safe-audit-\d{5}/i).first()).toBeVisible()
     await expect(page.getByText(/Safe receipt fields/i)).toBeVisible()
     await expect(page.getByText(/Omitted receipt artifacts/i)).toBeVisible()
     await expect(
@@ -768,6 +800,17 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(
         /fresh broker preview is required after owner action before any mutation retry/i
+      )
+    ).toBeVisible()
+    await expect(
+      page.getByText(/owner action required before close/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/Blocked until required checks complete/i)
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        /blocked operations stay open until owner action and a fresh preview are completed/i
       )
     ).toBeVisible()
     await expect(page.getByText(/4 submitted/i)).toBeVisible()


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Adds a metadata-only single-secret operator closure review after broker operation results.
- Shows whether an operation review can close, must continue monitoring, or requires owner action before a fresh preview/retry.
- Keeps retained closure evidence limited to operation ids, refs, audit/correlation ids, receipt checksum, status endpoint, support evidence refs, handoff id, and owner ticket id.

## Scope
- In scope: Service Admin `Secrets Broker > Secrets` single-secret post-result closure review and tests.
- Out of scope: live Secrets Broker mutation API wiring, full #231 closure, release/demo pin gate after merge.

## Spec / contract / fixture impact
- Updated: metadata model for safe single-secret closure review in `src/features/secrets-broker/secrets-management.ts`.
- Not required: backend API contract changes, because this remains the Service Admin metadata-only stub/operator surface until the production mutation contract lands.

## Nash invariant impact
- Invariant: no raw secret values, request/response bodies, provider credentials, tokens, cookies, keys, recovery material, environment values, value screenshots, or diagnostic payload bodies are retained or rendered.
- Preservation proof: new model leak guard plus unit/browser assertions cover allowed and omitted closure fields.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/unit-secrets-management.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "submits a single-secret rotate preview"` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/playwright-closure-review.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/lint.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-closure-review/git-diff-check.log`

## Approval trail
- Required: no special approval requirement found for this focused UI/test advancement.
- Evidence: #231 remains open; this PR uses `Refs #231` because it is a bounded slice, not full issue completion.

## Cleanup
- Branch: `agent/issue-231-closure-review`
- Release-to-demo gate: required after merge/release because Service Admin is demo-consumed. Do not mark #231 done until the exact released Service Admin tag is pinned in core and the canonical demo is recycled/verified.