### PR TITLE
feat: show telemetry correlation posture

### DIFF
--- a/docs/operations-telemetry.md
+++ b/docs/operations-telemetry.md
@@ -10,6 +10,8 @@ Current behavior:
 - Secrets Broker service telemetry status is read through the core runtime route `/api/services/@secretsbroker/telemetry`.
 - The browser does not call the broker loopback endpoint directly; core remains the operator-visible API boundary.
 - Rows may show service id, version/tag, artifact asset, signal kind, health/readiness, phase, outcome, trace id posture, span id posture, `traceparent` posture, and Service Lasso correlation id posture.
+- Rows may show core W3C trace propagation posture and response header names. They must show whether incoming/raw header values are returned, not the values themselves.
+- Cross-service rows may compare core trace propagation posture with the `@secretsbroker` service telemetry trace-context posture.
 - Rows must not show OTLP endpoints, OTLP headers, auth headers, cookies, provider tokens, credentials, raw request or response bodies, query strings, raw secret values, private keys, recovery material, or environment values.
 
 This page is a status/review surface only. It does not configure exporters and does not send telemetry.

--- a/src/features/operations/index.tsx
+++ b/src/features/operations/index.tsx
@@ -118,7 +118,8 @@ function telemetryPreviewState(telemetryPreview: TelemetryPreview) {
 
 function buildTelemetryPreviewRows(
   telemetryPreview?: TelemetryPreview,
-  telemetryError?: Error | null
+  telemetryError?: Error | null,
+  secretsBrokerTelemetry?: ServiceTelemetryPreview
 ): TelemetryRow[] {
   if (telemetryError) {
     return [
@@ -139,6 +140,21 @@ function buildTelemetryPreviewRows(
 
   const apiRequestBuffer = telemetryPreview.apiRequestBuffer
   const apiRequestSummary = telemetryPreview.apiRequestSummary
+  const traceContext = telemetryPreview.traceContext
+  const coreTraceContextSafe =
+    traceContext &&
+    traceContext.routeTemplateOnly &&
+    !traceContext.incomingHeadersReturned &&
+    !traceContext.rawHeadersReturned
+  const brokerTraceContextReady =
+    Boolean(secretsBrokerTelemetry?.signals.length) &&
+    secretsBrokerTelemetry?.signals.every(
+      (signal) =>
+        Boolean(signal.traceparent) &&
+        Boolean(signal.traceId) &&
+        Boolean(signal.spanId) &&
+        Boolean(signal.correlationId)
+    )
 
   return [
     {
@@ -182,6 +198,43 @@ function buildTelemetryPreviewRows(
       value: `${telemetryPreview.exportPreview.mode}/${telemetryPreview.exportPreview.status}; ${telemetryPreview.exportPreview.serviceCount} services`,
       nextAction: telemetryPreview.exportPreview.reason,
     },
+    ...(traceContext
+      ? [
+          {
+            id: 'runtime-telemetry-trace-context',
+            signal: 'Core trace propagation',
+            source: 'Service Lasso' as const,
+            owner: traceContext.propagation,
+            state: coreTraceContextSafe
+              ? ('available' as const)
+              : ('unavailable' as const),
+            lastSample: traceContext.traceparentSampled
+              ? 'sampled traceparent'
+              : 'unsampled traceparent',
+            value: `response header names=${Object.values(traceContext.responseHeaders).join(', ')}; raw headers returned=${traceContext.rawHeadersReturned}`,
+            nextAction:
+              'Propagate W3C trace context by header name only; incoming/raw header values stay hidden.',
+          },
+        ]
+      : []),
+    ...(traceContext && secretsBrokerTelemetry
+      ? [
+          {
+            id: 'runtime-telemetry-core-broker-correlation',
+            signal: 'Core-to-broker correlation',
+            source: 'Secrets Broker' as const,
+            owner: secretsBrokerTelemetry.serviceId,
+            state:
+              coreTraceContextSafe && brokerTraceContextReady
+                ? ('available' as const)
+                : ('degraded' as const),
+            lastSample: `${secretsBrokerTelemetry.signals.length} broker signals`,
+            value: `core propagation=${traceContext.propagation}; broker trace context=${brokerTraceContextReady}`,
+            nextAction:
+              'Use Service Lasso correlation IDs and W3C trace context posture without rendering header values or payloads.',
+          },
+        ]
+      : []),
     ...(apiRequestBuffer
       ? [
           {
@@ -245,7 +298,11 @@ function buildTelemetryRows(
   }))
 
   return [
-    ...buildTelemetryPreviewRows(telemetryPreview, telemetryError),
+    ...buildTelemetryPreviewRows(
+      telemetryPreview,
+      telemetryError,
+      secretsBrokerTelemetry
+    ),
     {
       id: 'runtime-health',
       signal: 'Runtime API health',
@@ -260,6 +317,10 @@ function buildTelemetryRows(
         ? 'Use Runtime or Logs for service-level details.'
         : 'Verify Service Lasso runtime health endpoint before operating.',
     },
+    ...buildSecretsBrokerTelemetryRows(
+      secretsBrokerTelemetry,
+      secretsBrokerTelemetryError
+    ),
     {
       id: 'secretsbroker-audit-metadata',
       signal: 'Secrets Broker audit metadata',
@@ -270,10 +331,6 @@ function buildTelemetryRows(
       value: `${secretsBrokerAuditEvents.length} metadata-only audit events loaded`,
       nextAction: 'Use Audit Logging for policy, outcome, and chain status.',
     },
-    ...buildSecretsBrokerTelemetryRows(
-      secretsBrokerTelemetry,
-      secretsBrokerTelemetryError
-    ),
     ...serviceRows,
   ]
 }

--- a/src/features/operations/operations.test.tsx
+++ b/src/features/operations/operations.test.tsx
@@ -17,6 +17,10 @@ describe('Operations pages', () => {
     expect(screen.getByText(/route templates only=true/i)).toBeVisible()
     expect(screen.getByText(/API request summary/i)).toBeVisible()
     expect(screen.getByText(/21 observed/i)).toBeVisible()
+    expect(screen.getByText(/Core trace propagation/i)).toBeVisible()
+    expect(screen.getByText(/raw headers returned=false/i)).toBeVisible()
+    expect(screen.getByText(/Core-to-broker correlation/i)).toBeVisible()
+    expect(screen.getByText(/broker trace context=true/i)).toBeVisible()
     expect(
       await screen.findByText(/Secrets Broker service trace context/i)
     ).toBeVisible()

--- a/src/lib/service-lasso-dashboard/stub.ts
+++ b/src/lib/service-lasso-dashboard/stub.ts
@@ -847,6 +847,19 @@ export async function fetchTelemetryPreview(): Promise<TelemetryPreview> {
       serviceNamespace: 'service-lasso',
       serviceInstanceId: 'stub-runtime',
     },
+    traceContext: {
+      propagation: 'w3c-trace-context',
+      responseHeaders: {
+        correlationId: 'x-service-lasso-correlation-id',
+        traceId: 'x-service-lasso-trace-id',
+        traceparent: 'traceparent',
+      },
+      traceparentSampled: true,
+      incomingHeadersAccepted: false,
+      incomingHeadersReturned: false,
+      rawHeadersReturned: false,
+      routeTemplateOnly: true,
+    },
     redaction: {
       mode: 'allowlist',
       allowedAttributes: [

--- a/src/lib/service-lasso-dashboard/types.ts
+++ b/src/lib/service-lasso-dashboard/types.ts
@@ -209,6 +209,19 @@ export type TelemetryPreview = {
     serviceNamespace: string
     serviceInstanceId: string
   }
+  traceContext?: {
+    propagation: string
+    responseHeaders: {
+      correlationId: string
+      traceId: string
+      traceparent: string
+    }
+    traceparentSampled: boolean
+    incomingHeadersAccepted: boolean
+    incomingHeadersReturned: boolean
+    rawHeadersReturned: boolean
+    routeTemplateOnly: boolean
+  }
   redaction: {
     mode: string
     allowedAttributes: string[]


### PR DESCRIPTION
## Issue
Advances service-lasso/service-lasso#635

## Summary
- Adds Service Admin Operations / Telemetry rows for core W3C trace propagation posture.
- Adds a cross-source core-to-`@secretsbroker` correlation posture row using the existing core telemetry and service-scoped broker telemetry metadata.
- Extends the Service Admin telemetry contract/stub types to model safe trace-context posture without returning header values.

## Scope
- In scope: read-only operator visibility for core trace propagation and core-to-broker trace/correlation posture.
- Out of scope: configuring exporters, sending telemetry, direct browser calls to the Secrets Broker loopback endpoint, or completing all remaining cross-service OTel work in #635.

## Spec / contract / fixture impact
- Updated: `docs/operations-telemetry.md`.
- Updated: dashboard telemetry types/stub fixture for runtime `traceContext` metadata.

## Nash invariant impact
- Invariant: telemetry UI remains metadata-only.
- Preservation proof: UI rows show response header names and boolean posture only; tests assert secret/token/private-key/OTLP endpoint/header sentinel material is not rendered.

## Validation
- PASS `npm run test:unit -- src/features/operations/operations.test.tsx src/lib/service-lasso-dashboard/client.test.ts src/lib/service-lasso-dashboard/stub.test.ts` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/test-focused-correlation-status.log`
- PASS `npm run build` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/build-correlation-status.log`
- PASS `npm run lint` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/lint-correlation-status.log`
- PASS `npx prettier --check src/features/operations/index.tsx src/features/operations/operations.test.tsx src/lib/service-lasso-dashboard/types.ts src/lib/service-lasso-dashboard/stub.ts docs/operations-telemetry.md` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/prettier-check-correlation-status.log`
- PASS `git diff --check` — `.work-agent/logs/755b8bea-10c9-4a16-bd2b-172e57d11ff6/issue-635-serviceadmin-telemetry-status/diff-check-correlation-status.log`

## Approval trail
- Required: no explicit human approval identified for this focused Service Admin UI slice.
- Evidence: Project #1 Ready / Ready for Agent on service-lasso/service-lasso#635.

## Cleanup
- Branch: `feature/635-serviceadmin-correlation-status`.
- If merged, `lasso-serviceadmin` is demo-consumed; publish/release as needed, pin the exact Service Admin release in core, recycle canonical demo on port 17883, then run `npm run demo:verify-canonical` before final completion claim.
