### PR TITLE
fix(audit): rename visible Audit labels

### DIFF
--- a/src/components/layout/data/sidebar-data.test.ts
+++ b/src/components/layout/data/sidebar-data.test.ts
@@ -76,7 +76,7 @@ describe('sidebar optional page classification', () => {
     ])
     expect(operationsGroup?.items.map((item) => item.title)).toEqual([
       'Telemetry',
-      'Audit Logging',
+      'Audit',
     ])
   })
 })

--- a/src/components/layout/data/sidebar-data.ts
+++ b/src/components/layout/data/sidebar-data.ts
@@ -92,7 +92,7 @@ export const sidebarData: SidebarData = {
           icon: FileChartColumn,
         },
         {
-          title: 'Audit Logging',
+          title: 'Audit',
           url: '/operations/audit-logging',
           icon: ScrollText,
         },

--- a/src/features/operations/index.tsx
+++ b/src/features/operations/index.tsx
@@ -329,7 +329,7 @@ function buildTelemetryRows(
       state: 'available',
       lastSample: secretsBrokerAuditEvents[0]?.timestamp ?? 'Not sampled',
       value: `${secretsBrokerAuditEvents.length} metadata-only audit events loaded`,
-      nextAction: 'Use Audit Logging for policy, outcome, and chain status.',
+      nextAction: 'Use Audit for policy, outcome, and chain status.',
     },
     ...serviceRows,
   ]
