### PR TITLE
feat: surface broker telemetry status

### DIFF
--- a/docs/operations-telemetry.md
+++ b/docs/operations-telemetry.md
@@ -1,0 +1,15 @@
+# Operations telemetry
+
+Issue: service-lasso/service-lasso#635
+
+Service Admin exposes Operations / Telemetry as a metadata-only operator surface for Service Lasso runtime and Secrets Broker telemetry status.
+
+Current behavior:
+
+- Core runtime status is read from `/api/telemetry`.
+- Secrets Broker service telemetry status is read through the core runtime route `/api/services/@secretsbroker/telemetry`.
+- The browser does not call the broker loopback endpoint directly; core remains the operator-visible API boundary.
+- Rows may show service id, version/tag, artifact asset, signal kind, health/readiness, phase, outcome, trace id posture, span id posture, `traceparent` posture, and Service Lasso correlation id posture.
+- Rows must not show OTLP endpoints, OTLP headers, auth headers, cookies, provider tokens, credentials, raw request or response bodies, query strings, raw secret values, private keys, recovery material, or environment values.
+
+This page is a status/review surface only. It does not configure exporters and does not send telemetry.

--- a/src/features/operations/index.tsx
+++ b/src/features/operations/index.tsx
@@ -16,11 +16,13 @@ import {
 import { Activity, ClipboardCheck, FileChartColumn } from 'lucide-react'
 import { usePageMetadata } from '@/lib/page-metadata'
 import {
+  useServiceTelemetryPreview,
   useServices,
   useTelemetryPreview,
 } from '@/lib/service-lasso-dashboard/hooks'
 import type {
   DashboardService,
+  ServiceTelemetryPreview,
   TelemetryPreview,
 } from '@/lib/service-lasso-dashboard/types'
 import { Badge } from '@/components/ui/badge'
@@ -224,7 +226,9 @@ function buildTelemetryPreviewRows(
 function buildTelemetryRows(
   services: DashboardService[],
   telemetryPreview?: TelemetryPreview,
-  telemetryError?: Error | null
+  telemetryError?: Error | null,
+  secretsBrokerTelemetry?: ServiceTelemetryPreview,
+  secretsBrokerTelemetryError?: Error | null
 ): TelemetryRow[] {
   const serviceRows: TelemetryRow[] = services.slice(0, 6).map((service) => ({
     id: `service-${service.id}`,
@@ -266,18 +270,99 @@ function buildTelemetryRows(
       value: `${secretsBrokerAuditEvents.length} metadata-only audit events loaded`,
       nextAction: 'Use Audit Logging for policy, outcome, and chain status.',
     },
-    {
-      id: 'secretsbroker-telemetry-endpoint',
-      signal: 'Secrets Broker telemetry endpoint',
-      source: 'Secrets Broker',
-      owner: '@secretsbroker',
-      state: 'unavailable',
-      lastSample: 'Not configured',
-      value: 'Broker metrics endpoint is not configured in the current demo.',
-      nextAction:
-        'Keep this explicit instead of presenting missing telemetry as success.',
-    },
+    ...buildSecretsBrokerTelemetryRows(
+      secretsBrokerTelemetry,
+      secretsBrokerTelemetryError
+    ),
     ...serviceRows,
+  ]
+}
+
+function buildSecretsBrokerTelemetryRows(
+  telemetryPreview?: ServiceTelemetryPreview,
+  telemetryError?: Error | null
+): TelemetryRow[] {
+  if (telemetryError) {
+    return [
+      {
+        id: 'secretsbroker-telemetry-preview-error',
+        signal: 'Secrets Broker service telemetry',
+        source: 'Secrets Broker',
+        owner: '@secretsbroker',
+        state: 'unavailable',
+        lastSample: 'Unavailable',
+        value: telemetryError.message,
+        nextAction:
+          'Verify the core /api/services/@secretsbroker/telemetry proxy before relying on broker telemetry status.',
+      },
+    ]
+  }
+
+  if (!telemetryPreview) {
+    return [
+      {
+        id: 'secretsbroker-telemetry-preview-pending',
+        signal: 'Secrets Broker service telemetry',
+        source: 'Secrets Broker',
+        owner: '@secretsbroker',
+        state: 'degraded',
+        lastSample: 'Not sampled',
+        value: 'Waiting for core service telemetry preview.',
+        nextAction:
+          'Keep broker telemetry explicit until a runtime-backed preview is available.',
+      },
+    ]
+  }
+
+  const signals = telemetryPreview.signals
+  const firstSignal = signals[0]
+  const attributes = firstSignal?.attributes ?? {}
+  const signalCount = signals.length
+  const signalKinds = Array.from(new Set(signals.map((signal) => signal.kind)))
+  const allSignalsHaveTraceContext =
+    signalCount > 0 &&
+    signals.every(
+      (signal) =>
+        Boolean(signal.traceparent) &&
+        Boolean(signal.traceId) &&
+        Boolean(signal.spanId) &&
+        Boolean(signal.correlationId)
+    )
+  const rawAttributeKeysReturned = Object.keys(attributes).some((key) =>
+    /authorization|cookie|header|body|query|secret|token|credential|private/i.test(
+      key
+    )
+  )
+  const serviceTag =
+    typeof attributes['service.artifact.tag'] === 'string'
+      ? attributes['service.artifact.tag']
+      : typeof attributes['service.version'] === 'string'
+        ? attributes['service.version']
+        : 'tag unavailable'
+
+  return [
+    {
+      id: 'secretsbroker-service-trace-context',
+      signal: 'Secrets Broker service trace context',
+      source: 'Secrets Broker',
+      owner: telemetryPreview.serviceId,
+      state: allSignalsHaveTraceContext ? 'available' : 'degraded',
+      lastSample: `${signalCount} signals`,
+      value: `w3c traceparent=${allSignalsHaveTraceContext}; correlation ids=${allSignalsHaveTraceContext}`,
+      nextAction:
+        'Use the core service telemetry route for broker trace posture; incoming headers and raw request material stay out of the UI.',
+    },
+    {
+      id: 'secretsbroker-service-safe-envelope',
+      signal: 'Secrets Broker telemetry safe envelope',
+      source: 'Secrets Broker',
+      owner: serviceTag,
+      state: rawAttributeKeysReturned ? 'unavailable' : 'available',
+      lastSample: signalKinds.join(', ') || 'No signals',
+      value: `route/service attributes only; unsafe keys returned=${rawAttributeKeysReturned}`,
+      nextAction:
+        'Display service id, version, health, phase, outcome, and artifact metadata only.',
+    },
   ]
 }
 
@@ -640,16 +725,30 @@ export function OperationsTelemetry() {
 
   const servicesQuery = useServices()
   const telemetryQuery = useTelemetryPreview()
+  const secretsBrokerTelemetryQuery =
+    useServiceTelemetryPreview('@secretsbroker')
   const telemetryError =
     telemetryQuery.error instanceof Error ? telemetryQuery.error : null
+  const secretsBrokerTelemetryError =
+    secretsBrokerTelemetryQuery.error instanceof Error
+      ? secretsBrokerTelemetryQuery.error
+      : null
   const rows = useMemo(
     () =>
       buildTelemetryRows(
         servicesQuery.data ?? [],
         telemetryQuery.data,
-        telemetryError
+        telemetryError,
+        secretsBrokerTelemetryQuery.data,
+        secretsBrokerTelemetryError
       ),
-    [servicesQuery.data, telemetryError, telemetryQuery.data]
+    [
+      secretsBrokerTelemetryError,
+      secretsBrokerTelemetryQuery.data,
+      servicesQuery.data,
+      telemetryError,
+      telemetryQuery.data,
+    ]
   )
   const requestSummary = telemetryQuery.data?.apiRequestSummary
   const exporter = telemetryQuery.data?.exporter
@@ -681,7 +780,7 @@ export function OperationsTelemetry() {
               {rows.filter((row) => row.source === 'Secrets Broker').length}
             </div>
             <p className='text-xs text-muted-foreground'>
-              Broker rows are metadata-only and mark unavailable telemetry.
+              Broker rows are sourced from core service telemetry metadata.
             </p>
           </div>
           <div className='rounded-md border p-4'>
@@ -704,7 +803,9 @@ export function OperationsTelemetry() {
           </div>
         </div>
 
-        {servicesQuery.isLoading || telemetryQuery.isLoading ? (
+        {servicesQuery.isLoading ||
+        telemetryQuery.isLoading ||
+        secretsBrokerTelemetryQuery.isLoading ? (
           <OperationsLoading />
         ) : (
           <OperationsTable

--- a/src/features/operations/operations.test.tsx
+++ b/src/features/operations/operations.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 describe('Operations pages', () => {
-  it('renders telemetry rows for Service Lasso and Secrets Broker with explicit unavailable state', async () => {
+  it('renders telemetry rows for Service Lasso and Secrets Broker without secret material', async () => {
     const { container } = await renderRoute('/operations/telemetry')
 
     expect(
@@ -18,11 +18,13 @@ describe('Operations pages', () => {
     expect(screen.getByText(/API request summary/i)).toBeVisible()
     expect(screen.getByText(/21 observed/i)).toBeVisible()
     expect(
-      await screen.findByText(/Secrets Broker telemetry endpoint/i)
+      await screen.findByText(/Secrets Broker service trace context/i)
     ).toBeVisible()
+    expect(await screen.findByText(/w3c traceparent=true/i)).toBeVisible()
     expect(
-      await screen.findByText(/not configured in the current demo/i)
+      await screen.findByText(/Secrets Broker telemetry safe envelope/i)
     ).toBeVisible()
+    expect(screen.getByText(/unsafe keys returned=false/i)).toBeVisible()
     const [hiddenBoundary] = screen.getAllByText(/Hidden/i)
     expect(hiddenBoundary).toBeVisible()
     expect(container).not.toHaveTextContent(/BEGIN PRIVATE KEY/i)
@@ -31,6 +33,8 @@ describe('Operations pages', () => {
     expect(container).not.toHaveTextContent(/OTEL_EXPORTER_OTLP_HEADERS/i)
     expect(container).not.toHaveTextContent(/Authorization/i)
     expect(container).not.toHaveTextContent(/http:\/\/otel-collector/i)
+    expect(container).not.toHaveTextContent(/ACTUAL_SECRET/i)
+    expect(container).not.toHaveTextContent(/BOT_TOKEN=/i)
   })
 
   it('renders audit logging rows from both operation sources without secret payloads', async () => {

--- a/src/lib/service-lasso-dashboard/client.test.ts
+++ b/src/lib/service-lasso-dashboard/client.test.ts
@@ -178,6 +178,52 @@ describe('service lasso dashboard runtime client', () => {
     )
   })
 
+  it('uses the runtime service telemetry route for service-scoped telemetry previews', async () => {
+    vi.stubEnv('VITE_SERVICE_LASSO_API_BASE_URL', 'http://runtime.test')
+
+    const telemetry = {
+      serviceId: '@secretsbroker',
+      signals: [
+        {
+          kind: 'span',
+          name: 'service_lasso.service.lifecycle',
+          traceId: 'f2d1412190c7ec276ca474894c82eb27',
+          spanId: '5a2ae73908a7986d',
+          traceparent:
+            '00-f2d1412190c7ec276ca474894c82eb27-5a2ae73908a7986d-01',
+          correlationId: 'sl-85a59ffe07646ec3',
+          attributes: {
+            'service.id': '@secretsbroker',
+            'service.version': '2026.6.26-test',
+            'service.operation.outcome': 'healthy',
+          },
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (
+        url === 'http://runtime.test/api/services/%40secretsbroker/telemetry'
+      ) {
+        return jsonResponse({ telemetry })
+      }
+
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { fetchServiceTelemetryPreview } = await import('./client')
+
+    await expect(
+      fetchServiceTelemetryPreview('@secretsbroker')
+    ).resolves.toEqual(telemetry)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://runtime.test/api/services/%40secretsbroker/telemetry',
+      undefined
+    )
+  })
+
   it('uses same-origin runtime API by default instead of dashboard stubs', async () => {
     const services = [service('@archive', 'Archive Runtime', 'available')]
     const fetchMock = vi.fn(async (url: string) => {

--- a/src/lib/service-lasso-dashboard/client.ts
+++ b/src/lib/service-lasso-dashboard/client.ts
@@ -3,6 +3,7 @@ import {
   fetchServiceConfigDocument as fetchStubServiceConfigDocument,
   fetchDashboardService as fetchStubDashboardService,
   fetchDashboardSummary as fetchStubDashboardSummary,
+  fetchServiceTelemetryPreview as fetchStubServiceTelemetryPreview,
   fetchServices as fetchStubServices,
   fetchTelemetryPreview as fetchStubTelemetryPreview,
   runDashboardAction as runStubDashboardAction,
@@ -17,6 +18,7 @@ import type {
   ServiceConfigDocument,
   ServiceConfigSaveResult,
   ServiceLogType,
+  ServiceTelemetryPreview,
   TelemetryPreview,
 } from './types'
 
@@ -34,6 +36,10 @@ type DashboardServiceDetailResponse = {
 
 type TelemetryPreviewResponse = {
   telemetry: TelemetryPreview
+}
+
+type ServiceTelemetryPreviewResponse = {
+  telemetry: ServiceTelemetryPreview
 }
 
 function encodeServiceId(serviceId: string) {
@@ -125,6 +131,13 @@ async function fetchRuntimeTelemetryPreview() {
   return payload.telemetry
 }
 
+async function fetchRuntimeServiceTelemetryPreview(serviceId: string) {
+  const payload = await fetchRuntimeJson<ServiceTelemetryPreviewResponse>(
+    `/api/services/${encodeServiceId(serviceId)}/telemetry`
+  )
+  return payload.telemetry
+}
+
 async function updateRuntimeFavorite(serviceId: string) {
   const service = await fetchRuntimeDashboardService(serviceId)
   if (!service) {
@@ -205,6 +218,14 @@ export async function fetchTelemetryPreview() {
   }
 
   return fetchRuntimeTelemetryPreview()
+}
+
+export async function fetchServiceTelemetryPreview(serviceId: string) {
+  if (stubDashboardDataEnabled) {
+    return fetchStubServiceTelemetryPreview(serviceId)
+  }
+
+  return fetchRuntimeServiceTelemetryPreview(serviceId)
 }
 
 export async function fetchServiceConfigDocument(serviceId: string) {

--- a/src/lib/service-lasso-dashboard/hooks.ts
+++ b/src/lib/service-lasso-dashboard/hooks.ts
@@ -4,6 +4,7 @@ import {
   buildServiceLogUrl,
   fetchDashboardService,
   fetchDashboardSummary,
+  fetchServiceTelemetryPreview,
   fetchServices,
   fetchTelemetryPreview,
   runDashboardAction,
@@ -31,6 +32,13 @@ export function useTelemetryPreview() {
   return useQuery({
     queryKey: [...dashboardQueryKey, 'telemetry-preview'],
     queryFn: fetchTelemetryPreview,
+  })
+}
+
+export function useServiceTelemetryPreview(serviceId: string) {
+  return useQuery({
+    queryKey: [...dashboardQueryKey, serviceId, 'telemetry-preview'],
+    queryFn: () => fetchServiceTelemetryPreview(serviceId),
   })
 }
 

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -7,6 +7,8 @@ import type {
   ServiceConfigSaveResult,
   ServiceLogType,
   ServiceStatus,
+  ServiceTelemetryPreview,
+  ServiceTelemetrySignal,
   TelemetryPreview,
 } from './types'
 
@@ -905,6 +907,79 @@ export async function fetchTelemetryPreview(): Promise<TelemetryPreview> {
       rawMaterialReturned: false,
     },
   } satisfies TelemetryPreview)
+}
+
+export async function fetchServiceTelemetryPreview(
+  serviceId: string
+): Promise<ServiceTelemetryPreview> {
+  await wait(120)
+
+  const service = services.find((item) => item.id === serviceId)
+  const serviceVersion = service?.metadata.version ?? 'unknown'
+  const running =
+    service?.status === 'running' || service?.status === 'available'
+  const signals: ServiceTelemetrySignal[] = [
+    {
+      kind: 'span',
+      name: 'service_lasso.service.lifecycle',
+      traceId: 'f2d1412190c7ec276ca474894c82eb27',
+      spanId: '5a2ae73908a7986d',
+      traceparent: '00-f2d1412190c7ec276ca474894c82eb27-5a2ae73908a7986d-01',
+      correlationId: 'sl-85a59ffe07646ec3',
+      attributes: {
+        'service.id': serviceId,
+        'service.role': 'service',
+        'service.version': serviceVersion,
+        'service.artifact.tag': serviceVersion,
+        'service.artifact.asset':
+          serviceId === '@secretsbroker'
+            ? 'secretsbroker-win32.zip'
+            : 'service-package.zip',
+        'service.lifecycle.installed': Boolean(service?.installed),
+        'service.lifecycle.running': running,
+        'service.operation.phase': 'lifecycle',
+        'service.operation.outcome': running ? 'healthy' : 'unavailable',
+      },
+    },
+    {
+      kind: 'span',
+      name: 'service_lasso.service.health_check',
+      traceId: 'f2d1412190c7ec276ca474894c82eb27',
+      spanId: '771b717f65a3d595',
+      traceparent: '00-f2d1412190c7ec276ca474894c82eb27-771b717f65a3d595-01',
+      correlationId: 'sl-85a59ffe07646ec3',
+      attributes: {
+        'service.id': serviceId,
+        'service.role': 'service',
+        'service.version': serviceVersion,
+        'service.health.status': running ? 'healthy' : 'critical',
+        'service.health.readiness': running ? 'ready' : 'blocked',
+        'service.operation.phase': 'health_check',
+        'service.operation.outcome': running ? 'healthy' : 'unavailable',
+      },
+    },
+    {
+      kind: 'metric',
+      name: 'service_lasso.service.runtime.launches',
+      traceId: 'f2d1412190c7ec276ca474894c82eb27',
+      spanId: '3df4003721bde212',
+      traceparent: '00-f2d1412190c7ec276ca474894c82eb27-3df4003721bde212-01',
+      correlationId: 'sl-85a59ffe07646ec3',
+      attributes: {
+        'service.id': serviceId,
+        'service.role': 'service',
+        'service.version': serviceVersion,
+        'service.operation.phase': 'runtime_metrics',
+        'service.operation.outcome': running ? 'healthy' : 'unavailable',
+        'service.operation.duration_ms': 0,
+      },
+    },
+  ]
+
+  return structuredClone({
+    serviceId,
+    signals,
+  } satisfies ServiceTelemetryPreview)
 }
 
 export async function fetchDashboardService(serviceId: string) {

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -179,6 +179,21 @@ export type TelemetryCountBucket = {
   count: number
 }
 
+export type ServiceTelemetrySignal = {
+  kind: 'span' | 'metric' | 'log' | string
+  name: string
+  traceId?: string
+  spanId?: string
+  traceparent?: string
+  correlationId?: string
+  attributes: Record<string, string | number | boolean>
+}
+
+export type ServiceTelemetryPreview = {
+  serviceId: string
+  signals: ServiceTelemetrySignal[]
+}
+
 export type TelemetryPreview = {
   contractVersion: string
   exporter: {


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Adds Service Admin client/hook support for runtime service-scoped telemetry previews via `/api/services/{serviceId}/telemetry`.
- Surfaces `@secretsbroker` telemetry trace-context and safe-envelope posture on Operations / Telemetry.
- Documents the Service Admin telemetry boundary: core runtime API only, no direct browser calls to broker loopback endpoints, no endpoint/header/value material.

## Scope
- In scope: read-only Service Admin telemetry status surfacing for core-managed `@secretsbroker` service telemetry metadata.
- Out of scope: configuring exporters, sending telemetry, direct Secrets Broker loopback calls from the browser, or completing all remaining cross-service OTel work in #635.

## Spec / contract / fixture impact
- Updated: `docs/operations-telemetry.md`.
- Updated: dashboard telemetry client/stub types and fixtures for service-scoped telemetry preview.

## Nash invariant impact
- Invariant: telemetry UI remains metadata-only.
- Preservation proof: Operations test asserts no secret/token/private-key/OTLP endpoint/header sentinel material is rendered; UI rows are derived from allowlisted service signal metadata only.

## Validation
- PASS `npm run test:unit -- src/features/operations/operations.test.tsx src/lib/service-lasso-dashboard/client.test.ts src/lib/service-lasso-dashboard/stub.test.ts` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/test-focused-serviceadmin-telemetry-status.log`
- PASS `npm run build` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/build-serviceadmin-telemetry-status.log`
- PASS `npm run lint` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/lint-serviceadmin-telemetry-status.log`
- PASS `npx prettier --check ...` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/prettier-check-serviceadmin-telemetry-status.log`
- PASS `git diff --check` — `.work-agent/logs/cron-755b8bea-10c9-4a16-bd2b-172e57d11ff6-20260626T1431/issue-635-serviceadmin-telemetry-status/diff-check-serviceadmin-telemetry-status.log`

## Approval trail
- Required: no explicit human approval identified for this focused Service Admin UI slice.
- Evidence: open developer issue worker lane and Project #1 Ready status on service-lasso/service-lasso#635.

## Cleanup
- Branch: `feature/635-serviceadmin-telemetry-status`.
- If merged, `lasso-serviceadmin` is demo-consumed; publish/release as needed, pin the exact Service Admin release in core, recycle canonical demo on port 17883, then run `npm run demo:verify-canonical` before final completion claim.