### PR TITLE
fix(config): remove runtime safety copy

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -21,7 +21,6 @@ import {
   ArrowRight,
   Copy,
   ExternalLink,
-  FileJson,
   HeartPulse,
   Link2,
   Network,
@@ -74,16 +73,6 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -129,9 +118,6 @@ import {
   type ServiceDetailTabId,
 } from './service-detail-tabs'
 
-const REDACTED_CONFIG_VALUE = '[redacted by Service Admin]'
-const SENSITIVE_CONFIG_KEY_PATTERN =
-  /(?:password|passphrase|token|api[_-]?key|secret|private[_-]?key|credential|cookie)/i
 const editableShortcutTargetSelector = [
   'input',
   'textarea',
@@ -144,42 +130,6 @@ const editableShortcutTargetSelector = [
   '[data-terminal-input]',
   '.xterm',
 ].join(', ')
-
-function redactSensitiveConfigValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => redactSensitiveConfigValue(item))
-  }
-
-  if (!value || typeof value !== 'object') {
-    return value
-  }
-
-  const record = value as Record<string, unknown>
-
-  if (typeof record.key === 'string' && record.secret === true) {
-    return {
-      ...record,
-      value: REDACTED_CONFIG_VALUE,
-    }
-  }
-
-  return Object.fromEntries(
-    Object.entries(record).map(([key, entryValue]) => {
-      if (
-        SENSITIVE_CONFIG_KEY_PATTERN.test(key) &&
-        typeof entryValue === 'string'
-      ) {
-        return [key, REDACTED_CONFIG_VALUE]
-      }
-
-      return [key, redactSensitiveConfigValue(entryValue)]
-    })
-  )
-}
-
-function buildServiceConfigJson(service: DashboardService) {
-  return JSON.stringify(redactSensitiveConfigValue(service), null, 2)
-}
 
 function StatusBadge({ status }: { status: ServiceStatus }) {
   if (status === 'running') {
@@ -1479,42 +1429,6 @@ function ServiceMetadataTable({ service }: { service: DashboardService }) {
   )
 }
 
-function FullConfigJsonDialog({ service }: { service: DashboardService }) {
-  const configJson = useMemo(() => buildServiceConfigJson(service), [service])
-
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button type='button' variant='outline' size='sm'>
-          <FileJson className='mr-2 size-4' />
-          View full config JSON
-        </Button>
-      </DialogTrigger>
-      <DialogContent className='max-h-[88vh] gap-5 sm:max-w-4xl'>
-        <DialogHeader className='pr-8'>
-          <DialogTitle>Full config JSON</DialogTitle>
-          <DialogDescription>
-            {service.name} runtime service record with sensitive values masked.
-          </DialogDescription>
-        </DialogHeader>
-        <pre
-          data-testid='service-detail-full-config-json'
-          className='max-h-[60vh] overflow-auto rounded-md border bg-muted/35 p-4 font-mono text-xs leading-relaxed break-words whitespace-pre-wrap text-foreground'
-        >
-          {configJson}
-        </pre>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button type='button' variant='outline'>
-              Close
-            </Button>
-          </DialogClose>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 function ServiceDetailQuickAction({
   children,
   label,
@@ -2055,10 +1969,7 @@ export function ServiceDetail({
                     </Card>
                   </TabsContent>
 
-                  <TabsContent value='config' className='mt-0 space-y-4'>
-                    <div className='flex justify-end'>
-                      <FullConfigJsonDialog service={service} />
-                    </div>
+                  <TabsContent value='config' className='mt-0'>
                     <ServiceConfigEditor service={service} />
                   </TabsContent>
 

--- a/src/features/service-detail/service-config-editor.tsx
+++ b/src/features/service-detail/service-config-editor.tsx
@@ -6,7 +6,6 @@ import {
   GitCompare,
   RefreshCw,
   Save,
-  ShieldCheck,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
@@ -36,7 +35,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Separator } from '@/components/ui/separator'
 import {
   Table,
   TableBody,
@@ -372,35 +370,6 @@ export function ServiceConfigEditor({
               />
             </div>
             <div className='space-y-4'>
-              <div className='rounded-md border p-3'>
-                <div className='flex items-center gap-2 text-sm font-medium'>
-                  <ShieldCheck className='size-4' /> Runtime safety
-                </div>
-                <div className='mt-2 space-y-2 text-sm text-muted-foreground'>
-                  <div>File: {document?.fileName ?? 'server.json'}</div>
-                  <div>
-                    Hash: {document ? shortHash(document.hash) : 'loading'}
-                  </div>
-                  <div>
-                    Updated:{' '}
-                    {document
-                      ? new Date(document.updatedAt).toLocaleString()
-                      : 'loading'}
-                  </div>
-                  <Separator />
-                  <ul className='list-inside list-disc space-y-1'>
-                    {(
-                      document?.safety.omittedSensitiveFields ?? [
-                        'resolved environment values',
-                        'provider credentials',
-                        'authorization headers',
-                      ]
-                    ).map((field) => (
-                      <li key={field}>{field}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
               <label className='block space-y-2 text-sm font-medium'>
                 Audit reason
                 <textarea

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -178,7 +178,7 @@ describe('service detail quick actions', () => {
     expect(screen.getByText('Diagnostics + recent logs')).toBeVisible()
   })
 
-  it('opens a full config JSON modal with secret values redacted', async () => {
+  it('keeps the Config tab focused on the server.json editor', async () => {
     const user = userEvent.setup()
 
     await renderRoute('/services/@serviceadmin')
@@ -190,34 +190,15 @@ describe('service detail quick actions', () => {
     })
 
     await user.click(screen.getByRole('tab', { name: /config/i }))
-    await user.click(
-      screen.getByRole('button', { name: /view full config json/i })
-    )
 
-    const dialog = screen.getByRole('dialog', { name: /full config json/i })
-    const configJson = within(dialog).getByTestId(
-      'service-detail-full-config-json'
-    )
-
-    expect(configJson).toHaveTextContent('"id": "@serviceadmin"')
-    expect(configJson).toHaveTextContent('"favorite": true')
-    expect(configJson).toHaveTextContent('"templateValue"')
-    expect(configJson).toHaveTextContent('SESSION_SECRET')
-    expect(configJson).toHaveTextContent('[redacted by Service Admin]')
-    expect(configJson).not.toHaveTextContent(
-      'secret://@serviceadmin/SESSION_SECRET'
-    )
-    expect(configJson).not.toHaveTextContent(
-      'secret://openclaw/anthropic/api_key'
-    )
-
-    await user.keyboard('{Escape}')
-
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('dialog', { name: /full config json/i })
-      ).toBeNull()
-    })
+    expect(screen.getByTestId('service-config-editor')).toBeVisible()
+    expect(
+      screen.queryByRole('button', { name: /view full config json/i })
+    ).toBeNull()
+    expect(screen.queryByText(/runtime safety/i)).toBeNull()
+    expect(screen.queryByText(/resolved environment values/i)).toBeNull()
+    expect(screen.queryByText(/provider credentials/i)).toBeNull()
+    expect(screen.queryByText(/authorization headers/i)).toBeNull()
   })
 
   it('shows separate stdout and stderr run streams without leaking sensitive values', async () => {
@@ -869,7 +850,10 @@ describe('service detail server.json config editor', () => {
     expect(screen.getByText(/Valid JSON/i)).toBeVisible()
     expect(screen.getByText(/0 backups/i)).toBeVisible()
     expect(screen.getAllByText(/server\.json/i).length).toBeGreaterThan(0)
-    expect(screen.getByText(/resolved environment values/i)).toBeVisible()
+    expect(screen.queryByText(/Runtime safety/i)).toBeNull()
+    expect(screen.queryByText(/resolved environment values/i)).toBeNull()
+    expect(screen.queryByText(/provider credentials/i)).toBeNull()
+    expect(screen.queryByText(/authorization headers/i)).toBeNull()
   })
 
   it('blocks invalid JSON saves and dirty reloads until confirmed', async () => {


### PR DESCRIPTION
## Summary
- Remove the Config tab `Runtime safety` panel and its technical sensitive-values list.
- Remove the redundant `View full config JSON` modal action from Service Details.
- Update Service Details tests to assert the Config tab stays focused on the `server.json` editor and no longer renders the removed copy/actions.

## Validation
- `npm test -- src/features/service-detail/service-detail.test.tsx` (18 passed)
- `npm run build`
- `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1`
- Canonical demo recycled onto this staged build; `http://192.168.1.53:17700/` returned HTTP 200 and `http://192.168.1.53:17883/api/health` returned `status: ok`.
- Deployed `dist` string check: no `Runtime safety`, `View full config JSON`, or `resolved environment values` strings.

Closes #323