@@ -892,9 +892,9 @@ export function OperationsTelemetry() {
 
 export function OperationsAuditLogging() {
   usePageMetadata({
-    title: 'Service Admin - Operations Audit Logging',
+    title: 'Service Admin - Operations Audit',
     description:
-      'Operations audit logging across Service Lasso and Secrets Broker sources.',
+      'Operations audit events across Service Lasso and Secrets Broker sources.',
   })
 
   const rows = useMemo(() => buildAuditRows(), [])
@@ -916,7 +916,7 @@ export function OperationsAuditLogging() {
   return (
     <>
       <OperationsHeader
-        title='Audit Logging'
+        title='Audit'
         description='Metadata-only operation events for Service Lasso and Secrets Broker, including explicit unavailable chain proof states.'
       />
       <Main className='flex flex-1 flex-col gap-4 sm:gap-6'>

--- a/src/features/operations/operations.test.tsx
+++ b/src/features/operations/operations.test.tsx
@@ -41,12 +41,13 @@ describe('Operations pages', () => {
     expect(container).not.toHaveTextContent(/BOT_TOKEN=/i)
   })
 
-  it('renders audit logging rows from both operation sources without secret payloads', async () => {
+  it('renders audit rows from both operation sources without secret payloads', async () => {
     const { container } = await renderRoute('/operations/audit-logging')
 
     expect(
-      await screen.findByRole('heading', { name: /Audit Logging/i })
+      await screen.findByRole('heading', { name: /^Audit$/i })
     ).toBeVisible()
+    expect(container).not.toHaveTextContent(/Audit Logging/i)
     expect(screen.getByText(/runtime health checked/i)).toBeVisible()
     expect(screen.getByText(/resolve granted/i)).toBeVisible()
     expect(screen.getAllByText(/Service Lasso/i)[0]).toBeVisible()

--- a/src/features/secrets-broker/audit-events.test.tsx
+++ b/src/features/secrets-broker/audit-events.test.tsx
@@ -8,12 +8,12 @@ import {
 } from './audit-events'
 
 describe('Secrets Broker audit event viewer', () => {
-  it('redirects the legacy Secrets Broker audit route to Operations Audit Logging', async () => {
+  it('redirects the legacy Secrets Broker audit route to Operations Audit', async () => {
     const { router } = await renderRoute('/secrets-broker/audit-events')
 
     expect(
       await screen.findByRole('heading', {
-        name: /Audit Logging/i,
+        name: /^Audit$/i,
       })
     ).toBeVisible()
     expect(screen.getAllByText(/runtime health checked/i)[0]).toBeVisible()

--- a/src/features/secrets-broker/index.tsx
+++ b/src/features/secrets-broker/index.tsx
@@ -200,8 +200,8 @@ const secretsBrokerSectionMetadata: Record<
     description: 'Inspect safe service-to-secret relationship metadata.',
   },
   'audit-events': {
-    title: 'Service Admin - Operations Audit Logging',
-    heading: 'Audit Logging',
+    title: 'Service Admin - Operations Audit',
+    heading: 'Audit',
     description: 'Inspect audit events and tamper-evidence metadata.',
   },
   diagnostics: {
@@ -2297,7 +2297,7 @@ export function SecretsBrokerSetupWizard({
                     <Link to='/secrets-broker/sources'>Add provider</Link>
                   </Button>
                   <Button variant='outline' size='sm' asChild>
-                    <Link to='/operations/audit-logging'>Audit Logging</Link>
+                    <Link to='/operations/audit-logging'>Audit</Link>
                   </Button>
                   <Button variant='outline' size='sm' asChild>
                     <Link to='/secrets-broker/sources'>

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -124,7 +124,7 @@ describe('Secrets Broker overview dashboard', () => {
     expect(screen.getByText(/Needs operator action/i)).toBeVisible()
     expect(
       screen
-        .getAllByRole('link', { name: /Audit Logging/i })
+        .getAllByRole('link', { name: /^Audit$/i })
         .some(
           (link) => link.getAttribute('href') === '/operations/audit-logging'
         )
@@ -167,7 +167,7 @@ describe('Secrets Broker overview dashboard', () => {
     expect(screen.getByText(/local encrypted store reachable/i)).toBeVisible()
     expect(screen.getByText(/key version v3/i)).toBeVisible()
     expect(screen.getByText(/View providers/i)).toBeVisible()
-    expect(screen.getAllByText(/Audit Logging/i)[0]).toBeVisible()
+    expect(screen.getAllByText(/^Audit$/i)[0]).toBeVisible()
 
     await user.selectOptions(
       screen.getByLabelText(/Preview state/i),
@@ -200,14 +200,14 @@ describe('Secrets Broker overview dashboard', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('redirects the removed operational controls route to Audit Logging', async () => {
+  it('redirects the removed operational controls route to Audit', async () => {
     const { router } = await renderRoute('/secrets-broker/operational-controls')
 
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/operations/audit-logging')
     })
     expect(
-      screen.getByRole('heading', { name: /^Audit Logging$/i })
+      screen.getByRole('heading', { name: /^Audit$/i })
     ).toBeVisible()
     expect(
       screen.queryByRole('heading', { name: /^Operational Controls$/i })
@@ -1132,7 +1132,7 @@ describe('Secrets Broker overview dashboard', () => {
     await renderRoute('/operations/audit-logging')
 
     expect(
-      screen.getByRole('heading', { name: /Audit Logging/i })
+      screen.getByRole('heading', { name: /^Audit$/i })
     ).toBeVisible()
     expect(screen.getAllByText(/resolve granted/i)[0]).toBeVisible()
     expect(screen.getAllByText(/resolve denied/i)[0]).toBeVisible()

--- a/src/features/secrets-broker/secrets-broker-setup.test.tsx
+++ b/src/features/secrets-broker/secrets-broker-setup.test.tsx
@@ -206,9 +206,7 @@ describe('Secrets Broker overview dashboard', () => {
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/operations/audit-logging')
     })
-    expect(
-      screen.getByRole('heading', { name: /^Audit$/i })
-    ).toBeVisible()
+    expect(screen.getByRole('heading', { name: /^Audit$/i })).toBeVisible()
     expect(
       screen.queryByRole('heading', { name: /^Operational Controls$/i })
     ).not.toBeInTheDocument()
@@ -1131,9 +1129,7 @@ describe('Secrets Broker overview dashboard', () => {
   it('covers audit event types, filtering, and safe detail rendering', async () => {
     await renderRoute('/operations/audit-logging')
 
-    expect(
-      screen.getByRole('heading', { name: /^Audit$/i })
-    ).toBeVisible()
+    expect(screen.getByRole('heading', { name: /^Audit$/i })).toBeVisible()
     expect(screen.getAllByText(/resolve granted/i)[0]).toBeVisible()
     expect(screen.getAllByText(/resolve denied/i)[0]).toBeVisible()
 

--- a/src/test/app-screens.test.tsx
+++ b/src/test/app-screens.test.tsx
@@ -76,8 +76,8 @@ const appScreens: ScreenCase[] = [
   },
   {
     path: '/operations/audit-logging',
-    heading: /^Audit Logging$/i,
-    title: 'Service Admin - Operations Audit Logging',
+    heading: /^Audit$/i,
+    title: 'Service Admin - Operations Audit',
   },
   {
     path: '/auth-session',

--- a/tests/ui/secrets-broker.spec.ts
+++ b/tests/ui/secrets-broker.spec.ts
@@ -82,7 +82,7 @@ test.describe('Secrets Broker browser coverage', () => {
     ).toBeVisible()
     await expect(page.getByRole('link', { name: 'Add provider' })).toBeVisible()
     await expect(
-      page.getByRole('main').getByRole('link', { name: 'Audit Logging' })
+      page.getByRole('main').getByRole('link', { name: 'Audit' })
     ).toBeVisible()
     await expect(
       page.getByRole('link', { name: 'View provider status' })
@@ -1149,7 +1149,7 @@ test.describe('Secrets Broker browser coverage', () => {
       ['/secrets-broker/sources', /Secrets Broker providers/i],
       ['/secrets-broker/backup-keys', /Local encrypted store/i],
       ['/secrets-broker/topology', /Secrets Broker topology/i],
-      ['/operations/audit-logging', /Audit Logging/i],
+      ['/operations/audit-logging', /^Audit$/i],
     ] as const
 
     for (const [path, label] of sections) {


### PR DESCRIPTION
## Issue
Closes #344

## Summary
- Renamed the visible Operations audit surface from `Audit Logging` to `Audit` while preserving `/operations/audit-logging`.
- Updated page metadata, sidebar navigation, Secrets Broker links, and focused unit/browser expectations.

## Scope
- In scope: visible labels, page title, helper wording, tests for the rename.
- Out of scope: adding `/operations/audit` alias or live audit API wiring.

## Spec / contract / fixture impact
- Route compatibility preserved at `/operations/audit-logging`.
- No fixture schema changes.

## Service Lasso invariant impact
- Metadata-only audit safety boundary remains unchanged.
- Existing route links continue to work.

## Validation
- PASS `npm test -- src/features/operations/operations.test.tsx src/components/layout/data/sidebar-data.test.ts src/test/app-screens.test.tsx src/features/secrets-broker/audit-events.test.tsx src/features/secrets-broker/secrets-broker-setup.test.tsx` — 5 files, 87 tests passed.
- PASS `npm run build` — production build completed.
- PASS package `pwsh -NoLogo -NoProfile -File .\scripts\package.ps1` — created `dist\@serviceadmin-win32.zip`.
- PASS canonical demo recycle/deploy — packaged branch artifact copied into managed `@serviceadmin` runtime state and service restarted.
- PASS LAN reachability — `http://192.168.1.53:17700/` HTTP 200 and `http://192.168.1.53:17883/api/health` HTTP 200/status `ok`.
- PASS browser probe — `/operations/audit-logging` rendered heading `Audit`, title `Service Admin - Operations Audit`, and zero visible `Audit Logging` text.

## Approval trail
Required: no
Evidence: focused UI rename with route compatibility and demo proof.

## Cleanup
- Branch: `dev/issue-344-audit-label-rename`
- Commit: `3b43667bb7c3386bca2d2350530834f03e2994c2`
- Log root: `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260628-1236`