### PR TITLE
fix(service-detail): show Terminal stdout visibly

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1276,6 +1276,20 @@ function ServiceTerminalPanel({ service }: { service: DashboardService }) {
                 >
                   {logText}
                 </pre>
+                <div
+                  className='mb-3 max-h-72 overflow-auto rounded-md border bg-muted/20 p-3 font-mono text-xs leading-relaxed'
+                  data-testid='service-detail-terminal-visible-lines'
+                >
+                  {lines.map((line, index) => (
+                    <div
+                      // Runtime log chunks are windowed and may contain repeated text.
+                      key={`${index}-${line}`}
+                      className='whitespace-pre-wrap break-words'
+                    >
+                      {line}
+                    </div>
+                  ))}
+                </div>
                 <div className='h-[360px] overflow-hidden rounded-md border'>
                   <ScrollFollow
                     startFollowing={!paused}

--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -1284,7 +1284,7 @@ function ServiceTerminalPanel({ service }: { service: DashboardService }) {
                     <div
                       // Runtime log chunks are windowed and may contain repeated text.
                       key={`${index}-${line}`}
-                      className='whitespace-pre-wrap break-words'
+                      className='break-words whitespace-pre-wrap'
                     >
                       {line}
                     </div>

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -503,11 +503,19 @@ describe('service detail quick actions', () => {
     await user.click(screen.getByRole('tab', { name: /terminal/i }))
 
     const terminal = screen.getByTestId('service-detail-terminal-lines')
+    const visibleTerminal = screen.getByTestId(
+      'service-detail-terminal-visible-lines'
+    )
 
     await waitFor(() => {
       expect(terminal).toHaveTextContent(/service ready/)
     })
 
+    expect(visibleTerminal).toBeVisible()
+    expect(visibleTerminal).toHaveTextContent(/service ready/)
+    expect(visibleTerminal).toHaveTextContent(/listening on/)
+    expect(visibleTerminal).toHaveTextContent(/token=\[redacted\]/)
+    expect(visibleTerminal).not.toHaveTextContent(/hidden-value/)
     expect(terminal).toHaveTextContent(/token=\[redacted\]/)
     expect(terminal).not.toHaveTextContent(/hidden-value/)
     expect(screen.getByText('run-2026-06-25T05-00-00Z')).toBeVisible()


### PR DESCRIPTION
## Issue
Reopens/continues #275 after live review found the Terminal tab visually inert.

## Summary
- Keeps the existing Terminal stdout fetch path and virtualized viewer.
- Adds a direct visible stdout line viewport backed by the same redacted runtime lines so the tab cannot appear blank when stdout exists.
- Extends the focused regression test to assert visible terminal content, not only the hidden screen-reader text copy.

## Evidence
Live canonical APIs already return stdout for `@serviceadmin`:
- `http://192.168.1.53:17883/api/logs/read?service=%40serviceadmin&type=stdout&limit=20` returned line `@serviceadmin listening on http://0.0.0.0:17700`.
- `http://192.168.1.53:17700/api/logs/read?service=%40serviceadmin&type=stdout&limit=20` returned the same stdout line through the Service Admin host.

## Validation
- PASS `npm test -- --run src/features/service-detail/service-detail.test.tsx` — 18 tests passed.
- PASS `git diff --check`.
- Install note: fresh clone required `npm ci --legacy-peer-deps` because plain `npm ci` hits the repo's existing ESLint peer-resolution conflict.

## Logs
`C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260627T222647Z`

## Demo gate
This PR has not been merged/released/pinned yet. After review/merge, publish Service Admin, update the core `@serviceadmin` demo pin, recycle canonical runtime on port `17883`, and verify the live Terminal tab before closing #275 again.