### PR TITLE
feat: surface runtime telemetry status

### DIFF
--- a/src/features/operations/index.tsx
+++ b/src/features/operations/index.tsx
@@ -15,8 +15,14 @@ import {
 } from '@tanstack/react-table'
 import { Activity, ClipboardCheck, FileChartColumn } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
-import { useServices } from '@/lib/service-lasso-dashboard/hooks'
-import type { DashboardService } from '@/lib/service-lasso-dashboard/types'
+import {
+  useServices,
+  useTelemetryPreview,
+} from '@/lib/service-lasso-dashboard/hooks'
+import type {
+  DashboardService,
+  TelemetryPreview,
+} from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -97,7 +103,129 @@ function operationStateForService(service: DashboardService): OperationsState {
   return 'unavailable'
 }
 
-function buildTelemetryRows(services: DashboardService[]): TelemetryRow[] {
+function telemetryPreviewState(telemetryPreview: TelemetryPreview) {
+  const hasSafeExportPreview =
+    !telemetryPreview.exportPreview.endpointValueReturned &&
+    !telemetryPreview.exportPreview.headersValueReturned &&
+    !telemetryPreview.exportPreview.bodyValueReturned
+
+  if (!hasSafeExportPreview) return 'unavailable'
+  if (telemetryPreview.exporter.status === 'disabled') return 'degraded'
+  return 'available'
+}
+
+function buildTelemetryPreviewRows(
+  telemetryPreview?: TelemetryPreview,
+  telemetryError?: Error | null
+): TelemetryRow[] {
+  if (telemetryError) {
+    return [
+      {
+        id: 'runtime-telemetry-preview-error',
+        signal: 'Core telemetry preview',
+        source: 'Service Lasso',
+        owner: 'service-lasso-core',
+        state: 'unavailable',
+        lastSample: 'Unavailable',
+        value: telemetryError.message,
+        nextAction: 'Verify the Service Lasso runtime /api/telemetry endpoint.',
+      },
+    ]
+  }
+
+  if (!telemetryPreview) return []
+
+  const apiRequestBuffer = telemetryPreview.apiRequestBuffer
+  const apiRequestSummary = telemetryPreview.apiRequestSummary
+
+  return [
+    {
+      id: 'runtime-telemetry-exporter',
+      signal: 'Core telemetry exporter',
+      source: 'Service Lasso',
+      owner: telemetryPreview.resource.serviceName,
+      state: telemetryPreviewState(telemetryPreview),
+      lastSample: telemetryPreview.contractVersion,
+      value: `${telemetryPreview.exporter.protocol} ${telemetryPreview.exporter.status}; endpoint hidden=${!telemetryPreview.exporter.endpointValueReturned}; headers hidden=${!telemetryPreview.exporter.headersValueReturned}`,
+      nextAction: telemetryPreview.exporter.reason,
+    },
+    {
+      id: 'runtime-telemetry-redaction',
+      signal: 'Telemetry allowlist redaction',
+      source: 'Service Lasso',
+      owner: telemetryPreview.resource.serviceNamespace,
+      state:
+        telemetryPreview.redaction.mode === 'allowlist'
+          ? 'available'
+          : 'degraded',
+      lastSample: `${telemetryPreview.redaction.allowedAttributes.length} attributes`,
+      value: `${telemetryPreview.redaction.forbiddenFieldClasses.length} forbidden field classes omitted`,
+      nextAction:
+        'Keep Service Admin telemetry metadata-only and avoid raw request, config, credential, or secret material.',
+    },
+    {
+      id: 'runtime-telemetry-export-preview',
+      signal: 'OTLP export preview',
+      source: 'Service Lasso',
+      owner: telemetryPreview.resource.serviceInstanceId,
+      state:
+        telemetryPreview.exportPreview.endpointValueReturned ||
+        telemetryPreview.exportPreview.headersValueReturned ||
+        telemetryPreview.exportPreview.bodyValueReturned
+          ? 'unavailable'
+          : telemetryPreview.exportPreview.mode === 'disabled'
+            ? 'degraded'
+            : 'available',
+      lastSample: `${telemetryPreview.exportPreview.signalCount} signals`,
+      value: `${telemetryPreview.exportPreview.mode}/${telemetryPreview.exportPreview.status}; ${telemetryPreview.exportPreview.serviceCount} services`,
+      nextAction: telemetryPreview.exportPreview.reason,
+    },
+    ...(apiRequestBuffer
+      ? [
+          {
+            id: 'runtime-telemetry-request-buffer',
+            signal: 'API request buffer safety',
+            source: 'Service Lasso' as const,
+            owner: 'route-template telemetry',
+            state:
+              apiRequestBuffer.routeTemplateOnly &&
+              !apiRequestBuffer.rawMaterialReturned
+                ? ('available' as const)
+                : ('unavailable' as const),
+            lastSample: `${apiRequestBuffer.retainedCount}/${apiRequestBuffer.capacity} retained`,
+            value: `${apiRequestBuffer.droppedCount} dropped; route templates only=${apiRequestBuffer.routeTemplateOnly}`,
+            nextAction:
+              'Use aggregate request metadata only; raw URLs, query strings, headers, and bodies stay hidden.',
+          },
+        ]
+      : []),
+    ...(apiRequestSummary
+      ? [
+          {
+            id: 'runtime-telemetry-request-summary',
+            signal: 'API request summary',
+            source: 'Service Lasso' as const,
+            owner: 'operations telemetry',
+            state:
+              apiRequestSummary.routeTemplateOnly &&
+              !apiRequestSummary.rawMaterialReturned
+                ? ('available' as const)
+                : ('unavailable' as const),
+            lastSample: `${apiRequestSummary.totalObservedCount} observed`,
+            value: `${apiRequestSummary.mutatingCount} mutating; ${apiRequestSummary.routeGroups.length} route groups`,
+            nextAction:
+              'Show status classes, outcomes, and route groups without raw request material.',
+          },
+        ]
+      : []),
+  ]
+}
+
+function buildTelemetryRows(
+  services: DashboardService[],
+  telemetryPreview?: TelemetryPreview,
+  telemetryError?: Error | null
+): TelemetryRow[] {
   const serviceRows: TelemetryRow[] = services.slice(0, 6).map((service) => ({
     id: `service-${service.id}`,
     signal: service.name,
@@ -113,7 +241,7 @@ function buildTelemetryRows(services: DashboardService[]): TelemetryRow[] {
   }))
 
   return [
-    ...serviceRows,
+    ...buildTelemetryPreviewRows(telemetryPreview, telemetryError),
     {
       id: 'runtime-health',
       signal: 'Runtime API health',
@@ -149,6 +277,7 @@ function buildTelemetryRows(services: DashboardService[]): TelemetryRow[] {
       nextAction:
         'Keep this explicit instead of presenting missing telemetry as success.',
     },
+    ...serviceRows,
   ]
 }
 
@@ -510,10 +639,20 @@ export function OperationsTelemetry() {
   })
 
   const servicesQuery = useServices()
+  const telemetryQuery = useTelemetryPreview()
+  const telemetryError =
+    telemetryQuery.error instanceof Error ? telemetryQuery.error : null
   const rows = useMemo(
-    () => buildTelemetryRows(servicesQuery.data ?? []),
-    [servicesQuery.data]
+    () =>
+      buildTelemetryRows(
+        servicesQuery.data ?? [],
+        telemetryQuery.data,
+        telemetryError
+      ),
+    [servicesQuery.data, telemetryError, telemetryQuery.data]
   )
+  const requestSummary = telemetryQuery.data?.apiRequestSummary
+  const exporter = telemetryQuery.data?.exporter
 
   return (
     <>
@@ -549,15 +688,23 @@ export function OperationsTelemetry() {
             <div className='flex items-center gap-2 text-sm font-medium'>
               <ClipboardCheck className='size-4' /> Safety boundary
             </div>
-            <div className='mt-2 text-2xl font-bold'>No values</div>
+            <div className='mt-2 text-2xl font-bold'>
+              {exporter
+                ? exporter.endpointValueReturned ||
+                  exporter.headersValueReturned
+                  ? 'Review'
+                  : 'Hidden'
+                : 'No values'}
+            </div>
             <p className='text-xs text-muted-foreground'>
-              No secret values, tokens, credentials, or raw log payloads are
-              shown.
+              {requestSummary
+                ? `${requestSummary.totalObservedCount} API requests observed with raw material returned=${requestSummary.rawMaterialReturned}.`
+                : 'No secret values, tokens, credentials, or raw log payloads are shown.'}
             </p>
           </div>
         </div>
 
-        {servicesQuery.isLoading ? (
+        {servicesQuery.isLoading || telemetryQuery.isLoading ? (
           <OperationsLoading />
         ) : (
           <OperationsTable

--- a/src/features/operations/operations.test.tsx
+++ b/src/features/operations/operations.test.tsx
@@ -10,16 +10,27 @@ describe('Operations pages', () => {
       await screen.findByRole('heading', { name: /^Telemetry$/i })
     ).toBeVisible()
     expect(screen.getByText(/Service Lasso runtime/i)).toBeVisible()
+    expect(await screen.findByText(/Core telemetry exporter/i)).toBeVisible()
+    expect(screen.getByText(/otlp-http disabled/i)).toBeVisible()
+    expect(screen.getByText(/endpoint hidden=true/i)).toBeVisible()
+    expect(screen.getByText(/API request buffer safety/i)).toBeVisible()
+    expect(screen.getByText(/route templates only=true/i)).toBeVisible()
+    expect(screen.getByText(/API request summary/i)).toBeVisible()
+    expect(screen.getByText(/21 observed/i)).toBeVisible()
     expect(
       await screen.findByText(/Secrets Broker telemetry endpoint/i)
     ).toBeVisible()
     expect(
       await screen.findByText(/not configured in the current demo/i)
     ).toBeVisible()
-    expect(screen.getByText(/No values/i)).toBeVisible()
+    const [hiddenBoundary] = screen.getAllByText(/Hidden/i)
+    expect(hiddenBoundary).toBeVisible()
     expect(container).not.toHaveTextContent(/BEGIN PRIVATE KEY/i)
     expect(container).not.toHaveTextContent(/CLIENT_SECRET=/i)
     expect(container).not.toHaveTextContent(/REFRESH_TOKEN=/i)
+    expect(container).not.toHaveTextContent(/OTEL_EXPORTER_OTLP_HEADERS/i)
+    expect(container).not.toHaveTextContent(/Authorization/i)
+    expect(container).not.toHaveTextContent(/http:\/\/otel-collector/i)
   })
 
   it('renders audit logging rows from both operation sources without secret payloads', async () => {

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -4,6 +4,7 @@ import {
   fetchDashboardService as fetchStubDashboardService,
   fetchDashboardSummary as fetchStubDashboardSummary,
   fetchServices as fetchStubServices,
+  fetchTelemetryPreview as fetchStubTelemetryPreview,
   runDashboardAction as runStubDashboardAction,
   saveServiceConfigDocument as saveStubServiceConfigDocument,
   serviceLassoApiBaseUrl,
@@ -16,6 +17,7 @@ import type {
   ServiceConfigDocument,
   ServiceConfigSaveResult,
   ServiceLogType,
+  TelemetryPreview,
 } from './types'
 
 type DashboardSummaryResponse = {
@@ -28,6 +30,10 @@ type DashboardServicesResponse = {
 
 type DashboardServiceDetailResponse = {
   service: DashboardService
+}
+
+type TelemetryPreviewResponse = {
+  telemetry: TelemetryPreview
 }
 
 function encodeServiceId(serviceId: string) {
@@ -113,6 +119,12 @@ async function fetchRuntimeDashboardService(serviceId: string) {
   return payload.service ?? null
 }
 
+async function fetchRuntimeTelemetryPreview() {
+  const payload =
+    await fetchRuntimeJson<TelemetryPreviewResponse>('/api/telemetry')
+  return payload.telemetry
+}
+
 async function updateRuntimeFavorite(serviceId: string) {
   const service = await fetchRuntimeDashboardService(serviceId)
   if (!service) {
@@ -185,6 +197,14 @@ export async function fetchDashboardService(serviceId: string) {
   }
 
   return fetchRuntimeDashboardService(serviceId)
+}
+
+export async function fetchTelemetryPreview() {
+  if (stubDashboardDataEnabled) {
+    return fetchStubTelemetryPreview()
+  }
+
+  return fetchRuntimeTelemetryPreview()
 }
 
 export async function fetchServiceConfigDocument(serviceId: string) {

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -5,6 +5,7 @@ import {
   fetchDashboardService,
   fetchDashboardSummary,
   fetchServices,
+  fetchTelemetryPreview,
   runDashboardAction,
 } from './client'
 import { favoritesMutationEnabled } from './stub'
@@ -23,6 +24,13 @@ export function useServices() {
   return useQuery({
     queryKey: [...dashboardQueryKey, 'services'],
     queryFn: fetchServices,
+  })
+}
+
+export function useTelemetryPreview() {
+  return useQuery({
+    queryKey: [...dashboardQueryKey, 'telemetry-preview'],
+    queryFn: fetchTelemetryPreview,
   })
 }
 

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -7,6 +7,7 @@ import type {
   ServiceConfigSaveResult,
   ServiceLogType,
   ServiceStatus,
+  TelemetryPreview,
 } from './types'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -824,6 +825,86 @@ export async function fetchServices() {
   await wait(120)
   await syncFavoriteStateFromApi()
   return structuredClone(services)
+}
+
+export async function fetchTelemetryPreview(): Promise<TelemetryPreview> {
+  await wait(120)
+  return structuredClone({
+    contractVersion: 'service-lasso.telemetry-preview.v1',
+    exporter: {
+      status: 'disabled',
+      protocol: 'otlp-http',
+      endpointConfigured: false,
+      endpointValueReturned: false,
+      headersValueReturned: false,
+      reason:
+        'OTLP export is disabled until runtime exporter settings are configured.',
+    },
+    resource: {
+      serviceName: 'service-lasso-core',
+      serviceNamespace: 'service-lasso',
+      serviceInstanceId: 'stub-runtime',
+    },
+    redaction: {
+      mode: 'allowlist',
+      allowedAttributes: [
+        'api.route_group',
+        'http.route',
+        'http.response.status_class',
+        'service.id',
+        'service.health.status',
+      ],
+      forbiddenFieldClasses: [
+        'raw secret values',
+        'environment values',
+        'provider tokens or credentials',
+        'cookies and authorization headers',
+        'raw request or response bodies',
+        'raw URL paths and query strings',
+      ],
+    },
+    exportPreview: {
+      mode: 'disabled',
+      status: 'not_sent',
+      signalCount: 42,
+      serviceCount: services.length,
+      endpointConfigured: false,
+      endpointValueReturned: false,
+      headersValueReturned: false,
+      bodyValueReturned: false,
+      allowedAttributeCount: 5,
+      reason:
+        'The Service Admin stub mirrors runtime telemetry status without exporter endpoints, headers, or payload bodies.',
+    },
+    apiRequestBuffer: {
+      capacity: 50,
+      retainedCount: 18,
+      droppedCount: 3,
+      routeTemplateOnly: true,
+      rawMaterialReturned: false,
+    },
+    apiRequestSummary: {
+      retainedCount: 18,
+      droppedCount: 3,
+      totalObservedCount: 21,
+      mutatingCount: 2,
+      routeGroups: [
+        { key: 'health', count: 8 },
+        { key: 'services', count: 6 },
+        { key: 'telemetry', count: 4 },
+      ],
+      statusClasses: [
+        { key: '2xx', count: 17 },
+        { key: '4xx', count: 1 },
+      ],
+      outcomes: [
+        { key: 'success', count: 17 },
+        { key: 'failure', count: 1 },
+      ],
+      routeTemplateOnly: true,
+      rawMaterialReturned: false,
+    },
+  } satisfies TelemetryPreview)
 }
 
 export async function fetchDashboardService(serviceId: string) {

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -173,3 +173,60 @@ export type ServiceConfigSaveResult = {
   backup: ServiceConfigRevision
   validationStatus: 'valid'
 }
+
+export type TelemetryCountBucket = {
+  key: string
+  count: number
+}
+
+export type TelemetryPreview = {
+  contractVersion: string
+  exporter: {
+    status: 'disabled' | 'configured' | 'error' | string
+    protocol: string
+    endpointConfigured: boolean
+    endpointValueReturned: boolean
+    headersValueReturned: boolean
+    reason: string
+  }
+  resource: {
+    serviceName: string
+    serviceNamespace: string
+    serviceInstanceId: string
+  }
+  redaction: {
+    mode: string
+    allowedAttributes: string[]
+    forbiddenFieldClasses: string[]
+  }
+  exportPreview: {
+    mode: 'disabled' | 'dry_run' | string
+    status: 'not_sent' | 'ready' | string
+    signalCount: number
+    serviceCount: number
+    endpointConfigured: boolean
+    endpointValueReturned: boolean
+    headersValueReturned: boolean
+    bodyValueReturned: boolean
+    allowedAttributeCount: number
+    reason: string
+  }
+  apiRequestBuffer?: {
+    capacity: number
+    retainedCount: number
+    droppedCount: number
+    routeTemplateOnly: boolean
+    rawMaterialReturned: boolean
+  }
+  apiRequestSummary?: {
+    retainedCount: number
+    droppedCount: number
+    totalObservedCount: number
+    mutatingCount: number
+    routeGroups: TelemetryCountBucket[]
+    statusClasses: TelemetryCountBucket[]
+    outcomes: TelemetryCountBucket[]
+    routeTemplateOnly: boolean
+    rawMaterialReturned: boolean
+  }
+}


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Add a typed Service Lasso /api/telemetry preview client and React Query hook.
- Surface core telemetry exporter state, redaction allowlist status, OTLP export preview, API request buffer safety, and API request summary aggregates in Operations > Telemetry.
- Add stub telemetry preview data and Operations tests proving endpoint/header/body values and secret-like material are not rendered.

## Scope
- In scope: Service Admin operator status surfacing for the existing core telemetry preview contract.
- Out of scope: live OTLP export, Secrets Broker-native telemetry emission, and full #635 closure.

## Spec / contract / fixture impact
- Updated: Service Admin runtime client types and stub fixture for the existing service-lasso.telemetry-preview.v1 contract.
- Not required: no new public Service Admin route or backend contract.

## Nash invariant impact
- Invariant: telemetry remains metadata-only and redacted by allowlist.
- Preservation proof: UI displays exporter/summary safety booleans and tests assert common endpoint/header/credential sentinels are absent.

## Validation
- PASS 
pm run test:unit -- src/features/operations/operations.test.tsx — .work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/test-operations-telemetry-status.log
- PASS 
pm run build — .work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/build-serviceadmin-telemetry-status.log
- PASS git diff --check — .work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/diff-check-serviceadmin-telemetry-status.log

## Approval trail
- Required: pending repository checks/review gate.
- Evidence: PR checks will be linked by GitHub Actions.

## Cleanup
- Release-to-demo gate is pending after merge because lasso-serviceadmin is demo-consumed: publish/release, update the core @serviceadmin pin to the exact release tag/commit, recycle canonical demo on port 17883, run 
pm run demo:verify-canonical, and verify expected/catalog/installed/live tag before demo-current claim.