### PR TITLE
fix(service-details): shorten tab shortcut labels

### DIFF
--- a/src/features/service-detail/index.tsx
+++ b/src/features/service-detail/index.tsx
@@ -115,6 +115,7 @@ import {
   normalizeServiceDetailTab,
   serviceDetailTabs,
   serviceDetailTabsByShortcut,
+  getServiceDetailTabShortcutLabel,
   type ServiceDetailTabId,
 } from './service-detail-tabs'
 
@@ -1846,7 +1847,7 @@ export function ServiceDetail({
                       >
                         {tab.label}{' '}
                         <span className='ml-1 italic opacity-80'>
-                          ({tab.shortcut})
+                          ({getServiceDetailTabShortcutLabel(tab.shortcut)})
                         </span>
                       </TabsTrigger>
                     ))}

--- a/src/features/service-detail/service-detail-tabs.ts
+++ b/src/features/service-detail/service-detail-tabs.ts
@@ -16,6 +16,12 @@ export const serviceDetailTabsByShortcut = Object.fromEntries(
   serviceDetailTabs.map((tab, index) => [String(index + 1), tab.id])
 ) as Record<string, ServiceDetailTabId>
 
+export function getServiceDetailTabShortcutLabel(shortcut: string): string {
+  const lastKey = shortcut.split('+').pop()?.trim()
+
+  return lastKey || shortcut
+}
+
 const serviceDetailTabIds = new Set<ServiceDetailTabId>(
   serviceDetailTabs.map((tab) => tab.id)
 )

--- a/src/features/service-detail/service-detail.test.tsx
+++ b/src/features/service-detail/service-detail.test.tsx
@@ -779,13 +779,12 @@ describe('service detail tab keyboard shortcuts', () => {
       })
     }
 
+    expect(screen.getByRole('tab', { name: /overview.*\(1\)/i })).toBeVisible()
+    expect(screen.getByRole('tab', { name: /logs.*\(6\)/i })).toBeVisible()
+    expect(screen.getByRole('tab', { name: /terminal.*\(7\)/i })).toBeVisible()
     expect(
-      screen.getByRole('tab', { name: /overview.*ctrl\+1/i })
-    ).toBeVisible()
-    expect(screen.getByRole('tab', { name: /logs.*ctrl\+6/i })).toBeVisible()
-    expect(
-      screen.getByRole('tab', { name: /terminal.*ctrl\+7/i })
-    ).toBeVisible()
+      screen.queryByRole('tab', { name: /overview.*ctrl\+1/i })
+    ).not.toBeInTheDocument()
   })
 
   it('ignores unmodified number keys and Ctrl+number inside the config editor', async () => {


### PR DESCRIPTION
## Summary
- Shortens Service Details tab shortcut labels from full combos like `(Ctrl+1)` to compact labels like `(1)`.
- Keeps the existing shortcut data and keyboard navigation behavior unchanged.
- Updates Service Details tests to assert compact visible labels and continued `Ctrl+1` through `Ctrl+7` behavior.

## Validation
- `npm test -- src/features/service-detail/service-detail.test.tsx` — 18 passed
- `npm run build` — passed
- `npx eslint src/features/service-detail/index.tsx src/features/service-detail/service-detail-tabs.ts src/features/service-detail/service-detail.test.tsx` — passed
- Recycled canonical Service Admin preview on `http://192.168.1.53:17700/` to this branch/build; HTTP 200
- Runtime health `http://192.168.1.53:17883/api/health`; HTTP 200 / status ok

## Logs
- `C:\projects\service-lasso\.work-agent\logs\cron-9e9b19ce-20260628-1625`

Closes #313