### PR TITLE
feat(secrets): add bulk campaign owner handoff

### DIFF
--- a/src/features/secrets-broker/secrets-management-page.tsx
+++ b/src/features/secrets-broker/secrets-management-page.tsx
@@ -60,6 +60,8 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildBulkSecretCampaignClosureReview,
+  buildBulkSecretCampaignOperatorHandoff,
+  buildBulkSecretCampaignOwnerActionTicket,
   buildManagedSecretActionPreview,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
@@ -355,6 +357,16 @@ export function SecretsManagementPage({
   )
   const bulkClosureReview = bulkApplyResult
     ? buildBulkSecretCampaignClosureReview(bulkApplyResult)
+    : null
+  const bulkOperatorHandoff =
+    bulkApplyResult && bulkClosureReview
+      ? buildBulkSecretCampaignOperatorHandoff(
+          bulkApplyResult,
+          bulkClosureReview
+        )
+      : null
+  const bulkOwnerActionTicket = bulkOperatorHandoff
+    ? buildBulkSecretCampaignOwnerActionTicket(bulkOperatorHandoff)
     : null
   const singleOperationAuditTrail = singleApplyResult
     ? buildSingleSecretOperationAuditTrail(
@@ -1747,6 +1759,172 @@ export function SecretsManagementPage({
                         </div>
                         <div className='mt-1 flex flex-wrap gap-1'>
                           {bulkClosureReview.omittedClosureFields.map(
+                            (field) => (
+                              <Badge key={field} variant='secondary'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                {bulkOperatorHandoff && bulkOwnerActionTicket ? (
+                  <div className='grid gap-4 rounded-md border p-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)]'>
+                    <div className='space-y-4'>
+                      <div className='flex flex-wrap items-start justify-between gap-3'>
+                        <div>
+                          <h3 className='font-medium'>
+                            Bulk campaign owner handoff
+                          </h3>
+                          <p className='mt-1 text-muted-foreground'>
+                            {bulkOperatorHandoff.requiredAction}
+                          </p>
+                        </div>
+                        <div className='flex flex-wrap gap-2'>
+                          <Badge
+                            variant={
+                              bulkOperatorHandoff.severity === 'critical'
+                                ? 'destructive'
+                                : bulkOperatorHandoff.severity === 'warning'
+                                  ? 'secondary'
+                                  : 'outline'
+                            }
+                          >
+                            {bulkOperatorHandoff.severity}
+                          </Badge>
+                          <Badge variant='outline'>
+                            {bulkOperatorHandoff.badge}
+                          </Badge>
+                        </div>
+                      </div>
+
+                      <dl className='grid gap-3 md:grid-cols-3'>
+                        <div>
+                          <dt className='text-muted-foreground'>Handoff ID</dt>
+                          <dd className='break-all'>
+                            {bulkOperatorHandoff.handoffId}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className='text-muted-foreground'>Owner lane</dt>
+                          <dd>{bulkOperatorHandoff.lane}</dd>
+                        </div>
+                        <div>
+                          <dt className='text-muted-foreground'>Owner</dt>
+                          <dd>{bulkOperatorHandoff.owner}</dd>
+                        </div>
+                      </dl>
+
+                      <div className='grid gap-3 md:grid-cols-2'>
+                        <div>
+                          <div className='text-xs font-medium text-muted-foreground uppercase'>
+                            Safe handoff rows
+                          </div>
+                          <ul className='mt-2 list-disc space-y-1 ps-5 text-muted-foreground'>
+                            {bulkOperatorHandoff.safeHandoffRows.map((row) => (
+                              <li key={row}>{row}</li>
+                            ))}
+                          </ul>
+                        </div>
+                        <div>
+                          <div className='text-xs font-medium text-muted-foreground uppercase'>
+                            Owner action ticket
+                          </div>
+                          <dl className='mt-2 space-y-2 text-muted-foreground'>
+                            <div>
+                              <dt className='text-foreground'>Ticket ID</dt>
+                              <dd className='break-all'>
+                                {bulkOwnerActionTicket.ticketId}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className='text-foreground'>
+                                Acknowledgement
+                              </dt>
+                              <dd>
+                                {bulkOwnerActionTicket.acknowledgementStatus}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className='text-foreground'>
+                                Escalation route
+                              </dt>
+                              <dd>
+                                {bulkOwnerActionTicket.safeEscalationRoute}
+                              </dd>
+                            </div>
+                          </dl>
+                        </div>
+                      </div>
+
+                      <div className='space-y-2'>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Safe ticket rows
+                        </div>
+                        <ul className='list-disc space-y-1 ps-5 text-muted-foreground'>
+                          {bulkOwnerActionTicket.safeTicketRows.map((row) => (
+                            <li key={row}>{row}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    </div>
+
+                    <div className='space-y-3 rounded-md bg-muted/40 p-3 text-sm'>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Shareable evidence refs
+                        </div>
+                        <div className='mt-1 space-y-1'>
+                          {bulkOperatorHandoff.shareableEvidenceRefs.map(
+                            (ref) => (
+                              <div key={ref} className='break-all'>
+                                {ref}
+                              </div>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      {bulkOperatorHandoff.blockedReason ? (
+                        <div>
+                          <div className='text-xs font-medium text-muted-foreground uppercase'>
+                            Blocked reason
+                          </div>
+                          <div className='mt-1'>
+                            {bulkOperatorHandoff.blockedReason}
+                          </div>
+                        </div>
+                      ) : null}
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Validator note
+                        </div>
+                        <div className='mt-1'>
+                          {bulkOperatorHandoff.validatorNote}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Allowed handoff fields
+                        </div>
+                        <div className='mt-1 flex flex-wrap gap-1'>
+                          {bulkOperatorHandoff.allowedHandoffFields.map(
+                            (field) => (
+                              <Badge key={field} variant='outline'>
+                                {field}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+                      </div>
+                      <div>
+                        <div className='text-xs font-medium text-muted-foreground uppercase'>
+                          Omitted ticket fields
+                        </div>
+                        <div className='mt-1 flex flex-wrap gap-1'>
+                          {bulkOwnerActionTicket.omittedTicketFields.map(
                             (field) => (
                               <Badge key={field} variant='secondary'>
                                 {field}

--- a/src/features/secrets-broker/secrets-management.test.tsx
+++ b/src/features/secrets-broker/secrets-management.test.tsx
@@ -7,6 +7,8 @@ import {
   buildBulkSecretCampaignApplyGate,
   buildBulkSecretCampaignApplyResult,
   buildBulkSecretCampaignClosureReview,
+  buildBulkSecretCampaignOperatorHandoff,
+  buildBulkSecretCampaignOwnerActionTicket,
   buildManagedSecretActionReadiness,
   buildSingleSecretDecommissionPreview,
   buildSingleSecretEditPreview,
@@ -35,6 +37,8 @@ import {
   filterManagedSecrets,
   managedSecretBulkApplyResultHasSecretMaterial,
   managedSecretBulkClosureReviewHasSecretMaterial,
+  managedSecretBulkOperatorHandoffHasSecretMaterial,
+  managedSecretBulkOwnerActionTicketHasSecretMaterial,
   managedSecretBulkPlanHasSecretMaterial,
   managedSecretActionReadinessHasSecretMaterial,
   managedSecretClosureReviewHasSecretMaterial,
@@ -3308,6 +3312,88 @@ describe('Secrets Broker secrets management page', () => {
       managedSecretBulkClosureReviewHasSecretMaterial(partialClosure)
     ).toBe(false)
 
+    const partialHandoff = buildBulkSecretCampaignOperatorHandoff(
+      applyResult,
+      partialClosure
+    )
+    expect(partialHandoff).toMatchObject({
+      campaignId: applyResult.campaignId,
+      operationId: applyResult.operationId,
+      outcome: 'partial_failure',
+      lane: 'item-recovery',
+      owner: 'broker operator',
+      severity: 'warning',
+      blockedReason: applyResult.nextAction,
+    })
+    expect(partialHandoff.shareableEvidenceRefs).toEqual(
+      expect.arrayContaining([
+        applyResult.campaignId,
+        applyResult.operationId,
+        applyResult.planToken,
+        partialClosure.auditRefs[0],
+        partialClosure.supportRefs[0],
+        applyResult.items[0].operationItemId,
+      ])
+    )
+    expect(partialHandoff.allowedHandoffFields).toEqual(
+      expect.arrayContaining([
+        'campaignId',
+        'operationId',
+        'itemOperationIds',
+        'typedItemOutcomes',
+        'supportEvidenceRefs',
+      ])
+    )
+    expect(partialHandoff.omittedHandoffFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'diagnosticPayloadsWithBodies',
+        'bulkSpreadsheetPayload',
+      ])
+    )
+    expect(
+      managedSecretBulkOperatorHandoffHasSecretMaterial(partialHandoff)
+    ).toBe(false)
+
+    const partialOwnerTicket =
+      buildBulkSecretCampaignOwnerActionTicket(partialHandoff)
+    expect(partialOwnerTicket).toMatchObject({
+      campaignId: applyResult.campaignId,
+      operationId: applyResult.operationId,
+      lane: 'item-recovery',
+      owner: 'broker operator',
+      severity: 'warning',
+      freshPlanRequired: true,
+      requiredAction:
+        'review retry-safe item operation ids and retry only by operation id',
+    })
+    expect(partialOwnerTicket.allowedTicketFields).toEqual(
+      expect.arrayContaining([
+        'ticketId',
+        'campaignId',
+        'operationId',
+        'itemOperationIds',
+        'typedItemOutcomes',
+      ])
+    )
+    expect(partialOwnerTicket.omittedTicketFields).toEqual(
+      expect.arrayContaining([
+        'rawValue',
+        'requestBody',
+        'responseBody',
+        'providerCredentials',
+        'environmentValues',
+        'screenshotsWithVisibleValues',
+        'bulkSpreadsheetPayload',
+      ])
+    )
+    expect(
+      managedSecretBulkOwnerActionTicketHasSecretMaterial(partialOwnerTicket)
+    ).toBe(false)
+
     const retryablePartialPlan = buildBulkSecretCampaignPlan(
       managedSecretRows,
       [managedSecretRows[0].id, managedSecretRows[2].id],
@@ -3353,6 +3439,31 @@ describe('Secrets Broker secrets management page', () => {
     )
     expect(
       managedSecretBulkClosureReviewHasSecretMaterial(successfulClosure)
+    ).toBe(false)
+    const successfulHandoff = buildBulkSecretCampaignOperatorHandoff(
+      successfulResult,
+      successfulClosure
+    )
+    const successfulOwnerTicket =
+      buildBulkSecretCampaignOwnerActionTicket(successfulHandoff)
+    expect(successfulHandoff).toMatchObject({
+      outcome: 'applied',
+      lane: 'settled',
+      owner: 'operator',
+      severity: 'info',
+      blockedReason: null,
+    })
+    expect(successfulOwnerTicket).toMatchObject({
+      lane: 'settled',
+      freshPlanRequired: false,
+      acknowledgementStatus:
+        'acknowledge terminal campaign metadata before closing operator review',
+    })
+    expect(
+      managedSecretBulkOperatorHandoffHasSecretMaterial(successfulHandoff)
+    ).toBe(false)
+    expect(
+      managedSecretBulkOwnerActionTicketHasSecretMaterial(successfulOwnerTicket)
     ).toBe(false)
 
     const bulkPolicyDeniedResult = buildBulkSecretCampaignApplyResult(
@@ -3428,6 +3539,23 @@ describe('Secrets Broker secrets management page', () => {
     })
     expect(
       managedSecretBulkApplyResultHasSecretMaterial(bulkAuditUnavailableResult)
+    ).toBe(false)
+    const auditUnavailableClosure = buildBulkSecretCampaignClosureReview(
+      bulkAuditUnavailableResult
+    )
+    const auditUnavailableHandoff = buildBulkSecretCampaignOperatorHandoff(
+      bulkAuditUnavailableResult,
+      auditUnavailableClosure
+    )
+    expect(auditUnavailableHandoff).toMatchObject({
+      lane: 'audit-recovery',
+      owner: 'audit operator',
+      severity: 'critical',
+      requiredAction:
+        'restore audit persistence before creating a fresh campaign preview',
+    })
+    expect(
+      managedSecretBulkOperatorHandoffHasSecretMaterial(auditUnavailableHandoff)
     ).toBe(false)
 
     const bulkProviderUnavailableResult = buildBulkSecretCampaignApplyResult(

--- a/src/features/secrets-broker/secrets-management.ts
+++ b/src/features/secrets-broker/secrets-management.ts
@@ -655,6 +655,49 @@ export type BulkSecretCampaignClosureReview = {
   safeClosureRows: string[]
 }
 
+export type BulkSecretCampaignOperatorHandoff = {
+  handoffId: string
+  campaignId: string
+  operationId: string
+  outcome: BulkSecretCampaignApplyResult['outcome']
+  lane:
+    | 'monitor'
+    | 'settled'
+    | 'policy-review'
+    | 'provider-auth'
+    | 'audit-recovery'
+    | 'provider-recovery'
+    | 'fresh-preview'
+    | 'item-recovery'
+  badge: string
+  owner: string
+  severity: 'info' | 'warning' | 'critical'
+  requiredAction: string
+  shareableEvidenceRefs: string[]
+  blockedReason: string | null
+  validatorNote: string
+  allowedHandoffFields: string[]
+  omittedHandoffFields: string[]
+  safeHandoffRows: string[]
+}
+
+export type BulkSecretCampaignOwnerActionTicket = {
+  ticketId: string
+  campaignId: string
+  operationId: string
+  lane: BulkSecretCampaignOperatorHandoff['lane']
+  owner: string
+  severity: BulkSecretCampaignOperatorHandoff['severity']
+  acknowledgementStatus: string
+  requiredAction: string
+  freshPlanRequired: boolean
+  evidenceRefs: string[]
+  safeEscalationRoute: string
+  allowedTicketFields: string[]
+  omittedTicketFields: string[]
+  safeTicketRows: string[]
+}
+
 export const managedSecretRows: ManagedSecretRow[] = [
   {
     id: 'serviceadmin-session-signing',
@@ -1690,6 +1733,210 @@ export function buildBulkSecretCampaignClosureReview(
           ? 'partial campaigns remain open while retry-safe item recovery is monitored by operation id'
           : 'blocked campaigns stay open until policy, auth, audit, provider, or stale-plan recovery creates a fresh plan',
       'closing or keeping the campaign open never requires raw values, request body replay, provider credentials, or diagnostic payload bodies',
+    ],
+  }
+}
+
+export function buildBulkSecretCampaignOperatorHandoff(
+  result: BulkSecretCampaignApplyResult,
+  closureReview: BulkSecretCampaignClosureReview
+): BulkSecretCampaignOperatorHandoff {
+  const slug = safeCampaignSlug(result.campaignId)
+  const lane: BulkSecretCampaignOperatorHandoff['lane'] =
+    result.outcome === 'applied'
+      ? 'settled'
+      : result.outcome === 'partial_failure' || result.outcome === 'failed'
+        ? 'item-recovery'
+        : result.outcome === 'policy_denied'
+          ? 'policy-review'
+          : result.outcome === 'auth_required'
+            ? 'provider-auth'
+            : result.outcome === 'audit_unavailable'
+              ? 'audit-recovery'
+              : result.outcome === 'provider_unavailable'
+                ? 'provider-recovery'
+                : result.outcome === 'stale_plan'
+                  ? 'fresh-preview'
+                  : 'monitor'
+
+  const owner =
+    lane === 'settled' || lane === 'monitor'
+      ? 'operator'
+      : lane === 'policy-review'
+        ? 'policy approver'
+        : lane === 'provider-auth'
+          ? 'provider owner'
+          : lane === 'audit-recovery'
+            ? 'audit operator'
+            : lane === 'provider-recovery'
+              ? 'provider operator'
+              : lane === 'fresh-preview'
+                ? 'operator'
+                : 'broker operator'
+
+  const severity: BulkSecretCampaignOperatorHandoff['severity'] =
+    lane === 'settled' || lane === 'monitor'
+      ? 'info'
+      : lane === 'audit-recovery' || lane === 'provider-recovery'
+        ? 'critical'
+        : 'warning'
+
+  const requiredAction =
+    lane === 'settled'
+      ? 'acknowledge campaign audit summary and close operator review'
+      : lane === 'monitor'
+        ? 'monitor campaign status until every item has terminal metadata'
+        : lane === 'policy-review'
+          ? 'request least-privilege policy approval and create a fresh campaign preview'
+          : lane === 'provider-auth'
+            ? 'complete provider reauthentication and create a fresh campaign preview'
+            : lane === 'audit-recovery'
+              ? 'restore audit persistence before creating a fresh campaign preview'
+              : lane === 'provider-recovery'
+                ? 'restore provider connectivity before creating a fresh campaign preview'
+                : lane === 'fresh-preview'
+                  ? 'discard the stale plan token and create a fresh campaign preview'
+                  : 'review retry-safe item operation ids and retry only by operation id'
+
+  return {
+    handoffId: `bulk-handoff-${slug}-${result.outcome}`,
+    campaignId: result.campaignId,
+    operationId: result.operationId,
+    outcome: result.outcome,
+    lane,
+    badge:
+      lane === 'settled'
+        ? 'closed'
+        : lane === 'monitor'
+          ? 'monitoring'
+          : lane === 'fresh-preview'
+            ? 'fresh plan'
+            : 'owner action required',
+    owner,
+    severity,
+    requiredAction,
+    shareableEvidenceRefs: [
+      result.campaignId,
+      result.operationId,
+      result.planToken,
+      ...closureReview.auditRefs,
+      ...closureReview.supportRefs,
+      ...result.items.map((item) => item.operationItemId),
+    ],
+    blockedReason:
+      lane === 'settled' || lane === 'monitor' ? null : result.nextAction,
+    validatorNote:
+      lane === 'settled'
+        ? 'campaign can be validated from campaign id, operation id, audit refs, item outcomes, and support refs only'
+        : lane === 'monitor'
+          ? 'campaign remains evidence-only until every item has terminal metadata'
+          : 'blocked campaign requires owner action and a fresh broker preview before another mutation attempt',
+    allowedHandoffFields: [
+      'handoffId',
+      'campaignId',
+      'operationId',
+      'planToken',
+      'outcome',
+      'lane',
+      'owner',
+      'auditRefs',
+      'correlationRefs',
+      'itemOperationIds',
+      'typedItemOutcomes',
+      'supportEvidenceRefs',
+    ],
+    omittedHandoffFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+      'bulkSpreadsheetPayload',
+    ],
+    safeHandoffRows: [
+      'bulk campaign handoffs use ids, owner lanes, typed item outcomes, audit refs, and support refs only',
+      'handoff evidence can be copied into issue or audit notes without raw secret material',
+      lane === 'settled' || lane === 'monitor'
+        ? 'settled or monitored campaigns do not include mutation payload echoes'
+        : 'blocked campaign handoffs require owner action and a fresh broker preview before another submit',
+      `required action: ${requiredAction}`,
+    ],
+  }
+}
+
+export function buildBulkSecretCampaignOwnerActionTicket(
+  handoff: BulkSecretCampaignOperatorHandoff
+): BulkSecretCampaignOwnerActionTicket {
+  const freshPlanRequired =
+    handoff.lane !== 'settled' && handoff.lane !== 'monitor'
+
+  return {
+    ticketId: `bulk-owner-action-${safeCampaignSlug(handoff.campaignId)}-${handoff.outcome}`,
+    campaignId: handoff.campaignId,
+    operationId: handoff.operationId,
+    lane: handoff.lane,
+    owner: handoff.owner,
+    severity: handoff.severity,
+    acknowledgementStatus:
+      handoff.lane === 'settled'
+        ? 'acknowledge terminal campaign metadata before closing operator review'
+        : handoff.lane === 'monitor'
+          ? 'watch campaign item statuses until terminal metadata arrives'
+          : 'owner acknowledgement required before another broker campaign preview',
+    requiredAction: handoff.requiredAction,
+    freshPlanRequired,
+    evidenceRefs: handoff.shareableEvidenceRefs,
+    safeEscalationRoute:
+      handoff.severity === 'critical'
+        ? 'route to broker/audit owner with metadata-only evidence refs'
+        : 'keep in operator queue with metadata-only evidence refs',
+    allowedTicketFields: [
+      'ticketId',
+      'campaignId',
+      'operationId',
+      'planToken',
+      'lane',
+      'owner',
+      'severity',
+      'auditRefs',
+      'correlationRefs',
+      'itemOperationIds',
+      'typedItemOutcomes',
+      'supportEvidenceRefs',
+    ],
+    omittedTicketFields: [
+      'rawValue',
+      'requestBody',
+      'responseBody',
+      'providerCredentials',
+      'providerTokens',
+      'cookies',
+      'privateKeys',
+      'recoveryMaterial',
+      'environmentValues',
+      'screenshotsWithVisibleValues',
+      'diagnosticPayloadsWithBodies',
+      'bulkSpreadsheetPayload',
+    ],
+    safeTicketRows: [
+      'bulk owner action tickets are generated from the safe campaign handoff packet only',
+      'ticket evidence is shareable because it contains ids, owners, lanes, typed outcomes, and audit refs only',
+      freshPlanRequired
+        ? 'fresh campaign preview is required after owner action before any mutation retry'
+        : 'no mutation payload is retained while the campaign is monitored or settled',
+      handoff.lane === 'provider-auth'
+        ? 'provider authentication happens outside Service Admin and omits provider credentials'
+        : handoff.lane === 'audit-recovery'
+          ? 'audit recovery ticket carries sink status metadata only'
+          : handoff.lane === 'provider-recovery'
+            ? 'provider recovery ticket carries connector metadata only'
+            : 'owner queue omits request bodies, response bodies, and secret material',
     ],
   }
 }
@@ -4138,6 +4385,18 @@ export function managedSecretBulkClosureReviewHasSecretMaterial(
   review: BulkSecretCampaignClosureReview
 ) {
   return forbiddenSecretPattern.test(JSON.stringify(review))
+}
+
+export function managedSecretBulkOperatorHandoffHasSecretMaterial(
+  handoff: BulkSecretCampaignOperatorHandoff
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(handoff))
+}
+
+export function managedSecretBulkOwnerActionTicketHasSecretMaterial(
+  ticket: BulkSecretCampaignOwnerActionTicket
+) {
+  return forbiddenSecretPattern.test(JSON.stringify(ticket))
 }
 
 export function managedSecretSingleHistoryHasSecretMaterial(

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -987,7 +987,9 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/campaign audit unavailable; item mutation not applied/i)
     ).toBeVisible()
-    await expect(page.getByText(/restore audit persistence/i)).toBeVisible()
+    await expect(
+      page.getByText(/restore audit persistence/i).first()
+    ).toBeVisible()
     await expect(page.getByText(/Bulk campaign closure review/i)).toBeVisible()
     await expect(page.getByText(/operator review remains open/i)).toBeVisible()
     await expect(
@@ -997,7 +999,27 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByText(/Allowed closure fields/i)).toBeVisible()
     await expect(page.getByText(/Omitted closure fields/i)).toBeVisible()
-    await expect(page.getByText(/bulkSpreadsheetPayload/i)).toBeVisible()
+    await expect(page.getByText(/Bulk campaign owner handoff/i)).toBeVisible()
+    await expect(page.getByText(/audit-recovery/i)).toBeVisible()
+    await expect(page.getByText(/audit operator/i)).toBeVisible()
+    await expect(
+      page
+        .getByText(
+          /restore audit persistence before creating a fresh campaign preview/i
+        )
+        .first()
+    ).toBeVisible()
+    await expect(
+      page.getByText('Owner action ticket', { exact: true })
+    ).toBeVisible()
+    await expect(page.getByText(/Allowed handoff fields/i)).toBeVisible()
+    await expect(page.getByText(/Omitted ticket fields/i)).toBeVisible()
+    await expect(
+      page.getByText(/diagnosticPayloadsWithBodies/i).first()
+    ).toBeVisible()
+    await expect(
+      page.getByText(/bulkSpreadsheetPayload/i).first()
+    ).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
 
@@ -1017,8 +1039,10 @@ test.describe('Secrets Broker browser coverage', () => {
       )
     ).toBeVisible()
     await expect(
-      page.getByText(/request least-privilege policy approval/i)
+      page.getByText(/request least-privilege policy approval/i).first()
     ).toBeVisible()
+    await expect(page.getByText(/policy-review/i)).toBeVisible()
+    await expect(page.getByText(/policy approver/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
 
@@ -1040,8 +1064,10 @@ test.describe('Secrets Broker browser coverage', () => {
         .first()
     ).toBeVisible()
     await expect(
-      page.getByText(/complete provider reauthentication/i)
+      page.getByText(/complete provider reauthentication/i).first()
     ).toBeVisible()
+    await expect(page.getByText(/provider-auth/i)).toBeVisible()
+    await expect(page.getByText(/provider owner/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
 
@@ -1065,6 +1091,8 @@ test.describe('Secrets Broker browser coverage', () => {
     await expect(
       page.getByText(/restore provider connectivity/i).first()
     ).toBeVisible()
+    await expect(page.getByText(/provider-recovery/i)).toBeVisible()
+    await expect(page.getByText(/provider operator/i)).toBeVisible()
     await expect(page.getByText(/DEMO_REVEAL_VALUE_42/i)).toHaveCount(0)
     await expectNoSecretMaterial(page)
     expect(consoleErrors).toEqual([])


### PR DESCRIPTION
## Issue
Refs #231

## Summary
- Add metadata-only bulk campaign operator handoff and owner action ticket models after bulk apply/closure review.
- Surface owner lane, severity, required action, shareable refs, validator note, and ticket acknowledgement/escalation guidance in the Secrets page.
- Extend unit/browser coverage for partial failure, success, policy, auth, audit, and provider recovery lanes without raw secret material.

## Scope
- In scope: bulk campaign post-apply handoff/ticket evidence and safe UI display.
- Out of scope: real broker mutation API wiring, raw value reveal/export, and full #231 completion.

## Spec / contract / fixture impact
- Updated: `src/features/secrets-broker/secrets-management.ts` fixture/model contract for bulk campaign handoff and owner action tickets.
- Not required: no backend API/schema change; this remains deterministic Service Admin stub/fixture behavior pending production mutation contract.

## Nash invariant impact
- Invariant: Secrets UI remains metadata-only by default and never renders raw values or credential material.
- Preservation proof: handoff/ticket builders include allowlisted fields only and explicit omitted field guards for raw values, request/response bodies, credentials, tokens, cookies, private keys, recovery material, env values, value screenshots, diagnostic payload bodies, and spreadsheet payloads.

## Validation
- PASS `npm run test:unit -- src/features/secrets-broker/secrets-management.test.tsx` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/unit-secrets-management.log` (20 passed)
- PASS `npx playwright test tests/ui/secrets-broker.spec.ts --grep "shows bulk campaign audit auth policy-denied and provider-unavailable"` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/playwright-bulk-owner-handoff.log` (1 passed)
- PASS `npm run format:check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/format-check.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/lint.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/build.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-231-bulk-owner-handoff/git-diff-check.log`

## Approval trail
- Required: no documented separate approval requirement found for this focused UI/test advancement.
- Evidence: branch pushed with tests/build evidence; hosted `install-lint-build` pending on PR.

## Release / demo gate
- This Service Admin UI change is demo-consumed after merge/release.
- Release-to-demo gate is not complete in this PR-open state. After merge, publish/verify Service Admin release, update the core `@serviceadmin` demo pin to the exact release tag/commit, recycle canonical demo on port `17883`, run `npm run demo:verify-canonical`, and prove expected/catalog/live installed tag match before claiming this slice demo-current.

## Cleanup
- Branch: `agent/issue-231-bulk-owner-handoff`
- Local checkout clean after commit/push except normal branch tracking state.