### PR TITLE
fix(service-detail): show runtime log overview

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -112,9 +112,11 @@ import { ThemeSwitch } from '@/components/theme-switch'
 import {
   fetchServiceLogChunk,
   fetchServiceLogInfo,
+  fetchServiceLogsOverview,
   sendServiceTerminalInput,
   type ServiceLogChunk,
   type ServiceLogInfo,
+  type ServiceLogOverview,
   type ServiceTerminalStdinCapability,
 } from '@/features/logs/provider'
 import { buildMetadataTableRows } from './metadata-table'
@@ -852,8 +854,108 @@ function ServiceRunStreamPanel({
   )
 }
 
+function ServiceRunStreamsOverview({
+  overview,
+  streams,
+}: {
+  overview: ServiceLogOverview | null
+  streams: Record<ServiceDetailRunStreamType, ServiceDetailRunStreamState>
+}) {
+  const sourceRows = SERVICE_DETAIL_RUN_STREAMS.map((stream) => {
+    const state = streams[stream.type]
+    const source =
+      state.chunk?.source ??
+      state.info?.source ??
+      state.info?.sources?.find((candidate) => candidate.stream === stream.type)
+
+    return {
+      stream,
+      path: state.chunk?.path ?? state.info?.path ?? source?.path,
+      available:
+        state.chunk?.available ?? state.info?.available ?? source?.available,
+    }
+  })
+
+  const overviewRows = overview?.entries.slice(0, 6) ?? []
+  const hasSourcePath = sourceRows.some((row) => row.path)
+
+  if (!overview && !hasSourcePath) return null
+
+  return (
+    <div
+      className='space-y-3 rounded-md border bg-muted/20 p-3'
+      data-testid='service-detail-log-overview'
+    >
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <div>
+          <div className='font-medium'>Runtime log overview</div>
+          <p className='text-sm text-muted-foreground'>
+            Safe runtime log events and source metadata for the selected
+            service.
+          </p>
+        </div>
+        {overview?.runId ? (
+          <Badge variant='outline' className='font-mono'>
+            {overview.runId}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div className='grid gap-2 md:grid-cols-2'>
+        {sourceRows.map(({ stream, path, available }) => (
+          <div
+            key={stream.type}
+            className='min-w-0 rounded-md border bg-card p-2'
+          >
+            <div className='flex items-center justify-between gap-2 text-xs'>
+              <span className='font-medium'>{stream.label}</span>
+              <Badge variant={available === false ? 'outline' : 'secondary'}>
+                {available === false ? 'unavailable' : 'source'}
+              </Badge>
+            </div>
+            <div className='mt-1 truncate font-mono text-xs text-muted-foreground'>
+              {path ?? 'No source path reported'}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {overviewRows.length ? (
+        <div className='overflow-hidden rounded-md border bg-card'>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Level</TableHead>
+                <TableHead>Recent runtime event</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {overviewRows.map((entry, index) => (
+                <TableRow key={`${entry.level}-${index}`}>
+                  <TableCell className='w-28 align-top'>
+                    <Badge variant='outline'>{entry.level}</Badge>
+                  </TableCell>
+                  <TableCell className='align-top text-sm text-muted-foreground'>
+                    {entry.message}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <div className='rounded-md border border-dashed p-3 text-sm text-muted-foreground'>
+          The runtime reported log sources, but no overview events are recorded
+          yet.
+        </div>
+      )}
+    </div>
+  )
+}
+
 function ServiceRunStreams({ service }: { service: DashboardService }) {
   const [streams, setStreams] = useState(() => createRunStreamState())
+  const [overview, setOverview] = useState<ServiceLogOverview | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -908,9 +1010,17 @@ function ServiceRunStreams({ service }: { service: DashboardService }) {
     }
 
     setStreams(createRunStreamState(true))
+    setOverview(null)
     for (const stream of SERVICE_DETAIL_RUN_STREAMS) {
       void loadStream(stream.type)
     }
+    void fetchServiceLogsOverview(service)
+      .then((nextOverview) => {
+        if (!cancelled) setOverview(nextOverview)
+      })
+      .catch(() => {
+        if (!cancelled) setOverview(null)
+      })
 
     return () => {
       cancelled = true
@@ -960,6 +1070,7 @@ function ServiceRunStreams({ service }: { service: DashboardService }) {
         </div>
         <Badge variant='secondary'>run-scoped</Badge>
       </div>
+      <ServiceRunStreamsOverview overview={overview} streams={streams} />
       <div
         className='grid gap-3 lg:grid-cols-2'
         data-testid='service-detail-run-streams'

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -313,6 +313,128 @@ describe('service detail quick actions', () => {
     expect(within(streams).queryByText(/hunter2/)).not.toBeInTheDocument()
   })
 
+  it('shows runtime overview events when stdout and stderr stream files are empty', async () => {
+    const user = userEvent.setup()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const parsed = new URL(url, 'http://localhost')
+        const serviceId = parsed.searchParams.get('service') ?? '@serviceadmin'
+        const type = parsed.searchParams.get('type') ?? 'default'
+
+        if (parsed.pathname === '/api/services/log-info') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type,
+              path: `C:\\runtime\\${serviceId}\\${type}.log`,
+              available: true,
+              availableTypes: ['default', 'stdout', 'stderr'],
+              sources: [
+                {
+                  kind: 'current',
+                  stream: 'stdout',
+                  runId: 'run-1',
+                  path: `C:\\runtime\\${serviceId}\\stdout.log`,
+                  available: true,
+                },
+                {
+                  kind: 'current',
+                  stream: 'stderr',
+                  runId: 'run-1',
+                  path: `C:\\runtime\\${serviceId}\\stderr.log`,
+                  available: true,
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/logs/read') {
+          return new Response(
+            JSON.stringify({
+              serviceId,
+              type,
+              path: `C:\\runtime\\${serviceId}\\${type}.log`,
+              available: true,
+              totalLines: 0,
+              start: 0,
+              end: 0,
+              hasMore: false,
+              nextBefore: 0,
+              limit: 80,
+              lines: [],
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        if (parsed.pathname === '/api/services/%40serviceadmin/logs') {
+          return new Response(
+            JSON.stringify({
+              logs: {
+                serviceId: '@serviceadmin',
+                runId: 'run-1',
+                logPath: 'C:\\runtime\\@serviceadmin\\service.log',
+                stdoutPath: 'C:\\runtime\\@serviceadmin\\stdout.log',
+                stderrPath: 'C:\\runtime\\@serviceadmin\\stderr.log',
+                entries: [
+                  {
+                    level: 'info',
+                    message:
+                      'serviceadmin:start token=review-secret should be redacted',
+                  },
+                ],
+                archives: [],
+                retention: { maxArchives: 3 },
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }
+          )
+        }
+
+        return new Response('not found', { status: 404 })
+      })
+    )
+
+    await renderRoute('/services/@serviceadmin')
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /^Service Admin UI$/i })
+      ).toBeVisible()
+    })
+
+    await user.click(screen.getByRole('tab', { name: /logs/i }))
+
+    const overview = await screen.findByTestId('service-detail-log-overview')
+
+    expect(within(overview).getByText('Runtime log overview')).toBeVisible()
+    expect(within(overview).getByText('run-1')).toBeVisible()
+    expect(within(overview).getByText(/serviceadmin:start/)).toBeVisible()
+    expect(within(overview).getByText(/token=\[redacted\]/)).toBeVisible()
+    expect(
+      within(overview).queryByText(/review-secret/)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getAllByText(/No stdout entries are recorded/i).length
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(/No stderr entries are recorded/i).length
+    ).toBeGreaterThan(0)
+  })
+
   it('renders the Terminal tab from safe stdout history without leaking values', async () => {
     const user = userEvent.setup()
 


### PR DESCRIPTION
## Issue
Reopens/fixes #281 follow-up regression after live review found the Service Details Logs tab could still appear blank.

## Summary
- Adds a Service Details runtime log overview panel alongside the run-scoped stdout/stderr panels.
- Shows safe source path metadata and recent runtime overview events when stdout/stderr stream files exist but currently have zero lines.
- Keeps stdout/stderr empty states visible and keeps log event redaction through the existing logs provider.

## Scope
- In scope: Service Details `Logs` tab runtime overview/source fallback and regression coverage for empty stream files with non-empty overview events.
- Out of scope: runtime log capture changes, source registry expansion, and release/demo pinning after merge.

## Spec / contract / fixture impact
- Uses existing `/api/services/:serviceId/logs`, `/api/services/log-info`, and `/api/logs/read` contracts.
- No service manifest or runtime API contract changes.

## Validation
- PASS `npm run test:unit -- src/features/service-detail/service-detail.test.tsx` — `.work-agent/logs/cron-9e9b19ce-20260627-2325/issue-281-service-detail-test.log`
- PASS `npm run lint` — `.work-agent/logs/cron-9e9b19ce-20260627-2325/issue-281-lint.log`
- PASS `npm run build` — `.work-agent/logs/cron-9e9b19ce-20260627-2325/issue-281-build.log`
- PASS `npm run format:check` — `.work-agent/logs/cron-9e9b19ce-20260627-2325/issue-281-format-check.log`
- PASS `git diff --check` — `.work-agent/logs/cron-9e9b19ce-20260627-2325/issue-281-git-diff-check.log`

## Live runtime evidence
- Canonical Service Admin `http://192.168.1.53:17700/` HTTP 200.
- Canonical runtime `http://192.168.1.53:17883/api/health` HTTP 200.
- `node-sample-service` is currently stopped/unavailable for stdout/stderr proof in the canonical runtime.
- `echo-service` runtime overview returns current run metadata and events, while stdout/stderr `read` endpoints return available zero-line files. This PR makes those overview events/source paths visible in Service Details instead of leaving only blank stream panels.

## Cleanup
- Branch: `agent/issue-281-logs-regression`
- Release/demo gate remains pending until review/merge, Service Admin release, core `@serviceadmin` pin update, canonical recycle on port `17883`, and demo verification.