### PR TITLE
Fix Help Center source contract copy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,15 +2,16 @@
 
 Welcome to the Service Admin Help Center.
 
-This docs surface reads markdown files from the repo `docs/` folder and shows them inside the app.
+The in-app Help Center reads markdown files from `docs/help/**/*.md`.
+Reference material elsewhere under `docs/` is available to the repo, but it does not appear in the app unless the Help Center loader is intentionally expanded.
 
 ## Available doc areas
 
-- `reference/` for design notes and implementation specs
-- future guides, runbooks, and operator docs can live here too
+- `help/` for operator-facing Help Center guides and runbooks shown in the app
+- `reference/` for design notes and implementation specs that are not shown in the app by default
 
 ## Notes
 
-- Add new `.md` files under `docs/`
-- They will automatically appear in the Help Center list
+- Add new in-app Help Center articles under `docs/help/`
+- Markdown files outside `docs/help/` will not automatically appear in the Help Center list
 - Use clear filenames and folders so the navigation stays readable

--- a/docs/help/README.md
+++ b/docs/help/README.md
@@ -2,4 +2,10 @@
 
 This folder is the source for Service Admin Help Center content.
 
-Add markdown files here and they will appear in the in-app Help Center viewer.
+Add markdown files under `docs/help/` and they will appear in the in-app Help Center viewer. Markdown files in other `docs/` folders are repo reference material only unless the Help Center loader is intentionally expanded.
+
+## Content conventions
+
+- Write for operators first: explain what they can inspect, decide, or do in Service Admin.
+- Use clear filenames and first-level headings so the Help Center navigation stays readable.
+- Do not claim a page is runtime-backed, durable, or live unless the implementation and tests prove that contract.

--- a/src/features/help-center/index.tsx
+++ b/src/features/help-center/index.tsx
@@ -158,7 +158,8 @@ function MarkdownArticle({ content }: { content: string }) {
 export function HelpCenter() {
   usePageMetadata({
     title: 'Service Admin - Help Center',
-    description: 'Markdown-based Help Center for Service Lasso docs.',
+    description:
+      'Guides and runbooks for operating local Service Lasso services.',
   })
 
   const search = route.useSearch()
@@ -229,7 +230,7 @@ export function HelpCenter() {
           <div>
             <h2 className='text-2xl font-bold tracking-tight'>Help Center</h2>
             <p className='text-muted-foreground'>
-              Help docs loaded from the local docs set.
+              Guides and runbooks for operating local Service Lasso services.
             </p>
           </div>
           <div className='flex flex-wrap gap-2'>


### PR DESCRIPTION
## Summary
- Clarify that the in-app Help Center imports Markdown only from `docs/help/**/*.md`.
- Update `docs/help/README.md` with source-contract and content-convention guidance.
- Replace implementation-facing Help Center subtitle/metadata with operator-facing copy.

## Validation
- `npm test -- src/test/app-screens.test.tsx` (37 passed)
- `npm run build`
- Packaged `@serviceadmin-win32.zip` from commit `6eed499` and copied the built dist/runtime into the managed canonical `@serviceadmin` extracted payload.
- `npm run demo:verify-canonical` passed.
- LAN checks passed: `http://192.168.1.53:17700/` HTTP 200; `http://192.168.1.53:17883/api/health` HTTP 200/status ok.

## Logs
`C:\projects\service-lasso\work-agents\.work-agent\logs\cron-9e9b19ce-20260628-142549`

Closes #325
