### PR TITLE
feat(secrets): add bulk campaign closure review

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -59,6 +59,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildBulkSecretCampaignClosureReview,
   buildManagedSecretActionPreview,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
@@ -352,6 +353,9 @@ export function SecretsManagementPage({
     bulkRevalidated,
     bulkPlan.applyAvailable
   )
+  const bulkClosureReview = bulkApplyResult
+    ? buildBulkSecretCampaignClosureReview(bulkApplyResult)
+    : null
   const singleOperationAuditTrail = singleApplyResult
     ? buildSingleSecretOperationAuditTrail(
         selectedRow,
@@ -1594,6 +1598,166 @@ export function SecretsManagementPage({
                     </TableBody>
                   </Table>
                 </div>
+
+                {bulkClosureReview ? (
+                  <div className='grid gap-4 rounded-md border p-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]'>
+                    <div className='space-y-4'>
+                      <div className='flex flex-wrap items-start justify-between gap-3'>
+                        <div>
+                          <h3 className='font-medium'>
+                            Bulk campaign closure review
+                          </h3>
+                          <p className='mt-1 text-muted-foreground'>
+                            {bulkClosureReview.canCloseCampaignReview
+                              ? 'Campaign review can close after audit acknowledgement.'
+                              : bulkClosureReview.reviewState === 'monitoring'
+                                ? 'Campaign review stays open while retry-safe item recovery is monitored.'
+                                : 'Campaign review is blocked until recovery creates a fresh plan.'}
+                          </p>
+                        </div>
+                        <Badge
+                          variant={
+                            bulkClosureReview.canCloseCampaignReview
+                              ? 'default'
+                              : bulkClosureReview.reviewState === 'monitoring'
+                                ? 'secondary'
+                                : 'outline'
+                          }
+                        >
+                          {bulkClosureReview.reviewState}
+                        </Badge>
+                      </div>
+
+                      <dl className='grid gap-3 md:grid-cols-3'>
+                        <div>
+                          <dt className='text-muted-foreground'>Closure ID</dt>
+                          <dd className='break-all'>
+                            {bulkClosureReview.closureId}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className='text-muted-foreground'>Outcome</dt>
+                          <dd>{bulkClosureReview.outcome}</dd>
+                        </div>
+                        <div>
+                          <dt className='text-muted-foreground'>
+                            Close decision
+                          </dt>
+                          <dd>
+                            {bulkClosureReview.canCloseCampaignReview
+                              ? 'operator review can close'
+                              : 'operator review remains open'}
+                          </dd>
+                        </div>
+                      </dl>
+
+                      <div className='grid gap-3 md:grid-cols-2'>
+                        <div>
+                          <div className='text-xs font-medium text-muted-foreground uppercase'>
+                            Required before close
+                          </div>
+                          <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                            {bulkClosureReview.requiredBeforeClose.map(
+                              (item) => (
+                                <li key={item}>{item}</li>
+                              )
+                            )}
+                          </ul>
+                        </div>
+                        <div>
+                          <div className='text-xs font-medium text-muted-foreground uppercase'>
+                            Item outcome summary
+                          </div>
+                          <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                            {bulkClosureReview.itemOutcomeSummary.map(
+                              (item) => (
+                                <li key={item}>{item}</li>
+                              )
+                            )}
+                          </ul>
+                        </div>
+                      </div>
+
+                      <div className='space-y-2'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe closure evidence
+                        </div>
+                        <ul className='list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {bulkClosureReview.safeClosureRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+
+                    <div className='space-y-3 rounded-md bg-muted/40 p-3 text-sm'>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Retained evidence refs
+                        </div>
+                        <div className='mt-1 space-y-1'>
+                          {bulkClosureReview.retainedEvidenceRefs.map((ref) => (
+                            <div key={ref} className='break-all'>
+                              {ref}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Audit refs
+                        </div>
+                        <div className='mt-1 space-y-1'>
+                          {bulkClosureReview.auditRefs.map((ref) => (
+                            <div key={ref} className='break-all'>
+                              {ref}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Support refs
+                        </div>
+                        <div className='mt-1 space-y-1'>
+                          {bulkClosureReview.supportRefs.map((ref) => (
+                            <div key={ref} className='break-all'>
+                              {ref}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed closure fields
+                        </div>
+                        <div className='mt-1 flex flex-wrap gap-1'>
+                          {bulkClosureReview.allowedClosureFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted closure fields
+                        </div>
+                        <div className='mt-1 flex flex-wrap gap-1'>
+                          {bulkClosureReview.omittedClosureFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </CardContent>

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -6,6 +6,7 @@ import {
   buildBulkSecretCampaignPlan,
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
+  buildBulkSecretCampaignClosureReview,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
@@ -33,6 +34,7 @@ import {
   buildStubSecretMutationPreview,
   filterManagedSecrets,
   managedSecretBulkApplyResultHasSecretMaterial,
+  managedSecretBulkClosureReviewHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
   managedSecretClosureReviewHasSecretMaterial,
@@ -385,6 +387,13 @@ describe('Secrets Broker secrets management page', () => {
     expect(screen.getAllByText(/Applied 1/i)[0]).toBeVisible()
     expect(screen.getByText(/campaign and item audit recorded/i)).toBeVisible()
     expect(screen.getAllByText(/retry by operation id/i)[0]).toBeVisible()
+    expect(screen.getByText(/Bulk campaign closure review/i)).toBeVisible()
+    expect(screen.getByText(/operator review can close/i)).toBeVisible()
+    expect(
+      screen.getByText(/campaign review may close after audit acknowledgement/i)
+    ).toBeVisible()
+    expect(screen.getByText(/Allowed closure fields/i)).toBeVisible()
+    expect(screen.getByText(/Omitted closure fields/i)).toBeVisible()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
@@ -434,6 +443,13 @@ describe('Secrets Broker secrets management page', () => {
       screen.getAllByText(/retry with the same idempotency key/i)[0]
     ).toBeVisible()
     expect(screen.getAllByText(/campaign-update-edit/i)[0]).toBeVisible()
+    expect(screen.getByText(/Bulk campaign closure review/i)).toBeVisible()
+    expect(screen.getByText(/operator review remains open/i)).toBeVisible()
+    expect(
+      screen.getByText(
+        /partial campaigns remain open while retry-safe item recovery/i
+      )
+    ).toBeVisible()
     expect(screen.queryByText(/DEMO_REVEAL_VALUE_42/i)).not.toBeInTheDocument()
   })
 
@@ -609,6 +625,11 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(screen.getByText(/Campaign apply result: stale_plan/i)).toBeVisible()
     expect(screen.getAllByText(/create a fresh dry-run plan/i)[0]).toBeVisible()
+    expect(
+      screen.getByText(
+        /blocked campaigns stay open until policy, auth, audit, provider, or stale-plan recovery creates a fresh plan/i
+      )
+    ).toBeVisible()
   })
 
   it('shows stale plan and revalidation failure states before bulk apply', async () => {
@@ -3258,6 +3279,81 @@ describe('Secrets Broker secrets management page', () => {
     expect(managedSecretBulkApplyResultHasSecretMaterial(applyResult)).toBe(
       false
     )
+    const partialClosure = buildBulkSecretCampaignClosureReview(applyResult)
+    expect(partialClosure).toMatchObject({
+      campaignId: applyResult.campaignId,
+      operationId: applyResult.operationId,
+      outcome: 'partial_failure',
+      reviewState: 'blocked',
+      canCloseCampaignReview: false,
+    })
+    expect(partialClosure.requiredBeforeClose).toEqual(
+      expect.arrayContaining([
+        'resolve the typed blocker named by the campaign next action',
+        'create a fresh campaign dry-run before any new mutation attempt',
+      ])
+    )
+    expect(partialClosure.allowedClosureFields).toEqual(
+      expect.arrayContaining(['campaignId', 'operationId', 'typedItemOutcomes'])
+    )
+    expect(partialClosure.omittedClosureFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'providerCredentials',
+        'bulkSpreadsheetPayload',
+      ])
+    )
+    expect(
+      managedSecretBulkClosureReviewHasSecretMaterial(partialClosure)
+    ).toBe(false)
+
+    const retryablePartialPlan = buildBulkSecretCampaignPlan(
+      managedSecretRows,
+      [managedSecretRows[0].id, managedSecretRows[2].id],
+      'update-edit'
+    )
+    const retryablePartialResult = buildBulkSecretCampaignApplyResult(
+      retryablePartialPlan,
+      'partial-failure'
+    )
+    const retryablePartialClosure = buildBulkSecretCampaignClosureReview(
+      retryablePartialResult
+    )
+    expect(retryablePartialClosure).toMatchObject({
+      outcome: 'partial_failure',
+      reviewState: 'monitoring',
+      canCloseCampaignReview: false,
+    })
+    expect(retryablePartialClosure.requiredBeforeClose).toEqual(
+      expect.arrayContaining([
+        'review retry-safe failed item operation ids',
+        'retry only items marked retry safe and only by operation id',
+      ])
+    )
+    expect(
+      managedSecretBulkClosureReviewHasSecretMaterial(retryablePartialClosure)
+    ).toBe(false)
+
+    const successfulResult = buildBulkSecretCampaignApplyResult(
+      cleanPlan,
+      'success'
+    )
+    const successfulClosure =
+      buildBulkSecretCampaignClosureReview(successfulResult)
+    expect(successfulClosure).toMatchObject({
+      outcome: 'applied',
+      reviewState: 'closable',
+      canCloseCampaignReview: true,
+    })
+    expect(successfulClosure.safeClosureRows).toEqual(
+      expect.arrayContaining([
+        'campaign review may close after audit acknowledgement and dependent service status review',
+      ])
+    )
+    expect(
+      managedSecretBulkClosureReviewHasSecretMaterial(successfulClosure)
+    ).toBe(false)
 
     const bulkPolicyDeniedResult = buildBulkSecretCampaignApplyResult(
       cleanPlan,

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -638,6 +638,23 @@ export type BulkSecretCampaignApplyResult = {
   items: BulkSecretCampaignApplyItem[]
 }
 
+export type BulkSecretCampaignClosureReview = {
+  closureId: string
+  campaignId: string
+  operationId: string
+  outcome: BulkSecretCampaignApplyResult['outcome']
+  reviewState: 'closable' | 'monitoring' | 'blocked'
+  canCloseCampaignReview: boolean
+  requiredBeforeClose: string[]
+  retainedEvidenceRefs: string[]
+  auditRefs: string[]
+  supportRefs: string[]
+  itemOutcomeSummary: string[]
+  allowedClosureFields: string[]
+  omittedClosureFields: string[]
+  safeClosureRows: string[]
+}
+
 export const managedSecretRows: ManagedSecretRow[] = [
   {
     id: 'serviceadmin-session-signing',
@@ -831,6 +848,7 @@ export const managedSecretSafeSurfaces = {
     'secrets-management:bulk-campaign-dry-run',
     'secrets-management:bulk-campaign-apply',
     'secrets-management:bulk-campaign-status',
+    'secrets-management:bulk-campaign-closure-review',
   ],
   persistedStorage: 'none',
 }
@@ -1566,6 +1584,113 @@ export function buildBulkSecretCampaignApplyResult(
                   ? 'request least-privilege policy approval and create a fresh campaign preview'
                   : 'review per-item outcomes and retry only by operation id',
     items,
+  }
+}
+
+export function buildBulkSecretCampaignClosureReview(
+  result: BulkSecretCampaignApplyResult
+): BulkSecretCampaignClosureReview {
+  const nonAppliedCount =
+    result.failedCount +
+    result.deniedCount +
+    result.skippedCount +
+    result.unsupportedCount +
+    result.authRequiredCount +
+    result.auditUnavailableCount +
+    result.providerUnavailableCount +
+    result.staleCount
+  const retrySafeCount = result.items.filter(
+    (item) => !item.applied && item.retrySafe
+  ).length
+  const canCloseCampaignReview =
+    result.outcome === 'applied' && nonAppliedCount === 0
+  const reviewState: BulkSecretCampaignClosureReview['reviewState'] =
+    canCloseCampaignReview
+      ? 'closable'
+      : retrySafeCount > 0
+        ? 'monitoring'
+        : 'blocked'
+
+  return {
+    closureId: `bulk-closure-${safeCampaignSlug(result.campaignId)}`,
+    campaignId: result.campaignId,
+    operationId: result.operationId,
+    outcome: result.outcome,
+    reviewState,
+    canCloseCampaignReview,
+    requiredBeforeClose: canCloseCampaignReview
+      ? [
+          'acknowledge campaign-level audit summary',
+          'retain item operation ids and plan token',
+          'confirm dependent service status is reviewed',
+        ]
+      : reviewState === 'monitoring'
+        ? [
+            'review retry-safe failed item operation ids',
+            'retry only items marked retry safe and only by operation id',
+            'keep campaign open until every item has terminal recovery metadata',
+          ]
+        : [
+            'resolve the typed blocker named by the campaign next action',
+            'create a fresh campaign dry-run before any new mutation attempt',
+            'retain blocked item outcome evidence without request or response bodies',
+          ],
+    retainedEvidenceRefs: [
+      result.campaignId,
+      result.operationId,
+      result.planToken,
+      ...result.items.map((item) => item.operationItemId),
+    ],
+    auditRefs: [
+      `audit-campaign-${safeCampaignSlug(result.campaignId)}`,
+      `corr-campaign-${safeCampaignSlug(result.operationId)}`,
+      `audit-summary-${safeCampaignSlug(result.outcome)}`,
+    ],
+    supportRefs: [
+      `support://secrets-broker/campaigns/${safeCampaignSlug(result.campaignId)}/safe-summary`,
+      `diagnostics://secrets-broker/campaigns/${safeCampaignSlug(result.operationId)}/metadata-only`,
+      'screenshots-redacted-by-policy',
+    ],
+    itemOutcomeSummary: result.items.map(
+      (item) =>
+        `${item.name}: ${item.outcome}; ${item.retrySafe ? 'retry-safe' : 'fresh-plan-required'}`
+    ),
+    allowedClosureFields: [
+      'closureId',
+      'campaignId',
+      'operationId',
+      'planToken',
+      'outcome',
+      'itemOperationIds',
+      'idempotencyKeys',
+      'auditStatus',
+      'correlationId',
+      'supportEvidenceRef',
+      'typedItemOutcomes',
+    ],
+    omittedClosureFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+      'bulkSpreadsheetPayload',
+    ],
+    safeClosureRows: [
+      'bulk closure review stores only campaign ids, operation ids, typed item outcomes, audit refs, and support evidence refs',
+      canCloseCampaignReview
+        ? 'campaign review may close after audit acknowledgement and dependent service status review'
+        : reviewState === 'monitoring'
+          ? 'partial campaigns remain open while retry-safe item recovery is monitored by operation id'
+          : 'blocked campaigns stay open until policy, auth, audit, provider, or stale-plan recovery creates a fresh plan',
+      'closing or keeping the campaign open never requires raw values, request body replay, provider credentials, or diagnostic payload bodies',
+    ],
   }
 }
 
@@ -4007,6 +4132,12 @@ export function managedSecretBulkApplyResultHasSecretMaterial(
   result: BulkSecretCampaignApplyResult
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(result))
+}
+
+export function managedSecretBulkClosureReviewHasSecretMaterial(
+  review: BulkSecretCampaignClosureReview
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(review))
 }
 
 export function managedSecretSingleHistoryHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -988,6 +988,16 @@ test.describe('Secrets Broker browser coverage', () => {
       page.getByText(/campaign audit unavailable; item mutation not applied/i)
     ).toBeVisible()
     await expect(page.getByText(/restore audit persistence/i)).toBeVisible()
+    await expect(page.getByText(/Bulk campaign closure review/i)).toBeVisible()
+    await expect(page.getByText(/operator review remains open/i)).toBeVisible()
+    await expect(
+      page.getByText(
+        /blocked campaigns stay open until policy, auth, audit, provider, or stale-plan recovery creates a fresh plan/i
+      )
+    ).toBeVisible()
+    await expect(page.getByText(/Allowed closure fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted closure fields/i)).toBeVisible()
+    await expect(page.getByText(/bulkSpreadsheetPayload/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
 


### PR DESCRIPTION
## Issue
Closes part of #231

## Summary
- Added a metadata-only bulk campaign closure review after campaign apply results.
- Classifies campaigns as closable, monitoring, or blocked from typed apply outcomes.
- Shows retained campaign/item operation refs, audit refs, support refs, allowed fields, omitted fields, and safe close/monitor/block guidance.

## Scope
- In scope: Service Admin Secrets Broker bulk campaign closeout evidence for the existing stub-backed management workflow.
- Out of scope: production Secrets Broker mutation API implementation, raw value reveal/export, and backend policy enforcement changes.

## Spec / contract / fixture impact
- Updated: bulk campaign model/UI/test fixtures in the Service Admin secrets management surface.
- Not required: no public backend API/schema change; this adds metadata-only UI/model evidence around existing campaign results.

## Nash invariant impact
- Invariant: raw secret values, provider credentials/tokens, request/response bodies, private keys, cookies, environment values, screenshots with values, and diagnostic payload bodies must not enter the UI evidence surface.
- Preservation proof: closure review allowlists ids/refs/typed outcomes/audit/support refs and tests `managedSecretBulkClosureReviewHasSecretMaterial(...) === false`.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/unit-secrets-management.log` (20 passed)
- PASS `npm run test:ui -- tests/ui/secrets-broker.spec.ts` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/playwright-secrets-broker.log` (8 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/lint.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-closure-review/git-diff-check.log`

## Approval trail
- Required: hosted CI required before merge.
- Evidence: local proof above; awaiting GitHub Actions.

## Cleanup
- Branch: `agent/issue-231-bulk-closure-review`
- Post-merge: if Service Admin release publishes, pin the exact release in core, recycle canonical demo on port `17883`, and run `npm run demo:verify-canonical` before claiming demo-current.